### PR TITLE
Fixes for Matlab applications/examples in Windows

### DIFF
--- a/applications/fastsum/fastsum.m
+++ b/applications/fastsum/fastsum.m
@@ -45,7 +45,12 @@ save -ascii -double alpha.dat alpha2
 save -ascii -double y.dat y
 
 %execute C-program for fast summation
-system(sprintf('./fastsum_matlab %d %d %d %d %d %d %s %e %e %e',d,N,M,n,m,p,kernel,c,eps_I,eps_B));
+if ispc
+    cmd='fastsum_matlab.exe';
+else 
+    cmd='./fastsum_matlab';
+end
+system(sprintf('%s %d %d %d %d %d %d %s %e %e %e',cmd,d,N,M,n,m,p,kernel,c,eps_I,eps_B));
 
 %read result from file
 f2=load('f.dat');

--- a/applications/fastsumS2/fastsumS2.m
+++ b/applications/fastsumS2/fastsumS2.m
@@ -24,7 +24,11 @@ infilename = 'data.in';
 % The output file name.
 outfilename = 'data.out';
 % The name of the fastsumS2.c executable
-programname = 'fastsumS2';
+if ispc
+    programname='fastsumS2.exe';
+else 
+    programname='./fastsumS2';
+end
 % The name of the file to write the time measurements table to.
 texfilename = 'table.tex';
 
@@ -143,7 +147,7 @@ if (selection > 0 && selection <= 4)
 
   % Call fastsumS2.c with the generated input file writing the output to the
   % output file.
-  system(sprintf('./%s < %s > %s',programname,infilename,outfilename));
+  system(sprintf('%s < %s > %s',programname,infilename,outfilename));
 
   % Open the output file.
   file = fopen(outfilename,'r');
@@ -235,7 +239,7 @@ elseif (selection == 5)
 
   % Call fastsumS2.c with the generated input file writing the output to the
   % output file.
-  system(sprintf('./%s < %s > %s',programname,infilename,outfilename));
+  system(sprintf('%s < %s > %s',programname,infilename,outfilename));
 
   % Open the output file.
   file = fopen(outfilename,'r');

--- a/applications/mri/mri2d/mri.m
+++ b/applications/mri/mri2d/mri.m
@@ -32,7 +32,12 @@ M = construct_knots_spiral(N,1);
 
 % Make a 2d-NFFT on the constructed knots
 % and write the output to output_data_phantom_nfft.dat
