### PR TITLE
Bugfix/60 latex for target dist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ addons:
     packages:
     - libfftw3-dev
     - libcunit1-dev
-    - doxygen
 env:
 - WINDOW=kaiserbessel PRECISION=
 - WINDOW=gaussian PRECISION=
@@ -27,7 +26,10 @@ matrix:
   include:
     - compiler: gcc
       env: WINDOW=kaiserbessel PRECISION= BUILD_OCTAVE=1
-      addons: { apt: { packages: ["libfftw3-dev", "libcunit1-dev", "doxygen", "liboctave-dev"] } }
+      addons: { apt: { packages: ["libfftw3-dev", "libcunit1-dev", "liboctave-dev"] } }
+    - compiler: clang
+      env: WINDOW=kaiserbessel PRECISION= BUILD_OCTAVE=1
+      addons: { apt: { packages: ["libfftw3-dev", "libcunit1-dev", "liboctave-dev"] } }
     - compiler: gcc
       env: WINDOW=kaiserbessel PRECISION= DIST=dist
       addons: { apt: { packages: ["libfftw3-dev", "libcunit1-dev", "doxygen", "doxygen-latex"] } }

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,32 +27,13 @@ matrix:
   include:
     - compiler: gcc
       env: WINDOW=kaiserbessel PRECISION= BUILD_OCTAVE=1
-      addons:
-        apt:
-          packages:
-          - libfftw3-dev
-          - libcunit1-dev
-          - doxygen
-	  - liboctave-dev
-  include:
+      addons: { apt: { packages: ["libfftw3-dev", "libcunit1-dev", "doxygen", "liboctave-dev"] } }
     - compiler: gcc
       env: WINDOW=kaiserbessel PRECISION= DIST=dist
-      addons:
-        apt:
-          packages:
-          - libfftw3-dev
-          - libcunit1-dev
-          - doxygen
-	  - doxygen-latex
+      addons: { apt: { packages: ["libfftw3-dev", "libcunit1-dev", "doxygen", "doxygen-latex"] } }
     - compiler: clang
       env: WINDOW=kaiserbessel PRECISION= DIST=dist
-      addons:
-        apt:
-          packages:
-          - libfftw3-dev
-          - libcunit1-dev
-          - doxygen
-	  - doxygen-latex
+      addons: { apt: { packages: ["libfftw3-dev", "libcunit1-dev", "doxygen", "doxygen-latex"] } }
 before_script:
   if [ "x$TRAVIS_TAG" != "x" ]; then
     NFFT_TRAVIS_TAG=$(sed -e 's/\([0-9]*\.[0-9]*\.[0-9]*\)\(.*\)/\1.\2/' <<< "$TRAVIS_TAG");

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,36 @@ env:
 - WINDOW=gaussian PRECISION=--enable-long-double
 - WINDOW=bspline PRECISION=--enable-long-double
 - WINDOW=sinc PRECISION=--enable-long-double
-- WINDOW=kaiserbessel PRECISION= DIST=dist
+matrix:
+  include:
+    - compiler: gcc
+      env: WINDOW=kaiserbessel PRECISION= BUILD_OCTAVE=1
+      addons:
+        apt:
+          packages:
+          - libfftw3-dev
+          - libcunit1-dev
+          - doxygen
+	  - liboctave-dev
+  include:
+    - compiler: gcc
+      env: WINDOW=kaiserbessel PRECISION= DIST=dist
+      addons:
+        apt:
+          packages:
+          - libfftw3-dev
+          - libcunit1-dev
+          - doxygen
+	  - doxygen-latex
+    - compiler: clang
+      env: WINDOW=kaiserbessel PRECISION= DIST=dist
+      addons:
+        apt:
+          packages:
+          - libfftw3-dev
+          - libcunit1-dev
+          - doxygen
+	  - doxygen-latex
 before_script:
   if [ "x$TRAVIS_TAG" != "x" ]; then
     NFFT_TRAVIS_TAG=$(sed -e 's/\([0-9]*\.[0-9]*\.[0-9]*\)\(.*\)/\1.\2/' <<< "$TRAVIS_TAG");
@@ -34,7 +63,9 @@ before_script:
     fi
   fi
 script: ./bootstrap.sh && ./configure --with-window=$WINDOW $PRECISION --enable-all
-  $(if test "$CC" = "clang"; then echo ""; else echo "--enable-openmp"; fi) && make
+  $(if test "$CC" = "clang"; then echo ""; else echo "--enable-openmp"; fi)
+  $(if test "$BUILD_OCTAVE" = "1"; then echo "--with-octave=/usr"; else echo ""; fi)
+  && make
   && make check && make $DIST
 after_failure: cat config.log
 notifications:

--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,7 @@
 
 m4_define([nfft_version_major], [3])
 m4_define([nfft_version_minor], [4])
-m4_define([nfft_version_patch], [0])
+m4_define([nfft_version_patch], [1])
 m4_define([nfft_version_type], [alpha])
 m4_append([NFFT_VERSION], m4_expand([nfft_version_major.nfft_version_minor.nfft_version_patch]))
 m4_append([NFFT_VERSION], m4_expand([nfft_version_type]))


### PR DESCRIPTION
fix for #60: create latex png images for dist using travis ci,
#52: compile mex interface with GNU Octave in travis ci

I suggest to create a release 3.4.1 with the fixed formulas in the doxygen HTML doc if the changes are approved.