### PR TITLE
Fixes for tests

### DIFF
--- a/tests/nfct.c
+++ b/tests/nfct.c
@@ -380,7 +380,7 @@ static void setup_file(const testcase_delegate_t *ego_, int *d, int **N, int *NN
   const testcase_delegate_file_t *ego = (const testcase_delegate_file_t*)ego_;
   int j;
   char filename[200];
-  char* c = rindex(ego->filename, SEP[0]);
+  char* c = strrchr(ego->filename, SEP[0]);
   FILE *file = fopen(ego->filename, "r");
 
   filename[0] = (char) 0;

--- a/tests/nfct.c
+++ b/tests/nfct.c
@@ -29,7 +29,7 @@
 #include "cycle.h"
 #include "nfct.h"
 
-#define ABSPATH(x) ABS_SRCDIR SEP "tests" SEP x
+#define ABSPATH(x) x
 
 /* Testcase delegate. */
 typedef struct testcase_delegate_s testcase_delegate_t;
@@ -189,7 +189,7 @@ static R trafo_direct_cost(X(plan) *p)
             x += 1;
           }
           X(finalize)(&p2);
-          free(N);
+          Y(free)(N);
         }
       }
     }
@@ -444,9 +444,9 @@ static void setup_file(const testcase_delegate_t *ego_, int *d, int **N, int *NN
 static void destroy_file(const testcase_delegate_t *ego_, R *x, R *f_hat, R *f)
 {
   UNUSED(ego_);
-  free(x);
-  free(f_hat);
-  free(f);
+  Y(free)(x);
+  Y(free)(f_hat);
+  Y(free)(f);
 }
 
 static void setup_online(const testcase_delegate_t *ego_, int *d, int **N, int *NN, int *M, R **x, R **f_hat, R **f)
@@ -619,9 +619,9 @@ static void setup_adjoint_online(const testcase_delegate_t *ego_, int *d, int **
 static void destroy_online(const testcase_delegate_t *ego_, R *x, R *f_hat, R *f)
 {
   UNUSED(ego_);
-  free(x);
-  free(f_hat);
-  free(f);
+  Y(free)(x);
+  Y(free)(f_hat);
+  Y(free)(f);
 }
 
 /* Initializers. */
@@ -659,7 +659,7 @@ static void init_advanced_pre_psi_(init_delegate_t *ego, X(plan) *p, const int d
   for (i = 0; i < d; i++)
     n[i] = 2 * (int)(Y(next_power_of_2)(N[i]));
   X(init_guru)(p, d, N, M, n, ego->m, ego->flags, ego->fftw_flags);
-  free(n);
+  Y(free)(n);
 }
 
 static init_delegate_t init_direct = {"init_guru ()", init_advanced_pre_psi_, WINDOW_HELP_ESTIMATE_m, (DEFAULT_NFFT_FLAGS ^ PRE_PSI), DEFAULT_FFTW_FLAGS};
@@ -782,30 +782,30 @@ static const init_delegate_t* initializers_1d[] =
 #endif
 };
 
-static const testcase_delegate_file_t nfct_1d_1_1 = {setup_file,destroy_file,ABSPATH("data/nfct_1d_1_1.txt")};
-static const testcase_delegate_file_t nfct_1d_1_10 = {setup_file,destroy_file,ABSPATH("data/nfct_1d_1_10.txt")};
-static const testcase_delegate_file_t nfct_1d_1_20 = {setup_file,destroy_file,ABSPATH("data/nfct_1d_1_20.txt")};
-static const testcase_delegate_file_t nfct_1d_1_50 = {setup_file,destroy_file,ABSPATH("data/nfct_1d_1_50.txt")};
-static const testcase_delegate_file_t nfct_1d_2_1 = {setup_file,destroy_file,ABSPATH("data/nfct_1d_2_1.txt")};
-static const testcase_delegate_file_t nfct_1d_2_10 = {setup_file,destroy_file,ABSPATH("data/nfct_1d_2_10.txt")};
-static const testcase_delegate_file_t nfct_1d_2_20 = {setup_file,destroy_file,ABSPATH("data/nfct_1d_2_20.txt")};
-static const testcase_delegate_file_t nfct_1d_2_50 = {setup_file,destroy_file,ABSPATH("data/nfct_1d_2_50.txt")};
-static const testcase_delegate_file_t nfct_1d_4_1 = {setup_file,destroy_file,ABSPATH("data/nfct_1d_4_1.txt")};
-static const testcase_delegate_file_t nfct_1d_4_10 = {setup_file,destroy_file,ABSPATH("data/nfct_1d_4_10.txt")};
-static const testcase_delegate_file_t nfct_1d_4_20 = {setup_file,destroy_file,ABSPATH("data/nfct_1d_4_20.txt")};
-static const testcase_delegate_file_t nfct_1d_4_50 = {setup_file,destroy_file,ABSPATH("data/nfct_1d_4_50.txt")};
-static const testcase_delegate_file_t nfct_1d_10_1 = {setup_file,destroy_file,ABSPATH("data/nfct_1d_10_1.txt")};
-static const testcase_delegate_file_t nfct_1d_10_10 = {setup_file,destroy_file,ABSPATH("data/nfct_1d_10_10.txt")};
-static const testcase_delegate_file_t nfct_1d_10_20 = {setup_file,destroy_file,ABSPATH("data/nfct_1d_10_20.txt")};
-static const testcase_delegate_file_t nfct_1d_10_50 = {setup_file,destroy_file,ABSPATH("data/nfct_1d_10_50.txt")};
-static const testcase_delegate_file_t nfct_1d_20_1 = {setup_file,destroy_file,ABSPATH("data/nfct_1d_20_1.txt")};
-static const testcase_delegate_file_t nfct_1d_20_10 = {setup_file,destroy_file,ABSPATH("data/nfct_1d_20_10.txt")};
-static const testcase_delegate_file_t nfct_1d_20_20 = {setup_file,destroy_file,ABSPATH("data/nfct_1d_20_20.txt")};
-static const testcase_delegate_file_t nfct_1d_20_50 = {setup_file,destroy_file,ABSPATH("data/nfct_1d_20_50.txt")};
-static const testcase_delegate_file_t nfct_1d_50_1 = {setup_file,destroy_file,ABSPATH("data/nfct_1d_50_1.txt")};
-static const testcase_delegate_file_t nfct_1d_50_10 = {setup_file,destroy_file,ABSPATH("data/nfct_1d_50_10.txt")};
-static const testcase_delegate_file_t nfct_1d_50_20 = {setup_file,destroy_file,ABSPATH("data/nfct_1d_50_20.txt")};
-static const testcase_delegate_file_t nfct_1d_50_50 = {setup_file,destroy_file,ABSPATH("data/nfct_1d_50_50.txt")};
+static const testcase_delegate_file_t nfct_1d_1_1 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_1d_1_1.txt")};
+static const testcase_delegate_file_t nfct_1d_1_10 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_1d_1_10.txt")};
+static const testcase_delegate_file_t nfct_1d_1_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_1d_1_20.txt")};
+static const testcase_delegate_file_t nfct_1d_1_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_1d_1_50.txt")};
+static const testcase_delegate_file_t nfct_1d_2_1 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_1d_2_1.txt")};
+static const testcase_delegate_file_t nfct_1d_2_10 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_1d_2_10.txt")};
+static const testcase_delegate_file_t nfct_1d_2_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_1d_2_20.txt")};
+static const testcase_delegate_file_t nfct_1d_2_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_1d_2_50.txt")};
+static const testcase_delegate_file_t nfct_1d_4_1 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_1d_4_1.txt")};
+static const testcase_delegate_file_t nfct_1d_4_10 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_1d_4_10.txt")};
+static const testcase_delegate_file_t nfct_1d_4_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_1d_4_20.txt")};
+static const testcase_delegate_file_t nfct_1d_4_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_1d_4_50.txt")};
+static const testcase_delegate_file_t nfct_1d_10_1 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_1d_10_1.txt")};
+static const testcase_delegate_file_t nfct_1d_10_10 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_1d_10_10.txt")};
+static const testcase_delegate_file_t nfct_1d_10_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_1d_10_20.txt")};
+static const testcase_delegate_file_t nfct_1d_10_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_1d_10_50.txt")};
+static const testcase_delegate_file_t nfct_1d_20_1 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_1d_20_1.txt")};
+static const testcase_delegate_file_t nfct_1d_20_10 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_1d_20_10.txt")};
+static const testcase_delegate_file_t nfct_1d_20_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_1d_20_20.txt")};
+static const testcase_delegate_file_t nfct_1d_20_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_1d_20_50.txt")};
+static const testcase_delegate_file_t nfct_1d_50_1 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_1d_50_1.txt")};
+static const testcase_delegate_file_t nfct_1d_50_10 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_1d_50_10.txt")};
+static const testcase_delegate_file_t nfct_1d_50_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_1d_50_20.txt")};
+static const testcase_delegate_file_t nfct_1d_50_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_1d_50_50.txt")};
 
 static const testcase_delegate_file_t *testcases_1d_file[] =
 {
@@ -853,30 +853,30 @@ void X(check_1d_fast_file)(void)
     testcases_1d_file, initializers_1d, &check_trafo, trafos_1d_fast_file);
 }
 
