### PR TITLE
Add NFSOFT Matlab class

### DIFF
--- a/matlab/nfsft/nfsft.m
+++ b/matlab/nfsft/nfsft.m
@@ -33,7 +33,7 @@ properties(SetAccess='private')
     nfsft_flags = 0;
     fpt_flags = 0;
     nfft_cutoff = 6;
-    nfft_flags = 4096;   % NFFT_OMP_BLOCKWISE_ADJOINT
+    nfft_flags = bitshift(1,12);   % NFFT_OMP_BLOCKWISE_ADJOINT
 end %properties
 
 properties(Hidden=true,SetAccess='private',GetAccess='private')

--- a/matlab/nfsoft/Makefile.am
+++ b/matlab/nfsoft/Makefile.am
@@ -19,7 +19,7 @@ endif
 
 dist_nfsoftmatlab_DATA = Contents.m \
 	nfsoft_adjoint.m nfsoft_get_num_threads.m nfsoft_f_hat_size.m nfsoft_finalize.m nfsoft_get_f_hat.m nfsoft_get_f.m nfsoft_init.m nfsoft_precompute.m nfsoft_set_f.m nfsoft_set_f_hat.m nfsoft_set_x.m nfsoft_trafo.m test_nfsoft.m \
-	NFSOFT_NORMALIZED.m NFSOFT_REPRESENT.m NFSOFT_USE_DPT.m NFSOFT_USE_NDFT.m simple_test.m
+	NFSOFT_NORMALIZED.m NFSOFT_REPRESENT.m NFSOFT_USE_DPT.m NFSOFT_USE_NDFT.m simple_test.m nfsoft.m
 
 # target all-am builds .libs/libnfsoft@matlab_mexext@
 nfsoftmex@matlab_mexext@: all-am 

