### PR TITLE
use MinGW implementation of printf

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -374,6 +374,11 @@ fi
 # option to accept C99
 CFLAGS="$CFLAGS $ac_cv_prog_cc_c99"
 
+# use MinGW implementation of printf
+if test "x${host_os}" = "xmingw32" -o "x${host_os}" = "xmingw64"; then
+  CFLAGS="$CFLAGS -D__USE_MINGW_ANSI_STDIO=1"
+fi  
+
 CPPFLAGS="$CPPFLAGS $fftw3_CPPFLAGS"
 
 # add Matlab CFLAGS


### PR DESCRIPTION
`make check` crashes when compiled with long double precision in Windows. This is because MinGW by default uses the I/O libraries provided by Microsoft Visual C which [do not support extended precision](https://stackoverflow.com/a/14988103) (in Visual Studio `double = long double`). We fix this by using MinGW's own implementation of the I/O libraries that support extended precision [as recommended in the msys2 wiki](https://github.com/msys2/msys2/wiki/Porting#c-printf-format-specifier-issues).