### PR TITLE
Improve efficiency of NFFT direct transformation in one dimension.

### DIFF
--- a/kernel/nfft/nfft.c
+++ b/kernel/nfft/nfft.c
@@ -146,8 +146,6 @@ void X(trafo_direct)(const X(plan) *ths)
 {
   C *f_hat = (C*)ths->f_hat, *f = (C*)ths->f;
 
-  memset(f, 0, (size_t)(ths->M_total) * sizeof(C));
-
   if (ths->d == 1)
   {
     /* specialize for univariate case, rationale: faster */
@@ -157,16 +155,22 @@ void X(trafo_direct)(const X(plan) *ths)
 #endif
     for (j = 0; j < ths->M_total; j++)
     {
+      C v = K(0.0);
       INT k_L;
       for (k_L = 0; k_L < ths->N_total; k_L++)
       {
         R omega = K2PI * ((R)(k_L - ths->N_total/2)) * ths->x[j];
-        f[j] += f_hat[k_L] * BASE(-II * omega);
+        v += f_hat[k_L] * (COS(omega) - II * SIN(omega));
       }
+
+      f[j] = v;
     }
   }
   else
   {
+
+    memset(f, 0, (size_t)(ths->M_total) * sizeof(C));
+
     /* multivariate case */
     INT j;
 #ifdef _OPENMP

--- a/tests/nfft.c
+++ b/tests/nfft.c
@@ -783,13 +783,13 @@ static R compare_adjoint(check_delegate_t *ego, X(plan) *p, const int NN, const 
 static check_delegate_t check_trafo = {prepare_trafo, compare_trafo};
 static check_delegate_t check_adjoint = {prepare_adjoint, compare_adjoint};
 
-static trafo_delegate_t trafo_direct = {"trafo_direct", X(trafo_direct), 0, trafo_direct_cost, err_trafo_direct};
+static trafo_delegate_t trafo_direct = {"trafo_direct", (trafo_t)X(trafo_direct), 0, trafo_direct_cost, err_trafo_direct};
 static trafo_delegate_t trafo = {"trafo", X(trafo), X(check), 0, err_trafo};
 static trafo_delegate_t trafo_1d = {"trafo_1d", X(trafo_1d), X(check), 0, err_trafo};
 static trafo_delegate_t trafo_2d = {"trafo_2d", X(trafo_2d), X(check), 0, err_trafo};
 static trafo_delegate_t trafo_3d = {"trafo_3d", X(trafo_3d), X(check), 0, err_trafo};
 
-static trafo_delegate_t adjoint_direct = {"adjoint_direct", X(adjoint_direct), 0, trafo_direct_cost, err_trafo_direct};
+static trafo_delegate_t adjoint_direct = {"adjoint_direct", (trafo_t)X(adjoint_direct), 0, trafo_direct_cost, err_trafo_direct};
 static trafo_delegate_t adjoint = {"adjoint", X(adjoint), X(check), 0, err_trafo};
 static trafo_delegate_t adjoint_1d = {"adjoint_1d", X(adjoint_1d), X(check), 0, err_trafo};
 static trafo_delegate_t adjoint_2d = {"adjoint_2d", X(adjoint_2d), X(check), 0, err_trafo};


### PR DESCRIPTION
Small change to improve the efficiencvy of the direct NFFT trafo in one dimension:

- Instead of using `memset` to initialize the target vector with zeros, it's better to just write the final value to the target in the outer loop. Rationale: Using memset will need to access the entire target vector another time. This can be costly if the vector is large and does not fit inside the CPU cache.
- Instead of accessing the target location `f[j]` in the inner loop in each iteration, it may be better to accumulate the value in a local variable and write only the final value to `f[j]`. Rationale: May reduce potentially slow memory access to `f[j]`, but if `f[j]` is in the CPU cache and/or the compiler is smart, this may not make any difference.
- Instead of calling the complex expontential `cexp` to calculate e^{-i*omega}, use real-valued `sin` and `cos` functions. Rationale: `cexp` supports complex-valued arguments, but the actual argument is always purely imaginary.

It was difficult to test this one because there's not simple benchmark I could quickly run. Also, I tested this on arm64/v8 and `cycle.h` currently doesn't work for me. So I had to set up a scratch file to run a quick check which is not part of this PR. On my platform, the number of cycles for the direct transform drops to 60-80% compared to before.

Would be good if someone could test this separately and on a different architecture (e.g. amd64) as well.