### PR TITLE
Remove unnecessary dependence on ncurses library

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -35,12 +35,12 @@ else
 endif
 
 checkall_SOURCES = check.c util.c util.h reflect.c reflect.h bspline.c bspline.h bessel.c bessel.h nfft.c nfft.h $(NFCT_SOURCES) $(NFST_SOURCES)
-checkall_LDADD = $(top_builddir)/libnfft3@PREC_SUFFIX@.la -lm -lcunit -lncurses
+checkall_LDADD = $(top_builddir)/libnfft3@PREC_SUFFIX@.la -lm -lcunit
 
 if HAVE_THREADS
 if HAVE_OPENMP
   checkall_threads_SOURCES = $(checkall_SOURCES)
-  checkall_threads_LDADD = $(top_builddir)/libnfft3@PREC_SUFFIX@_threads.la @fftw3_LDFLAGS@ @fftw3_threads_LIBS@ -lcunit -lncurses
+  checkall_threads_LDADD = $(top_builddir)/libnfft3@PREC_SUFFIX@_threads.la @fftw3_LDFLAGS@ @fftw3_threads_LIBS@ -lcunit
   checkall_threads_CFLAGS = $(OPENMP_CFLAGS)
 endif
 endif

--- a/windows-build-dll.sh
+++ b/windows-build-dll.sh
@@ -89,7 +89,7 @@ else
 fi
 
 # Install required packages
-pacman -S --needed autoconf perl libtool automake mingw-w64-$ARCHNAME-gcc make mingw-w64-$ARCHNAME-cunit mingw-w64-$ARCHNAME-ncurses tar zip unzip wget dos2unix rsync p7zip
+pacman -S --needed autoconf perl libtool automake mingw-w64-$ARCHNAME-gcc make mingw-w64-$ARCHNAME-cunit tar zip unzip wget dos2unix rsync p7zip
 
 #NFFTDIR=$(pwd)
 NFFTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"


### PR DESCRIPTION
The NFFT unit tests link to `-lncurses`, but it does not use any functions of this library.  Hence, we do not need to link the NFFT to the `ncurses` library.
In newer MSYS2 releases on Windows, the library `ncurses` is replaced by the similar `pdcurses`, which cases an error when compiling the NFFT unit tests in this situation.