--- a/matlab/nfsoft/nfsoft.m
+++ b/matlab/nfsoft/nfsoft.m
@@ -1,0 +1,203 @@
+% This class provides a Matlab interface to the NFSOFT module.
+%
+% Examples
+%   See Matlab scripts simple_test.m.
+classdef nfsoft < handle
+
+properties(Dependent=true)
+    x;     % nodes (real 3xM matrix)
+    fhat;  % Fourier coefficients (complex column vector of length M)
+    f;     % samples (complex column vector of length M)
+end %properties
+
+properties(SetAccess='private')
+    N=[];  % polynomial degree (bandwidth)
+    M=[];  % number of nodes
+    nfsoft_flags = 0;
+    nfft_flags = bitshift(1,12);   % NFFT_OMP_BLOCKWISE_ADJOINT
+    nfft_cutoff = 6;
+    fpt_kappa = 1000;
+    fftw_size;
+end %properties
+
+properties(Hidden=true,SetAccess='private',GetAccess='private')
+    plan=[];
+    x_is_set=false;             % flag if x is set
+    fhat_is_set=false;          % flag if fhat is set
+    f_is_set=false;             % flag if f is set
+    plan_is_set=false;          % flag if plan was created
+end %properties
+
+methods
+
+% Constructer and destructor %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+function h=nfsoft(N, M, nfsoft_flags, nfft_flags, nfft_cutoff, fpt_kappa, fftw_size)
+% Constructor
+%
+% plan = nfsoft(N, M)
+% plan = nfsoft(N, M, nfsoft_flags)
+% plan = nfsoft(N, M, nfsoft_flags, nfft_flags, nfft_cutoff, fpt_kappa, fftw_size)
+% 
+% INPUT
+% N ... polynomial degree (bandwidth)
+% M ... number of nodes
+% nfsoft_flags  ... can be NFSOFT_NORMALIZED, NFSOFT_REPRESENT,
+%   NFSOFT_USE_DPT, NFSOFT_USE_NDFT (default=0)
+% nfft_cutoff ... NFFT cutoff parameter (default 6)
+% fpt_kappa ... threshold (affects accuracy, 1000 is the default)
+% fftw_size ... oversampling (must be >= 2*N+2 and even, default 4*N+4)
+% (fftw_size is the size of the fftw transform,
+% higher oversampling means better accuracy but more time and memory required)
+%
+% OUTPUT
+%   h   object of class type nfsoft
+
+    h.N=N;
+    h.M=M;
+    
+    if (nargin<2)
+        error('Too few arguments')
+    end
+    if exist('nfsoft_flags','var')
+        h.nfsoft_flags=nfsoft_flags;
+    end
+    if exist('nfft_flags','var')
+        h.nfft_flags=nfft_flags;
+    end
+    if exist('nfft_cutoff','var')
+        h.nfft_cutoff=nfft_cutoff;
+    end
+    if exist('fpt_kappa','var')
+        h.fpt_kappa=fpt_kappa;
+    end
+    if exist('fftw_size','var')
+        h. fftw_size= fftw_size;
+    else
+        h. fftw_size=4*h.N+4;
+    end
+    
+    h.plan= nfsoftmex('init',h.N,h.M,h.nfsoft_flags,h.nfft_flags,h.nfft_cutoff,h.fpt_kappa,h.fftw_size);
+    h.plan_is_set=true;
+end %function
+
+function delete(h)
+% Destructor
+    if(h.plan_is_set)
+         nfsoftmex('finalize',h.plan);
+    end %if
+end %function
+
+% Set functions %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+function set.N(h,N)
+    if( ~isscalar(N) || (N<1) || round(N)~=N )
+        error('The degree N must be a positive integer.')
+    else
+        h.N=N;
+    end %if
+end %function
+
+function set.M(h,M)
+    if( ~isscalar(M) || (M<1) || round(M)~=M )
+        error('The number of points M must be a positive integer.')
+    else
+        h.M=M;
+    end %if
+end %function
+
+function set.x(h,x)
+    if( isempty(x) || ~isnumeric(x) || ~isreal(x) )
+        error('The sampling points x have to be real numbers.');
+    elseif( size(x,1) ~= 3 || size(x,2) ~= h.M )
+        error('The sampling points x must be a 3 x M matrix.');
+    elseif( min(x(:))<0 || (max(x(:))>2*pi) || (max(x(2,:))>pi) )
+        error('The sampling points x have to be Euler angles on SO(3)');
+    else
+        nfsoftmex('set_x',h.plan,x);
+        nfsoftmex('precompute',h.plan);
+        h.x_is_set=true;
+    end %if
+end %function
+
+function set.fhat(h,fhat)
+    nfsoftmex('set_f_hat', h.plan, fhat);
+    h.fhat_is_set=true;
+end %function
+
+function set.f(h,f)
+    if(isempty(f) || ~isnumeric(f) || ~isvector(f) || length(f)~=h.M)
+        error('The samples f have to be a vector of length M=%u',h.M);
+    else
+        nfsoftmex('set_f',h.plan,f(:));
+        h.f_is_set=true;
+    end %if
+end %function
+
+% Get functions %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+function x=get.x(h)
+    if(h.x_is_set)
+        x= nfsoftmex('get_x',h.plan);
+    else
+        x=[];
+    end %if
+end %function
+
+function fhat=get.fhat(h)
+    if(h.fhat_is_set)
+        fhat= nfsoftmex('get_f_hat',h.plan);
+    else
+        fhat=[];
+    end %if
+end %funcition
+
+function f=get.f(h)
+    if(h.f_is_set)
+        f= nfsoftmex('get_f',h.plan);
+    else
+        f=[];
+    end %if
+end %function
+
+% User methods %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+function nfsoft_trafo(h)
+% NFSOFT.
+%
+% nfsoft_trafo(h)
+%
+% INPUT
+%   h  object of class type nfsoft
+
+    if(~h.x_is_set)
+        error('Before doing a NFSOFT transform you have to set nodes x.');
+    elseif(~h.fhat_is_set)
+        error('Before doing a NFSOFT transform you have to set Fourier coefficients in fhat.');
+    else
+        nfsoftmex('trafo',h.plan);
+        h.f_is_set=true;
+    end %if
+end %function
+
+function nfsoft_adjoint(h)
+% Adjoint NFSOFT
+%
+% nfsoft_adjoint(h)
+%
+% INPUT
+%   h  object of class type nfsoft
+
+    if(~h.x_is_set)
+        error('Before doing an adjoint NFSOFT transform you have to set nodes x.');
+    elseif(~h.f_is_set)
+        error('Before doing an adjoint NFSOFT transform you have to set samples in f.');
+    else
+        nfsoftmex('adjoint',h.plan);
+        h.fhat_is_set=true;
+    end %if
+end %function
+
+end %methods
+
+end %classdef