-static const testcase_delegate_file_t nfct_adjoint_1d_1_1 = {setup_file,destroy_file,ABSPATH("data/nfct_adjoint_1d_1_1.txt")};
-static const testcase_delegate_file_t nfct_adjoint_1d_1_10 = {setup_file,destroy_file,ABSPATH("data/nfct_adjoint_1d_1_10.txt")};
-static const testcase_delegate_file_t nfct_adjoint_1d_1_20 = {setup_file,destroy_file,ABSPATH("data/nfct_adjoint_1d_1_20.txt")};
-static const testcase_delegate_file_t nfct_adjoint_1d_1_50 = {setup_file,destroy_file,ABSPATH("data/nfct_adjoint_1d_1_50.txt")};
-static const testcase_delegate_file_t nfct_adjoint_1d_2_1 = {setup_file,destroy_file,ABSPATH("data/nfct_adjoint_1d_2_1.txt")};
-static const testcase_delegate_file_t nfct_adjoint_1d_2_10 = {setup_file,destroy_file,ABSPATH("data/nfct_adjoint_1d_2_10.txt")};
-static const testcase_delegate_file_t nfct_adjoint_1d_2_20 = {setup_file,destroy_file,ABSPATH("data/nfct_adjoint_1d_2_20.txt")};
-static const testcase_delegate_file_t nfct_adjoint_1d_2_50 = {setup_file,destroy_file,ABSPATH("data/nfct_adjoint_1d_2_50.txt")};
-static const testcase_delegate_file_t nfct_adjoint_1d_4_1 = {setup_file,destroy_file,ABSPATH("data/nfct_adjoint_1d_4_1.txt")};
-static const testcase_delegate_file_t nfct_adjoint_1d_4_10 = {setup_file,destroy_file,ABSPATH("data/nfct_adjoint_1d_4_10.txt")};
-static const testcase_delegate_file_t nfct_adjoint_1d_4_20 = {setup_file,destroy_file,ABSPATH("data/nfct_adjoint_1d_4_20.txt")};
-static const testcase_delegate_file_t nfct_adjoint_1d_4_50 = {setup_file,destroy_file,ABSPATH("data/nfct_adjoint_1d_4_50.txt")};
-static const testcase_delegate_file_t nfct_adjoint_1d_10_1 = {setup_file,destroy_file,ABSPATH("data/nfct_adjoint_1d_10_1.txt")};
-static const testcase_delegate_file_t nfct_adjoint_1d_10_10 = {setup_file,destroy_file,ABSPATH("data/nfct_adjoint_1d_10_10.txt")};
-static const testcase_delegate_file_t nfct_adjoint_1d_10_20 = {setup_file,destroy_file,ABSPATH("data/nfct_adjoint_1d_10_20.txt")};
-static const testcase_delegate_file_t nfct_adjoint_1d_10_50 = {setup_file,destroy_file,ABSPATH("data/nfct_adjoint_1d_10_50.txt")};
-static const testcase_delegate_file_t nfct_adjoint_1d_20_1 = {setup_file,destroy_file,ABSPATH("data/nfct_adjoint_1d_20_1.txt")};
-static const testcase_delegate_file_t nfct_adjoint_1d_20_10 = {setup_file,destroy_file,ABSPATH("data/nfct_adjoint_1d_20_10.txt")};
-static const testcase_delegate_file_t nfct_adjoint_1d_20_20 = {setup_file,destroy_file,ABSPATH("data/nfct_adjoint_1d_20_20.txt")};
-static const testcase_delegate_file_t nfct_adjoint_1d_20_50 = {setup_file,destroy_file,ABSPATH("data/nfct_adjoint_1d_20_50.txt")};
-static const testcase_delegate_file_t nfct_adjoint_1d_50_1 = {setup_file,destroy_file,ABSPATH("data/nfct_adjoint_1d_50_1.txt")};
-static const testcase_delegate_file_t nfct_adjoint_1d_50_10 = {setup_file,destroy_file,ABSPATH("data/nfct_adjoint_1d_50_10.txt")};
-static const testcase_delegate_file_t nfct_adjoint_1d_50_20 = {setup_file,destroy_file,ABSPATH("data/nfct_adjoint_1d_50_20.txt")};
-static const testcase_delegate_file_t nfct_adjoint_1d_50_50 = {setup_file,destroy_file,ABSPATH("data/nfct_adjoint_1d_50_50.txt")};
+static const testcase_delegate_file_t nfct_adjoint_1d_1_1 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_adjoint_1d_1_1.txt")};
+static const testcase_delegate_file_t nfct_adjoint_1d_1_10 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_adjoint_1d_1_10.txt")};
+static const testcase_delegate_file_t nfct_adjoint_1d_1_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_adjoint_1d_1_20.txt")};
+static const testcase_delegate_file_t nfct_adjoint_1d_1_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_adjoint_1d_1_50.txt")};
+static const testcase_delegate_file_t nfct_adjoint_1d_2_1 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_adjoint_1d_2_1.txt")};
+static const testcase_delegate_file_t nfct_adjoint_1d_2_10 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_adjoint_1d_2_10.txt")};
+static const testcase_delegate_file_t nfct_adjoint_1d_2_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_adjoint_1d_2_20.txt")};
+static const testcase_delegate_file_t nfct_adjoint_1d_2_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_adjoint_1d_2_50.txt")};
+static const testcase_delegate_file_t nfct_adjoint_1d_4_1 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_adjoint_1d_4_1.txt")};
+static const testcase_delegate_file_t nfct_adjoint_1d_4_10 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_adjoint_1d_4_10.txt")};
+static const testcase_delegate_file_t nfct_adjoint_1d_4_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_adjoint_1d_4_20.txt")};
+static const testcase_delegate_file_t nfct_adjoint_1d_4_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_adjoint_1d_4_50.txt")};
+static const testcase_delegate_file_t nfct_adjoint_1d_10_1 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_adjoint_1d_10_1.txt")};
+static const testcase_delegate_file_t nfct_adjoint_1d_10_10 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_adjoint_1d_10_10.txt")};
+static const testcase_delegate_file_t nfct_adjoint_1d_10_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_adjoint_1d_10_20.txt")};
+static const testcase_delegate_file_t nfct_adjoint_1d_10_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_adjoint_1d_10_50.txt")};
+static const testcase_delegate_file_t nfct_adjoint_1d_20_1 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_adjoint_1d_20_1.txt")};
+static const testcase_delegate_file_t nfct_adjoint_1d_20_10 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_adjoint_1d_20_10.txt")};
+static const testcase_delegate_file_t nfct_adjoint_1d_20_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_adjoint_1d_20_20.txt")};
+static const testcase_delegate_file_t nfct_adjoint_1d_20_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_adjoint_1d_20_50.txt")};
+static const testcase_delegate_file_t nfct_adjoint_1d_50_1 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_adjoint_1d_50_1.txt")};
+static const testcase_delegate_file_t nfct_adjoint_1d_50_10 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_adjoint_1d_50_10.txt")};
+static const testcase_delegate_file_t nfct_adjoint_1d_50_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_adjoint_1d_50_20.txt")};
+static const testcase_delegate_file_t nfct_adjoint_1d_50_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_adjoint_1d_50_50.txt")};
 
 static const testcase_delegate_file_t *testcases_adjoint_1d_file[] =
 {
@@ -1001,14 +1001,14 @@ static const init_delegate_t* initializers_2d[] =
 #endif
 };
 
