### PR TITLE
Use configured libdir for pkgconfig file.

### DIFF
--- a/nfft3.pc.in
+++ b/nfft3.pc.in
@@ -1,6 +1,6 @@
 prefix=@prefix@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib
+libdir=@libdir@
 includedir=${prefix}/include
 
 Name: NFFT


### PR DESCRIPTION
This PR fixes the libdir placeholder to use the libdir value configured instead of using a hardcoded suffix. The latter may change on Linux distributions depending on the build architecture.