-system(['./construct_data_2d ' 'output_phantom_nfft.dat ' ...
+if ispc
+    cmd='construct_data_2d.exe';
+else 
+    cmd='./construct_data_2d';
+end
+system([cmd ' output_phantom_nfft.dat ' ...
          int2str(N) ' ' int2str(M)]);
 
 % Precompute the weights using voronoi cells
@@ -44,7 +49,12 @@ precompute_weights('output_phantom_nfft.dat',M);
 % The usage is "./reconstruct_data_2 filename N M ITER WEIGHTS"
 % where ITER is the number of iteration and WEIGHTS is 1
 % if the weights are used 0 else
-system(['./reconstruct_data_2d ' 'output_phantom_nfft.dat ' ...
+if ispc
+    cmd='reconstruct_data_2d.exe';
+else 
+    cmd='./reconstruct_data_2d';
+end
+system([cmd ' output_phantom_nfft.dat ' ...
          int2str(N) ' ' int2str(M)  ' 3 1']);
 
 % Visualize the two dimensional phantom. Make a pic
@@ -59,7 +69,12 @@ rms('pics/rms_2d.txt');
 % The same as above but reconstructed with gridding
 % That means an adjoint 2d-NFFT
 % The ITER parameter is unused and just for compatibility
-system(['./reconstruct_data_gridding ' 'output_phantom_nfft.dat ' ...
+if ispc
+    cmd='reconstruct_data_gridding.exe';
+else 
+    cmd='./reconstruct_data_gridding';
+end
+system([cmd ' output_phantom_nfft.dat ' ...
          int2str(N) ' ' int2str(M)  ' 5 1']);
 visualize_data('pics/pic_gridding', N, 2, '2d-NFFT (Gridding)');
 rms('pics/rms_gridding.txt');

--- a/applications/mri/mri2d/mri_inh.m
+++ b/applications/mri/mri2d/mri_inh.m
@@ -38,7 +38,12 @@ save input_f.dat -ascii out
 
 % Construct the k-space data considering the fieldmap
 % and write the output to output_data_phantom_nfft.dat
-system(['./construct_data_inh_2d1d ' 'output_phantom_nfft.dat ' ...
+if ispc
+    cmd='construct_data_inh_2d1d.exe';
+else 
+    cmd='./construct_data_inh_2d1d';
+end
+system([cmd ' output_phantom_nfft.dat ' ...
          int2str(N) ' ' int2str(M)]);
 
 % Precompute the weights using voronoi cells
@@ -51,7 +56,12 @@ precompute_weights('output_phantom_nfft.dat',M);
 % where ITER is the number of iteration and WEIGHTS is 1
 % if the weights are used 0 else
 % The other methods can be used by replacing 2d1d with 3d or nnfft
-system(['./reconstruct_data_inh_2d1d ' 'output_phantom_nfft.dat ' ...
+if ispc
+    cmd='reconstruct_data_inh_2d1d.exe';
+else 
+    cmd='./reconstruct_data_inh_2d1d';
+end
+system([cmd ' output_phantom_nfft.dat ' ...
          int2str(N) ' ' int2str(M)  ' 3 1']);
 
 % Visualize the two dimensional phantom. Make a pic
@@ -62,7 +72,12 @@ visualize_data('pics/pic_2d1d', N, 1, 'Reconstruction considering the fieldmap')
 rms('pics/rms_2d1d.txt');
 
 % Reconstruct without considering the fieldmap
-system(['./reconstruct_data_2d ' 'output_phantom_nfft.dat ' ...
+if ispc
+    cmd='reconstruct_data_2d.exe';
+else 
+    cmd='./reconstruct_data_2d';
+end
+system([cmd ' output_phantom_nfft.dat ' ...
          int2str(N) ' ' int2str(M)  ' 3 1']);
 visualize_data('pics/pic_2d', N, 2, 'Inverse 2d-NFFT - 3. iteration');
 rms('pics/rms_2d.txt');

--- a/applications/mri/mri3d/mri.m
+++ b/applications/mri/mri3d/mri.m
@@ -89,7 +89,7 @@ if ispc
 else 
     cmd='./reconstruct_data_3d';
 end
-system([cmd 'output_phantom_nfft.dat ' ...
+system([cmd ' output_phantom_nfft.dat ' ...
          int2str(N) ' ' int2str(M) ' ' int2str(Z)  ' 1 1']);
 visualize_data('pics_3d/pic', N, Z, 3, 'Inverse 3d-NFFT - 1. iteration - spiral knots');
 rms('pics_3d/rms.txt');

--- a/applications/mri/mri3d/mri.m
+++ b/applications/mri/mri3d/mri.m
@@ -34,7 +34,12 @@ M = construct_knots_spiral(N,Z);
 
 % First make N^2 1d-FFT, then Z 2d-NFFT on the constructed knots
 % and write the output to output_phantom_nfft.dat
-system(['./construct_data_2d1d ' 'output_phantom_nfft.dat '...
+if ispc
+    cmd='construct_data_2d1d.exe';
+else 
+    cmd='./construct_data_2d1d';
+end
+system([cmd ' output_phantom_nfft.dat '...
          int2str(N) ' ' int2str(M) ' ' int2str(Z)]);
 
 % Precompute the weights using voronoi cells
@@ -46,7 +51,12 @@ precompute_weights_2d('output_phantom_nfft.dat',M,Z);
 % The usage is "./reconstruct_data_2d1d filename N M Z ITER WEIGHTS"
 % where ITER is the number of iteration and WEIGHTS is 1
 % if the weights are used 0 else
-system(['./reconstruct_data_2d1d ' 'output_phantom_nfft.dat ' ...
+if ispc
+    cmd='reconstruct_data_2d1d.exe';
+else 
+    cmd='./reconstruct_data_2d1d';
+end
+system([cmd ' output_phantom_nfft.dat ' ...
          int2str(N) ' ' int2str(M) ' ' int2str(Z)  ' 3 1']);
 
 % Visualize the three dimensional phantom. Makes a pic of
@@ -61,7 +71,12 @@ visualize_data('pics_2+1d/pic', N, Z, 1, 'Inverse 2d1d-NFFT - 3. iteration - spi
 % The same as above but reconstructed with gridding.
 % That means first an adjoint 2d-NFFT, then a 1d-FFT.
 % The ITER parameter is obsolent and just for compatibility
-system(['./reconstruct_data_gridding ' 'output_phantom_nfft.dat ' ...
+if ispc
+    cmd='reconstruct_data_gridding.exe';
+else 
+    cmd='./reconstruct_data_gridding';
+end
+system([cmd ' output_phantom_nfft.dat ' ...
          int2str(N) ' ' int2str(M) ' ' int2str(Z)  ' 0 1']);
 visualize_data('pics_gridding/pic', N, Z, 2, 'Adjoint 2d1d-NFFT (Gridding) - spiral knots');
 rms('pics_gridding/rms.txt');
@@ -69,7 +84,12 @@ rms('pics_gridding/rms.txt');
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % The same as above but reconstructed with a 3d-nfft
-system(['./reconstruct_data_3d ' 'output_phantom_nfft.dat ' ...
+if ispc
+    cmd='reconstruct_data_3d.exe';
+else 
+    cmd='./reconstruct_data_3d';
+end
+system([cmd 'output_phantom_nfft.dat ' ...
          int2str(N) ' ' int2str(M) ' ' int2str(Z)  ' 1 1']);
 visualize_data('pics_3d/pic', N, Z, 3, 'Inverse 3d-NFFT - 1. iteration - spiral knots');
 rms('pics_3d/rms.txt');

--- a/applications/polarFFT/fft_test.m
+++ b/applications/polarFFT/fft_test.m
@@ -25,7 +25,12 @@ save 'input_data_r.dat' fr -ascii -double
 save 'input_data_i.dat' fi -ascii -double
 
 
-system(sprintf('./polar_fft_test %d %d %d',N,T,R));
+if ispc
+    cmd='polar_fft_test.exe';
+else 
+    cmd='./polar_fft_test';
+end
+system(sprintf('%s %d %d %d',cmd,N,T,R));
 
 polar_fft_error = load('polar_fft_error.dat');
 polar_ifft_error3 = load('polar_ifft_error3.dat');
@@ -58,7 +63,12 @@ print fig_ipolar_fft -deps2
 disp(sprintf('\n'));
 
 
-system(sprintf('./mpolar_fft_test %d %d %d',N,T,R));
+if ispc
+    cmd_mpolar_fft_test='mpolar_fft_test.exe';
+else 
+    cmd_mpolar_fft_test='./mpolar_fft_test';
+end
+system(sprintf('%s %d %d %d',cmd_mpolar_fft_test,N,T,R));
 
 mpolar_fft_error = load('mpolar_fft_error.dat');
 mpolar_ifft_error3 = load('mpolar_ifft_error3.dat');
@@ -91,7 +101,12 @@ print fig_impolar_fft -deps2
 disp(sprintf('\n'));
 
 
-system(sprintf('./linogram_fft_test %d %d %d',N,T,R));
+if ispc
+    cmd_linogram_fft_test='linogram_fft_test.exe';
+else 
+    cmd_linogram_fft_test='./linogram_fft_test';
+end
+system(sprintf('%s %d %d %d',cmd_linogram_fft_test,N,T,R));
 
 linogram_fft_error = load('linogram_fft_error.dat');
 linogram_ifft_error3 = load('linogram_ifft_error3.dat');

--- a/applications/quadratureS2/quadratureS2.m
+++ b/applications/quadratureS2/quadratureS2.m
@@ -24,7 +24,11 @@ infilename = 'data.in';
 % The name of the output file
 outfilename = 'data.out';
 % The name of the program
-programname = 'quadratureS2';
+if ispc
+    programname='quadratureS2.exe';
+else 
+    programname='./quadratureS2';
+end
 
 % Display the menu.
 selection = menu('quadratureS2 - Fast evaluation of quadrature formulae on the sphere',...
@@ -122,7 +126,7 @@ fclose(file);
 
 fprintf('Program in execution. Please be patient! This may take a while!\n');
 
-system(sprintf('./%s < %s > %s',programname,infilename,outfilename));
+system(sprintf('%s < %s > %s',programname,infilename,outfilename));
 file = fopen(outfilename,'r');
 T = readTestcase(file);
 fclose(file);

--- a/applications/radon/radon.m
+++ b/applications/radon/radon.m
@@ -41,7 +41,12 @@ fwrite(fp,f','double');
 fclose(fp);
 
 %compute Radon transform by C-program
-system(sprintf('./radon %s %d %d %d',grid,N,T,R));
+if ispc
+    cmd='radon.exe';
+else 
+    cmd='./radon';
+end
+system(sprintf('%s %s %d %d %d',cmd,grid,N,T,R));
 
 %read result from file
 fp = fopen('sinogram_data.bin','rb+');
@@ -57,7 +62,12 @@ xlabel('angle');
 ylabel('offset');
 
 %compute inverse Radon transform by C-program
-system(sprintf('./inverse_radon %s %d %d %d %d',grid,N,T,R,it));
+if ispc
+    cmd='inverse_radon.exe';
+else 
+    cmd='./inverse_radon';
+end
+system(sprintf('%s %s %d %d %d %d',cmd,grid,N,T,R,it));
 
 %read result from file
 fp = fopen('output_data.bin','rb+');

--- a/applications/radon/ridgelet.m
+++ b/applications/radon/ridgelet.m
@@ -69,7 +69,12 @@ axis image
 title(sprintf('noisy image (SNR=%g)',SNR));
 
 %compute Radon transform by C-program
-system(sprintf('./radon %s %d %d %d %d',grid,N,T,R));
+if ispc
+    cmd='radon.exe';
+else 
+    cmd='./radon';
+end
+system(sprintf('%s %s %d %d %d %d',cmd,grid,N,T,R));
 
 %read result from file
 fp = fopen('sinogram_data.bin','rb+');
@@ -94,7 +99,12 @@ fwrite(fp,Rf2d,'double');
 fclose(fp);
 
 %compute inverse Radon transform by C-program
-system(sprintf('./inverse_radon %s %d %d %d %d',grid,N,T,R,it));
+if ispc
+    cmd='inverse_radon.exe';
+else 
+    cmd='./inverse_radon';
+end
+system(sprintf('%s %s %d %d %d %d',cmd,grid,N,T,R,it));
 
 %read result
 fp = fopen('output_data.bin','rb+');

--- a/examples/nfft/flags.m
+++ b/examples/nfft/flags.m
@@ -92,7 +92,12 @@ sigma_nfft2=8;
 sigma_taylor2=16;
 
 % typical sigma
-system(sprintf('./taylor_nfft %d %d %d %d %f %f > taylor_nfft2a.dat',1,first,...
+if ispc
+    cmd='taylor_nfft.exe';
+else 
+    cmd='./taylor_nfft';
+end
+system(sprintf('%s %d %d %d %d %f %f > taylor_nfft2a.dat',cmd,1,first,...
 	       last,trials,sigma_nfft,sigma_taylor));
 data=load('taylor_nfft2a.dat');
 
@@ -105,14 +110,14 @@ e_taylor=data(:,11);
 max_e_taylor=(max(reshape(e_taylor,trials,last-first+1)))';
 
 % small sigma
-system(sprintf('./taylor_nfft %d %d %d %d %f %f > taylor_nfft2b.dat',1,first,...
+system(sprintf('%s %d %d %d %d %f %f > taylor_nfft2b.dat',cmd,1,first,...
 	       last,trials,sigma_nfft1,sigma_taylor1));
 data1=load('taylor_nfft2b.dat');
 max_e_nfft_sigma=(max(reshape(data1(:,7),trials,last-first+1)))';
 max_e_taylor_sigma=(max(reshape(data1(:,11),trials,last-first+1)))';
 
 % large sigma
-system(sprintf('./taylor_nfft %d %d %d %d %f %f > taylor_nfft2c.dat',1,first,...
+system(sprintf('%s %d %d %d %d %f %f > taylor_nfft2c.dat',cmd,1,first,...
 	       last,trials,sigma_nfft2,sigma_taylor2));
 data2=load('taylor_nfft2c.dat');
 max_e_nfft_sigma2=(max(reshape(data2(:,7),trials,last-first+1)))';

--- a/examples/nfft/taylor_nfft.m
+++ b/examples/nfft/taylor_nfft.m
@@ -71,7 +71,12 @@ sigma_nfft_c=16;
 sigma_taylor_c=16;
 
 % typical sigma
-system(sprintf('./taylor_nfft %d %d %d %d %f %f > taylor_nfft.data1a',1,first,...
+if ispc
+    cmd='taylor_nfft.exe';
+else 
+    cmd='./taylor_nfft';
+end
+system(sprintf('%s %d %d %d %d %f %f > taylor_nfft.data1a',cmd,1,first,...
 	       last,trials,sigma_nfft_a,sigma_taylor_a));
 data=load('taylor_nfft.data1a');
 
@@ -84,7 +89,7 @@ e_taylor_a=(max(reshape(data(:,11),trials,last-first+1)))';
 t_taylor_a=(mean(reshape(data(:,10),trials,last-first+1)))';
 
 % small sigma
-system(sprintf('./taylor_nfft %d %d %d %d %f %f > taylor_nfft.data1b',1,first,...
+system(sprintf('%s %d %d %d %d %f %f > taylor_nfft.data1b',cmd,1,first,...
 	       last,trials,sigma_nfft_b,sigma_taylor_b));
 data=load('taylor_nfft.data1b');
 
@@ -92,7 +97,7 @@ e_nfft_b=(max(reshape(data1(:,7),trials,last-first+1)))';
 e_taylor_b=(max(reshape(data1(:,11),trials,last-first+1)))';
 
 % large sigma
-system(sprintf('./taylor_nfft %d %d %d %d %f %f > taylor_nfft.data1c',1,first,...
+system(sprintf('%s %d %d %d %d %f %f > taylor_nfft.data1c',cmd,1,first,...
 	       last,trials,sigma_nfft_c,sigma_taylor_c));
 data=load('taylor_nfft.data1c');
 

--- a/examples/solver/glacier.m
+++ b/examples/solver/glacier.m
@@ -29,7 +29,12 @@ input_data(:,2)=(input_data(:,2)-min(input_data(:,2))) /y_range*(1-2*border_eps)
 
 save input_data.dat -ascii -double -tabs input_data
 
-system(sprintf('./glacier %d %d > output_data.dat',N,M));
+if ispc
+    cmd='glacier.exe';
+else 
+    cmd='./glacier';
+end
+system(sprintf('%s %d %d > output_data.dat',cmd,N,M));
 
 load output_data.dat
 f_hat=output_data(:,1)+i*output_data(:,2);

--- a/examples/solver/glacier_cv.m
+++ b/examples/solver/glacier_cv.m
@@ -37,4 +37,9 @@ M_cv_end=1000;
 
 save input_data.dat -ascii -double -tabs input_data
 
-system(sprintf('./glacier %d %d %d %d %d > output_data_cv.tex',N,M,M_cv_start,M_cv_step,M_cv_end));
+if ispc
+    cmd='glacier.exe';
+else 
+    cmd='./glacier';
+end
+system(sprintf('%s %d %d %d %d %d > output_data_cv.tex',cmd,N,M,M_cv_start,M_cv_step,M_cv_end));

--- a/include/infft.h
+++ b/include/infft.h
@@ -1300,21 +1300,21 @@ extern double _Complex catanh(double _Complex z);
 #  define __FE__ "% 36.32LE"
 #  define __FI__ "%Lf"
 #  define __FIS__ "Lf"
-#  define __FR__ "%La"
+#  define __FR__ "%Le"
 #elif defined(NFFT_SINGLE)
 #  define __FGS__ "g"
 #  define __FES__ "E"
 #  define __FE__ "% 12.8E"
 #  define __FI__ "%f"
 #  define __FIS__ "f"
-#  define __FR__ "%a"
+#  define __FR__ "%e"
 #else
 #  define __FGS__ "lg"
 #  define __FES__ "lE"
 #  define __FE__ "% 20.16lE"
 #  define __FI__ "%lf"
 #  define __FIS__ "lf"
-#  define __FR__ "%la"
+#  define __FR__ "%le"
 #endif
 
 #define TRUE 1

--- a/include/nfft3mp.h
+++ b/include/nfft3mp.h
@@ -70,21 +70,21 @@ typedef double _Complex NFFT_C;
 #  define NFFT__FE__ "% 36.32LE"
 #  define NFFT__FI__ "%Lf"
 #  define NFFT__FIS__ "Lf"
-#  define NFFT__FR__ "%La"
+#  define NFFT__FR__ "%Le"
 #elif defined(NFFT_PRECISION_SINGLE)
 #  define NFFT__FGS__ "g"
 #  define NFFT__FES__ "E"
 #  define NFFT__FE__ "% 12.8E"
 #  define NFFT__FI__ "%f"
 #  define NFFT__FIS__ "f"
-#  define NFFT__FR__ "%a"
+#  define NFFT__FR__ "%e"
 #elif defined(NFFT_PRECISION_DOUBLE)
 #  define NFFT__FGS__ "lg"
 #  define NFFT__FES__ "lE"
 #  define NFFT__FE__ "% 20.16lE"
 #  define NFFT__FI__ "%lf"
 #  define NFFT__FIS__ "lf"
-#  define NFFT__FR__ "%la"
+#  define NFFT__FR__ "%le"
 #else
 #error Either define macro NFFT_PRECISION_SINGLE, NFFT_PRECISION_DOUBLE or NFFT_PRECISION_LONG_DOUBLE for single, double or long double precision
 #endif


### PR DESCRIPTION
1. The command executed by Matlab in the applications takes the platform (Windows/Unix) into account (./programname vs programname.exe)
2.  Changed %a in %e for macro __FR__ used to read matlab data with scanf. This is the same scanf/printf format string as it was used in nfft-3.2.