-static const testcase_delegate_file_t nfct_2d_10_10_20 = {setup_file,destroy_file,ABSPATH("data/nfct_2d_10_10_20.txt")};
-static const testcase_delegate_file_t nfct_2d_10_10_50 = {setup_file,destroy_file,ABSPATH("data/nfct_2d_10_10_50.txt")};
-static const testcase_delegate_file_t nfct_2d_10_20_20 = {setup_file,destroy_file,ABSPATH("data/nfct_2d_10_20_20.txt")};
-static const testcase_delegate_file_t nfct_2d_10_20_50 = {setup_file,destroy_file,ABSPATH("data/nfct_2d_10_20_50.txt")};
-static const testcase_delegate_file_t nfct_2d_20_10_20 = {setup_file,destroy_file,ABSPATH("data/nfct_2d_20_10_20.txt")};
-static const testcase_delegate_file_t nfct_2d_20_10_50 = {setup_file,destroy_file,ABSPATH("data/nfct_2d_20_10_50.txt")};
-static const testcase_delegate_file_t nfct_2d_20_20_20 = {setup_file,destroy_file,ABSPATH("data/nfct_2d_20_20_20.txt")};
-static const testcase_delegate_file_t nfct_2d_20_20_50 = {setup_file,destroy_file,ABSPATH("data/nfct_2d_20_20_50.txt")};
+static const testcase_delegate_file_t nfct_2d_10_10_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_2d_10_10_20.txt")};
+static const testcase_delegate_file_t nfct_2d_10_10_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_2d_10_10_50.txt")};
+static const testcase_delegate_file_t nfct_2d_10_20_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_2d_10_20_20.txt")};
+static const testcase_delegate_file_t nfct_2d_10_20_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_2d_10_20_50.txt")};
+static const testcase_delegate_file_t nfct_2d_20_10_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_2d_20_10_20.txt")};
+static const testcase_delegate_file_t nfct_2d_20_10_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_2d_20_10_50.txt")};
+static const testcase_delegate_file_t nfct_2d_20_20_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_2d_20_20_20.txt")};
+static const testcase_delegate_file_t nfct_2d_20_20_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_2d_20_20_50.txt")};
 
 static const testcase_delegate_file_t *testcases_2d_file[] =
 {
@@ -1040,14 +1040,14 @@ void X(check_2d_fast_file)(void)
     testcases_2d_file, initializers_2d, &check_trafo, trafos_2d_fast_file);
 }
 
