### PR TITLE
Support cross-compiling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -507,7 +507,7 @@ SLEEP;{
   FILE *f = fopen("ticks.tmp","w");
   fprintf(f,"%.1f\n",tps);
   fclose(f);}
-return 0;}],[read TICKS_PER_SECOND < ticks.tmp],[],[])
+return 0;}],[read TICKS_PER_SECOND < ticks.tmp],[],[TICKS_PER_SECOND=1])
     rm -f ticks.tmp
   if test "$TICKS_PER_SECOND" = "1"; then
     echo "***************************************************************"


### PR DESCRIPTION
This sets a default value to TICKS_PER_SECOND when cross-compiling
 and allows to configure and build nfft with mingw from Linux.