### PR TITLE
No HTML timestamp in docs

### DIFF
--- a/doxygen/doxygen.Doxyfile.in
+++ b/doxygen/doxygen.Doxyfile.in
@@ -1139,7 +1139,7 @@ HTML_COLORSTYLE_GAMMA  = 80
 # The default value is: YES.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_TIMESTAMP         = YES
+HTML_TIMESTAMP         = NO
 
 # If the HTML_DYNAMIC_SECTIONS tag is set to YES then the generated HTML
 # documentation will contain sections that can be hidden and shown after the


### PR DESCRIPTION
Use of HTML timestamps in the documentation hurts packaging reproducibility testing in downstream Linux distributions such as Debian.

Please consider accepting this patch to remove them from the generated pages unless there is a good reason for it.

Cheers.