-static const testcase_delegate_file_t nfct_adjoint_2d_10_10_20 = {setup_file,destroy_file,ABSPATH("data/nfct_adjoint_2d_10_10_20.txt")};
-static const testcase_delegate_file_t nfct_adjoint_2d_10_10_50 = {setup_file,destroy_file,ABSPATH("data/nfct_adjoint_2d_10_10_50.txt")};
-static const testcase_delegate_file_t nfct_adjoint_2d_10_20_20 = {setup_file,destroy_file,ABSPATH("data/nfct_adjoint_2d_10_20_20.txt")};
-static const testcase_delegate_file_t nfct_adjoint_2d_10_20_50 = {setup_file,destroy_file,ABSPATH("data/nfct_adjoint_2d_10_20_50.txt")};
-static const testcase_delegate_file_t nfct_adjoint_2d_20_10_20 = {setup_file,destroy_file,ABSPATH("data/nfct_adjoint_2d_20_10_20.txt")};
-static const testcase_delegate_file_t nfct_adjoint_2d_20_10_50 = {setup_file,destroy_file,ABSPATH("data/nfct_adjoint_2d_20_10_50.txt")};
-static const testcase_delegate_file_t nfct_adjoint_2d_20_20_20 = {setup_file,destroy_file,ABSPATH("data/nfct_adjoint_2d_20_20_20.txt")};
-static const testcase_delegate_file_t nfct_adjoint_2d_20_20_50 = {setup_file,destroy_file,ABSPATH("data/nfct_adjoint_2d_20_20_50.txt")};
+static const testcase_delegate_file_t nfct_adjoint_2d_10_10_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_adjoint_2d_10_10_20.txt")};
+static const testcase_delegate_file_t nfct_adjoint_2d_10_10_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_adjoint_2d_10_10_50.txt")};
+static const testcase_delegate_file_t nfct_adjoint_2d_10_20_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_adjoint_2d_10_20_20.txt")};
+static const testcase_delegate_file_t nfct_adjoint_2d_10_20_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_adjoint_2d_10_20_50.txt")};
+static const testcase_delegate_file_t nfct_adjoint_2d_20_10_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_adjoint_2d_20_10_20.txt")};
+static const testcase_delegate_file_t nfct_adjoint_2d_20_10_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_adjoint_2d_20_10_50.txt")};
+static const testcase_delegate_file_t nfct_adjoint_2d_20_20_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_adjoint_2d_20_20_20.txt")};
+static const testcase_delegate_file_t nfct_adjoint_2d_20_20_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_adjoint_2d_20_20_50.txt")};
 
 static const testcase_delegate_file_t *testcases_adjoint_2d_file[] =
 {
@@ -1144,7 +1144,7 @@ static const init_delegate_t* initializers_3d[] =
 #endif
 };
 
-static const testcase_delegate_file_t nfct_3d_10_10_10_10 = {setup_file,destroy_file,ABSPATH("data/nfct_3d_10_10_10_10.txt")};
+static const testcase_delegate_file_t nfct_3d_10_10_10_10 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_3d_10_10_10_10.txt")};
 
 static const testcase_delegate_file_t *testcases_3d_file[] =
 {
@@ -1169,7 +1169,7 @@ void X(check_3d_fast_file)(void)
     testcases_3d_file, initializers_3d, &check_trafo, trafos_3d_fast_file);
 }
 
