### PR TITLE
#50: define INT_MAX macro if not already defined

### DIFF
--- a/matlab/fastsum/fastsummex.c
+++ b/matlab/fastsum/fastsummex.c
@@ -36,6 +36,10 @@
 #define PLANS_MAX 100 /* maximum number of plans */
 #define CMD_LEN_MAX 40 /* maximum length of command argument */
 
+#ifndef INT_MAX
+  #define INT_MAX 2147483647 /* from limits.h */
+#endif
+
 /* global flags */
 #define FASTSUM_MEX_FIRST_CALL (1U << 0)
 unsigned short gflags = FASTSUM_MEX_FIRST_CALL;


### PR DESCRIPTION
Not the nicest way but should fix #50. Better suggestions are welcome.