--- a/matlab/nfsoft/nfsoft_init.m
+++ b/matlab/nfsoft/nfsoft_init.m
@@ -8,10 +8,10 @@
 % NFSOFT_USE_DPT, NFSOFT_USE_NDFT (default=0)
 
 function plan = nfsoft_init(N, M, ...
-    nfsoft_flags, nfft_flags, nfft_cutoff, fpt_kappa, nn_oversampled)
+    nfsoft_flags, nfft_flags, nfft_cutoff, fpt_kappa, fftw_size)
 narginchk(2,7);
 if(nargin<7)
-    nn_oversampled=8*N; % oversampling of NFFT
+    fftw_size=4*N+4; % oversampling of NFFT
 if(nargin<6)
     fpt_kappa=1000;
 if(nargin<5)
@@ -26,4 +26,4 @@ end
 end
 end
 plan = nfsoftmex('init',N,M,nfsoft_flags,nfft_flags,nfft_cutoff,...
-    fpt_kappa, nn_oversampled);
+    fpt_kappa, fftw_size);

--- a/matlab/nfsoft/simple_test.m
+++ b/matlab/nfsoft/simple_test.m
@@ -18,11 +18,9 @@ M = length(alpha);
 fh = rand(nfsoft_f_hat_size(N),1)./(1:nfsoft_f_hat_size(N)).';
 
 tic
-plan = nfsoft_init(N,M,NFSOFT_NORMALIZED);  % create NFSOFT plan
-nfsoft_set_x(plan,x);           % set nodes
-nfsoft_precompute(plan);        % node-dependent precomputation
-nfsoft_set_f_hat(plan,fh);      % set Fourier (Wigner) coefficients
+plan = nfsoft(N,M,NFSOFT_NORMALIZED);  % create NFSOFT plan
+plan.x = x;                     % set nodes
+plan.fhat = fh;                 % set Fourier (Wigner) coefficients
 nfsoft_trafo(plan);             % NFSOFT transform
-f = nfsoft_get_f(plan);         % get function values
-nfsoft_finalize(plan);
+f = plan.f;                     % get function values
 toc

--- a/matlab/nfsoft/test_nfsoft.m
+++ b/matlab/nfsoft/test_nfsoft.m
@@ -1,38 +1,37 @@
 %TEST_NFSOFT Example program: Advanced usage principles
 N = 32;     % bandwidth (polynomial degree)
 nfsoft_flags = NFSOFT_NORMALIZED; % L2-normalized Wigner functions (rotational harmonics)
-nfft_flags = 0;
+nfft_flags = bitshift(1,12);      % NFFT_OMP_BLOCKWISE_ADJOINT (default)
 nfft_cutoff = 6;
 fpt_kappa = 1000;   % threshold (affects accuracy, 1000 is the default)
 
-%% Gauss-Legendre quadrature nodes
+%% Gauss-Legendre quadrature nodes on SO(3)
 % These allow a rectonstruction with the adjoint transform.
 oldpath = addpath('../nfsft');