-static const testcase_delegate_file_t nfct_adjoint_3d_10_10_10_10 = {setup_file,destroy_file,ABSPATH("data/nfct_adjoint_3d_10_10_10_10.txt")};
+static const testcase_delegate_file_t nfct_adjoint_3d_10_10_10_10 = {setup_file,destroy_file,ABSPATH("data" SEP "nfct_adjoint_3d_10_10_10_10.txt")};
 
 static const testcase_delegate_file_t *testcases_adjoint_3d_file[] =
 {

--- a/tests/nfft.c
+++ b/tests/nfft.c
@@ -381,7 +381,7 @@ static void setup_file(const testcase_delegate_t *ego_, int *d, int **N, int *NN
   const testcase_delegate_file_t *ego = (const testcase_delegate_file_t*)ego_;
   int j;
   char filename[200];
-  char* c = rindex(ego->filename, SEP[0]);
+  char* c = strrchr(ego->filename, SEP[0]);
   FILE *file = fopen(ego->filename, "r");
 
   filename[0] = (char) 0;

--- a/tests/nfst.c
+++ b/tests/nfst.c
@@ -29,7 +29,7 @@
 #include "cycle.h"
 #include "nfst.h"
 
-#define ABSPATH(x) ABS_SRCDIR SEP "tests" SEP x
+#define ABSPATH(x) x
 
 /* Testcase delegate. */
 typedef struct testcase_delegate_s testcase_delegate_t;
@@ -189,7 +189,7 @@ static R trafo_direct_cost(X(plan) *p)
             x += 1;
           }
           X(finalize)(&p2);
-          free(N);
+          Y(free)(N);
         }
       }
     }
@@ -450,10 +450,10 @@ static void setup_file(const testcase_delegate_t *ego_, int *d, int **N, int *NN
 static void destroy_file(const testcase_delegate_t *ego_, int *N, R *x, R *f_hat, R *f)
 {
   UNUSED(ego_);
-  free(N);
-  free(x);
-  free(f_hat);
-  free(f);
+  Y(free)(N);
+  Y(free)(x);
+  Y(free)(f_hat);
+  Y(free)(f);
 }
 
 static void setup_online(const testcase_delegate_t *ego_, int *d, int **N, int *NN, int *M, R **x, R **f_hat, R **f)
@@ -626,10 +626,10 @@ static void setup_adjoint_online(const testcase_delegate_t *ego_, int *d, int **
 static void destroy_online(const testcase_delegate_t *ego_, int *N, R *x, R *f_hat, R *f)
 {
   UNUSED(ego_);
-  free(N);
-  free(x);
-  free(f_hat);
-  free(f);
+  Y(free)(N);
+  Y(free)(x);
+  Y(free)(f_hat);
+  Y(free)(f);
 }
 
 /* Initializers. */
@@ -667,7 +667,7 @@ static void init_advanced_pre_psi_(init_delegate_t *ego, X(plan) *p, const int d
   for (i = 0; i < d; i++)
     n[i] = 2 * (int)(Y(next_power_of_2)(N[i]));
   X(init_guru)(p, d, N, M, n, ego->m, ego->flags, ego->fftw_flags);
-  free(n);
+  Y(free)(n);
 }
 
 static init_delegate_t init_direct = {"init_guru ()", init_advanced_pre_psi_, WINDOW_HELP_ESTIMATE_m, (DEFAULT_NFFT_FLAGS ^ PRE_PSI), DEFAULT_FFTW_FLAGS};
@@ -790,26 +790,26 @@ static const init_delegate_t* initializers_1d[] =
 #endif
 };
 
-static const testcase_delegate_file_t nfst_1d_2_1 = {setup_file,destroy_file,ABSPATH("data/nfst_1d_2_1.txt")};
-static const testcase_delegate_file_t nfst_1d_2_10 = {setup_file,destroy_file,ABSPATH("data/nfst_1d_2_10.txt")};
-static const testcase_delegate_file_t nfst_1d_2_20 = {setup_file,destroy_file,ABSPATH("data/nfst_1d_2_20.txt")};
-static const testcase_delegate_file_t nfst_1d_2_50 = {setup_file,destroy_file,ABSPATH("data/nfst_1d_2_50.txt")};
-static const testcase_delegate_file_t nfst_1d_4_1 = {setup_file,destroy_file,ABSPATH("data/nfst_1d_4_1.txt")};
-static const testcase_delegate_file_t nfst_1d_4_10 = {setup_file,destroy_file,ABSPATH("data/nfst_1d_4_10.txt")};
-static const testcase_delegate_file_t nfst_1d_4_20 = {setup_file,destroy_file,ABSPATH("data/nfst_1d_4_20.txt")};
-static const testcase_delegate_file_t nfst_1d_4_50 = {setup_file,destroy_file,ABSPATH("data/nfst_1d_4_50.txt")};
-static const testcase_delegate_file_t nfst_1d_10_1 = {setup_file,destroy_file,ABSPATH("data/nfst_1d_10_1.txt")};
-static const testcase_delegate_file_t nfst_1d_10_10 = {setup_file,destroy_file,ABSPATH("data/nfst_1d_10_10.txt")};
-static const testcase_delegate_file_t nfst_1d_10_20 = {setup_file,destroy_file,ABSPATH("data/nfst_1d_10_20.txt")};
-static const testcase_delegate_file_t nfst_1d_10_50 = {setup_file,destroy_file,ABSPATH("data/nfst_1d_10_50.txt")};
-static const testcase_delegate_file_t nfst_1d_20_1 = {setup_file,destroy_file,ABSPATH("data/nfst_1d_20_1.txt")};
-static const testcase_delegate_file_t nfst_1d_20_10 = {setup_file,destroy_file,ABSPATH("data/nfst_1d_20_10.txt")};
-static const testcase_delegate_file_t nfst_1d_20_20 = {setup_file,destroy_file,ABSPATH("data/nfst_1d_20_20.txt")};
-static const testcase_delegate_file_t nfst_1d_20_50 = {setup_file,destroy_file,ABSPATH("data/nfst_1d_20_50.txt")};
-static const testcase_delegate_file_t nfst_1d_50_1 = {setup_file,destroy_file,ABSPATH("data/nfst_1d_50_1.txt")};
-static const testcase_delegate_file_t nfst_1d_50_10 = {setup_file,destroy_file,ABSPATH("data/nfst_1d_50_10.txt")};
-static const testcase_delegate_file_t nfst_1d_50_20 = {setup_file,destroy_file,ABSPATH("data/nfst_1d_50_20.txt")};
-static const testcase_delegate_file_t nfst_1d_50_50 = {setup_file,destroy_file,ABSPATH("data/nfst_1d_50_50.txt")};
+static const testcase_delegate_file_t nfst_1d_2_1 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_1d_2_1.txt")};
+static const testcase_delegate_file_t nfst_1d_2_10 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_1d_2_10.txt")};
+static const testcase_delegate_file_t nfst_1d_2_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_1d_2_20.txt")};
+static const testcase_delegate_file_t nfst_1d_2_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_1d_2_50.txt")};
+static const testcase_delegate_file_t nfst_1d_4_1 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_1d_4_1.txt")};
+static const testcase_delegate_file_t nfst_1d_4_10 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_1d_4_10.txt")};
+static const testcase_delegate_file_t nfst_1d_4_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_1d_4_20.txt")};
+static const testcase_delegate_file_t nfst_1d_4_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_1d_4_50.txt")};
+static const testcase_delegate_file_t nfst_1d_10_1 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_1d_10_1.txt")};
+static const testcase_delegate_file_t nfst_1d_10_10 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_1d_10_10.txt")};
+static const testcase_delegate_file_t nfst_1d_10_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_1d_10_20.txt")};
+static const testcase_delegate_file_t nfst_1d_10_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_1d_10_50.txt")};
+static const testcase_delegate_file_t nfst_1d_20_1 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_1d_20_1.txt")};
+static const testcase_delegate_file_t nfst_1d_20_10 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_1d_20_10.txt")};
+static const testcase_delegate_file_t nfst_1d_20_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_1d_20_20.txt")};
+static const testcase_delegate_file_t nfst_1d_20_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_1d_20_50.txt")};
+static const testcase_delegate_file_t nfst_1d_50_1 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_1d_50_1.txt")};
+static const testcase_delegate_file_t nfst_1d_50_10 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_1d_50_10.txt")};
+static const testcase_delegate_file_t nfst_1d_50_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_1d_50_20.txt")};
+static const testcase_delegate_file_t nfst_1d_50_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_1d_50_50.txt")};
 
 static const testcase_delegate_file_t *testcases_1d_file[] =
 {
@@ -853,26 +853,26 @@ void X(check_1d_fast_file)(void)
     testcases_1d_file, initializers_1d, &check_trafo, trafos_1d_fast_file);
 }
 
-static const testcase_delegate_file_t nfst_adjoint_1d_2_1 = {setup_file,destroy_file,ABSPATH("data/nfst_adjoint_1d_2_1.txt")};
-static const testcase_delegate_file_t nfst_adjoint_1d_2_10 = {setup_file,destroy_file,ABSPATH("data/nfst_adjoint_1d_2_10.txt")};
-static const testcase_delegate_file_t nfst_adjoint_1d_2_20 = {setup_file,destroy_file,ABSPATH("data/nfst_adjoint_1d_2_20.txt")};
-static const testcase_delegate_file_t nfst_adjoint_1d_2_50 = {setup_file,destroy_file,ABSPATH("data/nfst_adjoint_1d_2_50.txt")};
-static const testcase_delegate_file_t nfst_adjoint_1d_4_1 = {setup_file,destroy_file,ABSPATH("data/nfst_adjoint_1d_4_1.txt")};
-static const testcase_delegate_file_t nfst_adjoint_1d_4_10 = {setup_file,destroy_file,ABSPATH("data/nfst_adjoint_1d_4_10.txt")};
-static const testcase_delegate_file_t nfst_adjoint_1d_4_20 = {setup_file,destroy_file,ABSPATH("data/nfst_adjoint_1d_4_20.txt")};
-static const testcase_delegate_file_t nfst_adjoint_1d_4_50 = {setup_file,destroy_file,ABSPATH("data/nfst_adjoint_1d_4_50.txt")};
-static const testcase_delegate_file_t nfst_adjoint_1d_10_1 = {setup_file,destroy_file,ABSPATH("data/nfst_adjoint_1d_10_1.txt")};
-static const testcase_delegate_file_t nfst_adjoint_1d_10_10 = {setup_file,destroy_file,ABSPATH("data/nfst_adjoint_1d_10_10.txt")};
-static const testcase_delegate_file_t nfst_adjoint_1d_10_20 = {setup_file,destroy_file,ABSPATH("data/nfst_adjoint_1d_10_20.txt")};
-static const testcase_delegate_file_t nfst_adjoint_1d_10_50 = {setup_file,destroy_file,ABSPATH("data/nfst_adjoint_1d_10_50.txt")};
-static const testcase_delegate_file_t nfst_adjoint_1d_20_1 = {setup_file,destroy_file,ABSPATH("data/nfst_adjoint_1d_20_1.txt")};
-static const testcase_delegate_file_t nfst_adjoint_1d_20_10 = {setup_file,destroy_file,ABSPATH("data/nfst_adjoint_1d_20_10.txt")};
-static const testcase_delegate_file_t nfst_adjoint_1d_20_20 = {setup_file,destroy_file,ABSPATH("data/nfst_adjoint_1d_20_20.txt")};
-static const testcase_delegate_file_t nfst_adjoint_1d_20_50 = {setup_file,destroy_file,ABSPATH("data/nfst_adjoint_1d_20_50.txt")};
-static const testcase_delegate_file_t nfst_adjoint_1d_50_1 = {setup_file,destroy_file,ABSPATH("data/nfst_adjoint_1d_50_1.txt")};
-static const testcase_delegate_file_t nfst_adjoint_1d_50_10 = {setup_file,destroy_file,ABSPATH("data/nfst_adjoint_1d_50_10.txt")};
-static const testcase_delegate_file_t nfst_adjoint_1d_50_20 = {setup_file,destroy_file,ABSPATH("data/nfst_adjoint_1d_50_20.txt")};
-static const testcase_delegate_file_t nfst_adjoint_1d_50_50 = {setup_file,destroy_file,ABSPATH("data/nfst_adjoint_1d_50_50.txt")};
+static const testcase_delegate_file_t nfst_adjoint_1d_2_1 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_adjoint_1d_2_1.txt")};
+static const testcase_delegate_file_t nfst_adjoint_1d_2_10 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_adjoint_1d_2_10.txt")};
+static const testcase_delegate_file_t nfst_adjoint_1d_2_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_adjoint_1d_2_20.txt")};
+static const testcase_delegate_file_t nfst_adjoint_1d_2_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_adjoint_1d_2_50.txt")};
+static const testcase_delegate_file_t nfst_adjoint_1d_4_1 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_adjoint_1d_4_1.txt")};
+static const testcase_delegate_file_t nfst_adjoint_1d_4_10 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_adjoint_1d_4_10.txt")};
+static const testcase_delegate_file_t nfst_adjoint_1d_4_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_adjoint_1d_4_20.txt")};
+static const testcase_delegate_file_t nfst_adjoint_1d_4_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_adjoint_1d_4_50.txt")};
+static const testcase_delegate_file_t nfst_adjoint_1d_10_1 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_adjoint_1d_10_1.txt")};
+static const testcase_delegate_file_t nfst_adjoint_1d_10_10 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_adjoint_1d_10_10.txt")};
+static const testcase_delegate_file_t nfst_adjoint_1d_10_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_adjoint_1d_10_20.txt")};
+static const testcase_delegate_file_t nfst_adjoint_1d_10_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_adjoint_1d_10_50.txt")};
+static const testcase_delegate_file_t nfst_adjoint_1d_20_1 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_adjoint_1d_20_1.txt")};
+static const testcase_delegate_file_t nfst_adjoint_1d_20_10 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_adjoint_1d_20_10.txt")};
+static const testcase_delegate_file_t nfst_adjoint_1d_20_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_adjoint_1d_20_20.txt")};
+static const testcase_delegate_file_t nfst_adjoint_1d_20_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_adjoint_1d_20_50.txt")};
+static const testcase_delegate_file_t nfst_adjoint_1d_50_1 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_adjoint_1d_50_1.txt")};
+static const testcase_delegate_file_t nfst_adjoint_1d_50_10 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_adjoint_1d_50_10.txt")};
+static const testcase_delegate_file_t nfst_adjoint_1d_50_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_adjoint_1d_50_20.txt")};
+static const testcase_delegate_file_t nfst_adjoint_1d_50_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_adjoint_1d_50_50.txt")};
 
 static const testcase_delegate_file_t *testcases_adjoint_1d_file[] =
 {
@@ -993,14 +993,14 @@ static const init_delegate_t* initializers_2d[] =
 #endif
 };
 