-[beta, wb] = lgwt(N+1,-1,1);
+[beta, w] = lgwt(N+1,-1,1);
 [alpha,beta,gamma]=meshgrid(0:2*N,beta,0:2*N);
 alpha=alpha(:)*2*pi/(2*N+1);
 beta =acos(beta(:));
 gamma=gamma(:)*2*pi/(2*N+1);
 x = [alpha';beta';gamma'];
-w = repmat(wb,(2*N+1)^2,1)/2/(2*N+1)^2 * 8*pi^2;
+w = repmat(w,(2*N+1)^2,1)/2/(2*N+1)^2 * 8*pi^2;
 M = length(alpha);	% number of points
 
 %% random Fourier (Wigner) coefficients
 fh = rand(nfsoft_f_hat_size(N),1)./(1:nfsoft_f_hat_size(N)).';
 
-% compare different oversamplings (must be >= 2*N+2 and even, default 8*N)
+% compare different oversamplings fftw_size (must be >= 2*N+2 and even, default 4*N+4)
 % (higher oversampling means better accuracy but more time and memory required)
-for N_oversampled = [8*N, 4*N]
-    fprintf('\nPerform NFSOFT with bandwidth N = %d and oversampling %d\n',N,N_oversampled)
+for fftw_size = [8*N, 4*N+4]
+    fprintf('\nPerform NFSOFT with bandwidth N = %d and oversampling %d\n',N,fftw_size)
 
     % create NFSOFT plan
     tic
-    plan = nfsoft_init(N,M,nfsoft_flags,nfft_flags,nfft_cutoff,fpt_kappa,N_oversampled);
-    nfsoft_set_x(plan,x);           % set nodes
-    nfsoft_precompute(plan);        % node-dependent precomputation
+    plan = nfsoft(N,M,nfsoft_flags,nfft_flags,nfft_cutoff,fpt_kappa,fftw_size);
+    plan.x = x;           % set nodes
     fprintf('Time of initialization: %g seconds\n', toc);
 
-    nfsoft_set_f_hat(plan,fh);      % set Fourier (Wigner) coefficients
+    plan.fhat = fh;      % set Fourier (Wigner) coefficients
 
     % NFSOFT transform
     tic
@@ -40,19 +39,15 @@ for N_oversampled = [8*N, 4*N]
     fprintf('Time of transform:      %g seconds\n', toc);
 
     % get function values
-    f = nfsoft_get_f(plan);
+    f = plan.f;
 
     % adjoint transform with quadrature
-    nfsoft_set_f(plan,f.*w)
+    plan.f = f.*w;
     tic
     nfsoft_adjoint(plan);
     fprintf('Time of adjoint:        %g seconds\n', toc);
-    fh2 = nfsoft_get_f_hat(plan);
 
-    % finalize plan
-    nfsoft_finalize(plan)
-
-    fprintf('Relative error of reconstructed coefficients: %g\n',norm(fh2-fh)/norm(fh));
+    fprintf('Relative error of reconstructed coefficients: %g\n',norm(plan.fhat-fh)/norm(fh));
 end
 
 path(oldpath);

--- a/support/nfsoft.dox
+++ b/support/nfsoft.dox
@@ -78,6 +78,19 @@
  * \author Antje Vollrath
  */
 
+/*! \fn void nfsoft_init_guru_advanced(nfsoft_plan *plan, int N, int M,unsigned int nfsoft_flags,unsigned int nfft_flags,int nfft_cutoff,int fpt_kappa, int fftw_size)
+ * Creates a  NFSOFT transform plan.
+ *
+ * \arg plan a pointer to a \ref nfsoft_plan structure
+ * \arg N the bandwidth \f$N \in \mathbb{N}_0\f$
+ * \arg M the number of nodes \f$M \in \mathbb{N}\f$
+ * \arg nfsoft_flags the NFSFT flags
+ * \arg nfft_flags the NFFT flags
+ * \arg fpt_kappa a parameter contolling the accuracy of the FPT
+ * \arg nfft_cutoff the NFFT cutoff parameter
+ * \arg fftw_size the size of the 3D FFTW transform inside the NFFT ( fftw_size \f$= (2N+2)\,\sigma\f$, where \f$\sigma\ge1\f$ is the oversampling factor) 
+ */
+
 /*! \fn void nfsoft_trafo(nfsoft_plan *plan_nfsoft)
  * Executes a NFSOFT, i.e. computes for \f$m = 0,\ldots,M-1\f$
  * \f[
@@ -315,7 +328,7 @@
 /*! \def NFSOFT_INDEX(m,n,l,B)
  * These macro expands to the index \f$i\f$
  * corresponding to the SO(3) Fourier coefficient
- * \f$f_hat^{mn}_l\f$ for \f$l=0,...,B\f$, \f$m,n =-l,...,l\f$ with
+ * \f$\hat f^{mn}_l\f$ for \f$l=0,...,B\f$, \f$m,n =-l,...,l\f$ with
  */
 
 /*! \def NFSOFT_F_HAT_SIZE(B)


### PR DESCRIPTION
This adds a Matlab handle class for the NFSOFT module just like for other modules.

This changeset also includes a small reduction of memory usage of the NFSOFT. Previously, the vectors `x` and `f` were stored twice and copied during the precomputation (for `x` this includes also a renormalization and reordering). Now, the user can set the pointers to the same value to store the vectors only once. This is automatically done in the MEX interface.