-static const testcase_delegate_file_t nfst_2d_10_10_20 = {setup_file,destroy_file,ABSPATH("data/nfst_2d_10_10_20.txt")};
-static const testcase_delegate_file_t nfst_2d_10_10_50 = {setup_file,destroy_file,ABSPATH("data/nfst_2d_10_10_50.txt")};
-static const testcase_delegate_file_t nfst_2d_10_20_20 = {setup_file,destroy_file,ABSPATH("data/nfst_2d_10_20_20.txt")};
-static const testcase_delegate_file_t nfst_2d_10_20_50 = {setup_file,destroy_file,ABSPATH("data/nfst_2d_10_20_50.txt")};
-static const testcase_delegate_file_t nfst_2d_20_10_20 = {setup_file,destroy_file,ABSPATH("data/nfst_2d_20_10_20.txt")};
-static const testcase_delegate_file_t nfst_2d_20_10_50 = {setup_file,destroy_file,ABSPATH("data/nfst_2d_20_10_50.txt")};
-static const testcase_delegate_file_t nfst_2d_20_20_20 = {setup_file,destroy_file,ABSPATH("data/nfst_2d_20_20_20.txt")};
-static const testcase_delegate_file_t nfst_2d_20_20_50 = {setup_file,destroy_file,ABSPATH("data/nfst_2d_20_20_50.txt")};
+static const testcase_delegate_file_t nfst_2d_10_10_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_2d_10_10_20.txt")};
+static const testcase_delegate_file_t nfst_2d_10_10_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_2d_10_10_50.txt")};
+static const testcase_delegate_file_t nfst_2d_10_20_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_2d_10_20_20.txt")};
+static const testcase_delegate_file_t nfst_2d_10_20_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_2d_10_20_50.txt")};
+static const testcase_delegate_file_t nfst_2d_20_10_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_2d_20_10_20.txt")};
+static const testcase_delegate_file_t nfst_2d_20_10_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_2d_20_10_50.txt")};
+static const testcase_delegate_file_t nfst_2d_20_20_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_2d_20_20_20.txt")};
+static const testcase_delegate_file_t nfst_2d_20_20_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_2d_20_20_50.txt")};
 
 static const testcase_delegate_file_t *testcases_2d_file[] =
 {
@@ -1032,14 +1032,14 @@ void X(check_2d_fast_file)(void)
     testcases_2d_file, initializers_2d, &check_trafo, trafos_2d_fast_file);
 }
 
-static const testcase_delegate_file_t nfst_adjoint_2d_10_10_20 = {setup_file,destroy_file,ABSPATH("data/nfst_adjoint_2d_10_10_20.txt")};
-static const testcase_delegate_file_t nfst_adjoint_2d_10_10_50 = {setup_file,destroy_file,ABSPATH("data/nfst_adjoint_2d_10_10_50.txt")};
-static const testcase_delegate_file_t nfst_adjoint_2d_10_20_20 = {setup_file,destroy_file,ABSPATH("data/nfst_adjoint_2d_10_20_20.txt")};
-static const testcase_delegate_file_t nfst_adjoint_2d_10_20_50 = {setup_file,destroy_file,ABSPATH("data/nfst_adjoint_2d_10_20_50.txt")};
-static const testcase_delegate_file_t nfst_adjoint_2d_20_10_20 = {setup_file,destroy_file,ABSPATH("data/nfst_adjoint_2d_20_10_20.txt")};
-static const testcase_delegate_file_t nfst_adjoint_2d_20_10_50 = {setup_file,destroy_file,ABSPATH("data/nfst_adjoint_2d_20_10_50.txt")};
-static const testcase_delegate_file_t nfst_adjoint_2d_20_20_20 = {setup_file,destroy_file,ABSPATH("data/nfst_adjoint_2d_20_20_20.txt")};
-static const testcase_delegate_file_t nfst_adjoint_2d_20_20_50 = {setup_file,destroy_file,ABSPATH("data/nfst_adjoint_2d_20_20_50.txt")};
+static const testcase_delegate_file_t nfst_adjoint_2d_10_10_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_adjoint_2d_10_10_20.txt")};
+static const testcase_delegate_file_t nfst_adjoint_2d_10_10_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_adjoint_2d_10_10_50.txt")};
+static const testcase_delegate_file_t nfst_adjoint_2d_10_20_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_adjoint_2d_10_20_20.txt")};
+static const testcase_delegate_file_t nfst_adjoint_2d_10_20_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_adjoint_2d_10_20_50.txt")};
+static const testcase_delegate_file_t nfst_adjoint_2d_20_10_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_adjoint_2d_20_10_20.txt")};
+static const testcase_delegate_file_t nfst_adjoint_2d_20_10_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_adjoint_2d_20_10_50.txt")};
+static const testcase_delegate_file_t nfst_adjoint_2d_20_20_20 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_adjoint_2d_20_20_20.txt")};
+static const testcase_delegate_file_t nfst_adjoint_2d_20_20_50 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_adjoint_2d_20_20_50.txt")};
 
 static const testcase_delegate_file_t *testcases_adjoint_2d_file[] =
 {
@@ -1136,7 +1136,7 @@ static const init_delegate_t* initializers_3d[] =
 #endif
 };
 
-static const testcase_delegate_file_t nfst_3d_10_10_10_10 = {setup_file,destroy_file,ABSPATH("data/nfst_3d_10_10_10_10.txt")};
+static const testcase_delegate_file_t nfst_3d_10_10_10_10 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_3d_10_10_10_10.txt")};
 
 static const testcase_delegate_file_t *testcases_3d_file[] =
 {
@@ -1161,7 +1161,7 @@ void X(check_3d_fast_file)(void)
     testcases_3d_file, initializers_3d, &check_trafo, trafos_3d_fast_file);
 }
 
-static const testcase_delegate_file_t nfst_adjoint_3d_10_10_10_10 = {setup_file,destroy_file,ABSPATH("data/nfst_adjoint_3d_10_10_10_10.txt")};
+static const testcase_delegate_file_t nfst_adjoint_3d_10_10_10_10 = {setup_file,destroy_file,ABSPATH("data" SEP "nfst_adjoint_3d_10_10_10_10.txt")};
 
 static const testcase_delegate_file_t *testcases_adjoint_3d_file[] =
 {

--- a/tests/nfst.c
+++ b/tests/nfst.c
@@ -386,7 +386,7 @@ static void setup_file(const testcase_delegate_t *ego_, int *d, int **N, int *NN
   const testcase_delegate_file_t *ego = (const testcase_delegate_file_t*)ego_;
   int j;
   char filename[200];
-  char* c = rindex(ego->filename, SEP[0]);
+  char* c = strrchr(ego->filename, SEP[0]);
   FILE *file = fopen(ego->filename, "r");
 
   filename[0] = (char) 0;


### PR DESCRIPTION
- Replaced obsolete `rindex`, which did not work on windows, by `strrchr`
- Replaced `free` by `Y(free)` in tests/nfft.c nfct.c and nfst.c
- Use relative paths instead of absolute since the absolute path was wrong under windows