### PR TITLE
Add CodSpeed benchmarks.

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,0 +1,49 @@
+name: CodSpeed Benchmarks
+
+on:
+  pull_request:
+    branches: [ develop, master ]
+  workflow_dispatch:
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install build dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential cmake git libfftw3-dev libcunit1-dev
+
+    - name: Checkout CodSpeed integration library
+      uses: actions/checkout@v4
+      with:
+        repository: CodSpeedHQ/codspeed-cpp
+        path: codspeed-cpp
+        submodules: recursive
+
+    - name: Configure CMake for CodSpeed integration library
+      run: |
+        cd codspeed-cpp/google_benchmark
+        cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON -DCODSPEED_MODE=instrumentation -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_EXTENSIONS=OFF.
+
+    - name: Build CodSpeed integration library
+      run: |
+        cd codspeed-cpp/google_benchmark
+        cmake --build . -v
+
+    - name: Bootstrap NFFT project
+      run: ./bootstrap.sh
+
+    - name: Configure NFFT project
+      run: ./configure -enable-benchmarks --with-codspeed=$(pwd)/codspeed-cpp
+    
+    - name: Build NFFT project
+      run: make
+
+    - name: Run NFFT benchmarks
+      uses: CodSpeedHQ/action@v3
+      with:
+        run: benchmarks/bench_nfft_direct

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ config/*
 include/config.h.in
 include/config.h.in~
 configure
+configure~
 **/.deps/*
 Makefile
 applications/fastgauss/fastgauss.c
@@ -140,6 +141,7 @@ examples/nsfft/nsfft_test
 examples/nsfft/simple_test
 examples/solver/glacier
 examples/solver/simple_test
+benchmarks/bench_nfft_direct
 doc/html
 doc/latex
 doc/doxygen_sqlite3.db

--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,7 @@ libtool: $(LIBTOOL_DEPS)
 	$(SHELL) ./config.status --recheck
 
 # Subdirectories
-DIST_SUBDIRS=include kernel . tests examples applications matlab julia support doxygen
+DIST_SUBDIRS=include kernel . tests examples applications matlab julia support doxygen benchmarks
 
 if HAVE_EXAMPLES
   EXAMPLE_DIRS=examples
@@ -34,13 +34,19 @@ else
   LIBNFFT3_JULIA_LA=
 endif
 
+if HAVE_BENCHMARKS
+  BENCHMARK_DIRS=benchmarks
+else
+  BENCHMARK_DIRS=
+endif
+
 if HAVE_THREADS
   LIBNFFT3_THREADS_LA = libnfft3@PREC_SUFFIX@_threads.la
 else
   LIBNFFT3_THREADS_LA =
 endif
 
-SUBDIRS= include kernel . tests $(EXAMPLE_DIRS) $(APPLICATION_DIRS) $(MATLAB_DIRS) $(JULIA_DIRS)
+SUBDIRS= include kernel . tests $(EXAMPLE_DIRS) $(APPLICATION_DIRS) $(MATLAB_DIRS) $(JULIA_DIRS) $(BENCHMARK_DIRS)
 
 lib_LTLIBRARIES = libnfft3@PREC_SUFFIX@.la $(LIBNFFT3_THREADS_LA)
 noinst_LTLIBRARIES = $(LIBNFFT3_MATLAB_LA) $(LIBNFFT3_JULIA_LA)

--- a/README.md
+++ b/README.md
@@ -84,6 +84,18 @@ Optionally, install NFFT on your system.
 make install
 ```
 
+CodSpeed benchmarks
+-------------------
+Optionally, NFFT can build benchmark programs using the [CodSpeed](https://codspeed.io) C++ integration library.
+[CodSpeed](https://codspeed.io) is a continuous benchmarking service that can help with tracking performance 
+regressions and improvements.
+
+While these benchmarks can run locally, they are actually only intended to run in CI. They also require a build of the CodSpeed integration library from [source](https://github.com/CodSpeedHQ/codspeed-cpp).
+
+To enable building the benchmarks with the CodSpeed integration library, run `./configure --enable-benchmarks --with-codspeed=<path to codspeed-cpp source directory>`.
+
+After the build, the benchmrks can be found in the `benchmarks` directory.
+
 Citing
 ------
 The current general paper, the one that we recommend if you wish to cite NFFT, is *Keiner, J., Kunis, S., and Potts, D.
@@ -156,6 +168,7 @@ File/Folder        | Purpose
 aclocal.m4		   | Macros for configure script
 applications (dir) | Application programs (see 4) above)
 AUTHORS			   | Information about the authors of NFFT
+benchmarks (dir)   | Benchmark programs
 bootstrap.sh       | Bootstrap shell script that call Autoconf and friends
 ChangeLog          | A short version history
 config (dir)       | Used by configure script

--- a/benchmarks/Makefile.am
+++ b/benchmarks/Makefile.am
@@ -1,0 +1,15 @@
+AM_CPPFLAGS = -I$(top_srcdir)/include @nfft_benchmarks_CPPFLAGS@ @CPPFLAGS@
+
+if HAVE_BENCHMARKS
+  NFFT_BENCHMARKS = bench_nfft_direct
+else
+  NFFT_BENCHMARKS =
+endif
+
+noinst_PROGRAMS = $(NFFT_BENCHMARKS)
+
+# NFFT direct benchmarks
+bench_nfft_direct_SOURCES = bench_nfft_direct.cpp
+bench_nfft_direct_CXXFLAGS = @nfft_benchmarks_CXXFLAGS@ @CXXFLAGS@
+bench_nfft_direct_LDFLAGS = @nfft_benchmarks_LDFLAGS@ @fftw3_LDFLAGS@ @LDFLAGS@
+bench_nfft_direct_LDADD = @nfft_benchmarks_LIBS@ $(top_builddir)/libnfft3@PREC_SUFFIX@.la @fftw3_LIBS@ @LIBS@

--- a/benchmarks/bench_nfft_direct.cpp
+++ b/benchmarks/bench_nfft_direct.cpp
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2025 Jens Keiner, Stefan Kunis, Daniel Potts
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+#include <benchmark/benchmark.h>
+#include "config.h"
+
+#include <complex.h>
+#include <stdlib.h>
+#include <time.h>
+
+#include "nfft3.h"
+#include "infft.h"
+
+// Helper function to initialize random data
+static void init_random_data(nfft_plan* plan) {
+    NFFT(vrand_shifted_unit_double)(plan->x, plan->d * plan->M_total);
+    NFFT(vrand_unit_complex)(plan->f_hat, plan->N_total);
+    NFFT(vrand_unit_complex)(plan->f, plan->M_total);
+}
+
+// Benchmark for NFFT direct transform (trafo_direct)
+static void BM_NFFT_TrafoDirect(benchmark::State& state) {
+    int N = state.range(0);
+    int M = state.range(1);
+    
+    nfft_plan plan;
+    nfft_init_1d(&plan, N, M);
+    init_random_data(&plan);
+    
+    for (auto _ : state) {
+        nfft_trafo_direct(&plan);
+    }
+    
+    nfft_finalize(&plan);
+    state.SetComplexityN(N * M);
+}
+
+// Benchmark for NFFT adjoint direct transform (adjoint_direct)
+static void BM_NFFT_AdjointDirect(benchmark::State& state) {
+    int N = state.range(0);
+    int M = state.range(1);
+    
+    nfft_plan plan;
+    nfft_init_1d(&plan, N, M);
+    init_random_data(&plan);
+    
+    for (auto _ : state) {
+        nfft_adjoint_direct(&plan);
+    }
+    
+    nfft_finalize(&plan);
+    state.SetComplexityN(N * M);
+}
+
+// Benchmark for 2D NFFT direct transform
+static void BM_NFFT_2D_TrafoDirect(benchmark::State& state) {
+    int N1 = state.range(0);
+    int N2 = state.range(1);
+    int M = state.range(2);
+    
+    nfft_plan plan;
+    nfft_init_2d(&plan, N1, N2, M);
+    init_random_data(&plan);
+    
+    for (auto _ : state) {
+        nfft_trafo_direct(&plan);
+    }
+    
+    nfft_finalize(&plan);
+    state.SetComplexityN(N1 * N2 * M);
+}
+
+// Benchmark for 2D NFFT adjoint direct transform
+static void BM_NFFT_2D_AdjointDirect(benchmark::State& state) {
+    int N1 = state.range(0);
+    int N2 = state.range(1);
+    int M = state.range(2);
+    
+    nfft_plan plan;
+    nfft_init_2d(&plan, N1, N2, M);
+    init_random_data(&plan);
+    
+    for (auto _ : state) {
+        nfft_adjoint_direct(&plan);
+    }
+    
+    nfft_finalize(&plan);
+    state.SetComplexityN(N1 * N2 * M);
+}
+
+// Benchmark for 3D NFFT direct transform
+static void BM_NFFT_3D_TrafoDirect(benchmark::State& state) {
+    int N1 = state.range(0);
+    int N2 = state.range(1);
+    int N3 = state.range(2);
+    int M = state.range(3);
+    
+    nfft_plan plan;
+    nfft_init_3d(&plan, N1, N2, N3, M);
+    init_random_data(&plan);
+    
+    for (auto _ : state) {
+        nfft_trafo_direct(&plan);
+    }
+    
+    nfft_finalize(&plan);
+    state.SetComplexityN(N1 * N2 * N3 * M);
+}
+
+// Benchmark for 3D NFFT adjoint direct transform
+static void BM_NFFT_3D_AdjointDirect(benchmark::State& state) {
+    int N1 = state.range(0);
+    int N2 = state.range(1);
+    int N3 = state.range(2);
+    int M = state.range(3);
+    
+    nfft_plan plan;
+    nfft_init_3d(&plan, N1, N2, N3, M);
+    init_random_data(&plan);
+    
+    for (auto _ : state) {
+        nfft_adjoint_direct(&plan);
+    }
+    
+    nfft_finalize(&plan);
+    state.SetComplexityN(N1 * N2 * N3 * M);
+}
+
+// Register benchmarks for direct transforms
+BENCHMARK(BM_NFFT_TrafoDirect)
+    ->Args({32, 100})
+    ->Args({64, 200})
+    ->Args({128, 400})
+    ->Args({256, 800})
+    ->Args({512, 1600})
+    ->Complexity();
+
+BENCHMARK(BM_NFFT_AdjointDirect)
+    ->Args({32, 100})
+    ->Args({64, 200})
+    ->Args({128, 400})
+    ->Args({256, 800})
+    ->Args({512, 1600})
+    ->Complexity();
+
+BENCHMARK(BM_NFFT_2D_TrafoDirect)
+    ->Args({16, 16, 500})
+    ->Args({32, 32, 1000})
+    ->Args({64, 64, 2000})
+    ->Complexity();
+
+BENCHMARK(BM_NFFT_2D_AdjointDirect)
+    ->Args({16, 16, 500})
+    ->Args({32, 32, 1000})
+    ->Args({64, 64, 2000})
+    ->Complexity();
+
+BENCHMARK(BM_NFFT_3D_TrafoDirect)
+    ->Args({4, 4, 4, 250})
+    ->Args({8, 8, 8, 500})
+    ->Args({16, 16, 16, 1000})
+    ->Complexity();
+
+BENCHMARK(BM_NFFT_3D_AdjointDirect)
+    ->Args({4, 4, 4, 250})
+    ->Args({8, 8, 8, 500})
+    ->Args({16, 16, 16, 1000})
+    ->Complexity();
+
+// Main function.
+BENCHMARK_MAIN();

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 #
 # Copyright (c) 2003, 2006 Matteo Frigo
 # Copyright (c) 2003, 2006 Massachusetts Institute of Technology
@@ -26,13 +26,20 @@
 # M. Frigo and S. G. Johnson
 ################################################################################
 
-# alias to allow for systems having glibtoolize
-alias libtoolize=$(type -p glibtoolize libtoolize | head -1)
+# detect libtoolize command (glibtoolize on some systems)
+if command -v glibtoolize >/dev/null 2>&1; then
+    LIBTOOLIZE_CMD="glibtoolize"
+elif command -v libtoolize >/dev/null 2>&1; then
+    LIBTOOLIZE_CMD="libtoolize"
+else
+    echo "Error: Neither glibtoolize nor libtoolize found. Please install libtool." >&2
+    exit 1
+fi
 
 touch ChangeLog
 
 rm -rf autom4te.cache
-libtoolize
+"$LIBTOOLIZE_CMD"
 autoreconf --verbose --install --force
 
 rm -f config.cache

--- a/configure.ac
+++ b/configure.ac
@@ -29,7 +29,7 @@ m4_append([NFFT_VERSION], m4_expand([nfft_version_type]))
 AC_INIT([NFFT],[NFFT_VERSION],[mail@nfft.org])
 
 # copyright notice
-AC_COPYRIGHT([2003, 2019, Jens Keiner, Stefan Kunis, Daniel Potts])
+AC_COPYRIGHT([2003, 2025, Jens Keiner, Stefan Kunis, Daniel Potts])
 
 AC_DEFINE_UNQUOTED([NFFT_VERSION_MAJOR], [nfft_version_major], [Major version number.])
 AC_DEFINE_UNQUOTED([NFFT_VERSION_MINOR], [nfft_version_minor], [Minor version number.])
@@ -267,8 +267,10 @@ if test "$ok" = "yes"; then
 fi
 AC_SUBST(matlab_exhaustive_unit_tests_flag)
 
+AC_ARG_ENABLE(benchmarks, [AS_HELP_STRING([--enable-benchmarks],[enable building benchmark programs])], enable_benchmarks=$enableval, enable_benchmarks=no)
+
 ################################################################################
-# compiler characteristis
+# C compiler characteristis
 ################################################################################
 
 # select programming language
@@ -294,6 +296,11 @@ AC_C_INLINE
 
 # reset CC variable (the C99 option is added back below)
 CC="$ac_save_CC"
+
+################################################################################
+# C++ compiler characteristis
+################################################################################
+AC_PROG_CXX
 
 ################################################################################
 # program checks
@@ -569,6 +576,33 @@ fi
 AX_CUNIT
 AM_CONDITIONAL(HAVE_CUNIT, test "x$ax_cv_cunit" = "xyes" )
 
+nfft_cv_benchmarks="no"
+nfft_benchmarks_CPPFLAGS=""
+nfft_benchmarks_CXXFLAGS=""
+nfft_benchmarks_LDFLAGS=""
+nfft_benchmarks_LIBS=""
+
+if test "x$enable_benchmarks" = "xyes"; then
+  NFFT_LIB_CODSPEED
+  if test "x$nfft_cv_codspeed" = "xno"; then
+    AC_MSG_ERROR([You have enabled the build of benchmark programs, but the CodSpeed C++ integration library was not found.])
+  else
+    nfft_cv_benchmarks="yes"
+    nfft_benchmarks_CPPFLAGS="$nfft_codspeed_CPPFLAGS"
+    nfft_benchmarks_CXXFLAGS="$nfft_codspeed_CXXFLAGS"
+    nfft_benchmarks_LDFLAGS="$nfft_codspeed_LDFLAGS"
+    nfft_benchmarks_LIBS="$nfft_codspeed_LIBS"
+  fi
+else
+  nfft_cv_benchmarks="no"
+fi
+
+AM_CONDITIONAL(HAVE_BENCHMARKS, test "x$nfft_cv_benchmarks" = "xyes" )
+AC_SUBST(nfft_benchmarks_CPPFLAGS)
+AC_SUBST(nfft_benchmarks_CXXFLAGS)
+AC_SUBST(nfft_benchmarks_LDFLAGS)
+AC_SUBST(nfft_benchmarks_LIBS)
+
 # The output files to be generated
 AC_CONFIG_FILES(Makefile \
                 nfft3.pc \
@@ -647,6 +681,7 @@ AC_CONFIG_FILES(Makefile \
 		julia/fastsum/Makefile \
 		julia/nfct/Makefile \
 		julia/nfst/Makefile \
+                benchmarks/Makefile \
                 doxygen/Makefile \
                 support/Makefile)
 # temproarily removed:

--- a/m4/ax_cxx_compile_stdcxx.m4
+++ b/m4/ax_cxx_compile_stdcxx.m4
@@ -1,0 +1,1070 @@
+# ===========================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_cxx_compile_stdcxx.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CXX_COMPILE_STDCXX(VERSION, [ext|noext], [mandatory|optional])
+#
+# DESCRIPTION
+#
+#   Check for baseline language coverage in the compiler for the specified
+#   version of the C++ standard.  If necessary, add switches to CXX and
+#   CXXCPP to enable support.  VERSION may be '11', '14', '17', '20', or
+#   '23' for the respective C++ standard version.
+#
+#   The second argument, if specified, indicates whether you insist on an
+#   extended mode (e.g. -std=gnu++11) or a strict conformance mode (e.g.
+#   -std=c++11).  If neither is specified, you get whatever works, with
+#   preference for no added switch, and then for an extended mode.
+#
+#   The third argument, if specified 'mandatory' or if left unspecified,
+#   indicates that baseline support for the specified C++ standard is
+#   required and that the macro should error out if no mode with that
+#   support is found.  If specified 'optional', then configuration proceeds
+#   regardless, after defining HAVE_CXX${VERSION} if and only if a
+#   supporting mode is found.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Benjamin Kosnik <bkoz@redhat.com>
+#   Copyright (c) 2012 Zack Weinberg <zackw@panix.com>
+#   Copyright (c) 2013 Roy Stogner <roystgnr@ices.utexas.edu>
+#   Copyright (c) 2014, 2015 Google Inc.; contributed by Alexey Sokolov <sokolov@google.com>
+#   Copyright (c) 2015 Paul Norman <penorman@mac.com>
+#   Copyright (c) 2015 Moritz Klammler <moritz@klammler.eu>
+#   Copyright (c) 2016, 2018 Krzesimir Nowak <qdlacz@gmail.com>
+#   Copyright (c) 2019 Enji Cooper <yaneurabeya@gmail.com>
+#   Copyright (c) 2020 Jason Merrill <jason@redhat.com>
+#   Copyright (c) 2021, 2024 Jörn Heusipp <osmanx@problemloesungsmaschine.de>
+#   Copyright (c) 2015, 2022, 2023, 2024 Olly Betts
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 25
+
+dnl  This macro is based on the code from the AX_CXX_COMPILE_STDCXX_11 macro
+dnl  (serial version number 13).
+
+AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
+  m4_if([$1], [11], [ax_cxx_compile_alternatives="11 0x"],
+        [$1], [14], [ax_cxx_compile_alternatives="14 1y"],
+        [$1], [17], [ax_cxx_compile_alternatives="17 1z"],
+        [$1], [20], [ax_cxx_compile_alternatives="20"],
+        [$1], [23], [ax_cxx_compile_alternatives="23"],
+        [m4_fatal([invalid first argument `$1' to AX_CXX_COMPILE_STDCXX])])dnl
+  m4_if([$2], [], [],
+        [$2], [ext], [],
+        [$2], [noext], [],
+        [m4_fatal([invalid second argument `$2' to AX_CXX_COMPILE_STDCXX])])dnl
+  m4_if([$3], [], [ax_cxx_compile_cxx$1_required=true],
+        [$3], [mandatory], [ax_cxx_compile_cxx$1_required=true],
+        [$3], [optional], [ax_cxx_compile_cxx$1_required=false],
+        [m4_fatal([invalid third argument `$3' to AX_CXX_COMPILE_STDCXX])])
+  AC_LANG_PUSH([C++])dnl
+  ac_success=no
+
+  m4_if([$2], [], [dnl
+    AC_CACHE_CHECK(whether $CXX supports C++$1 features by default,
+		   ax_cv_cxx_compile_cxx$1,
+      [AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
+        [ax_cv_cxx_compile_cxx$1=yes],
+        [ax_cv_cxx_compile_cxx$1=no])])
+    if test x$ax_cv_cxx_compile_cxx$1 = xyes; then
+      ac_success=yes
+    fi])
+
+  m4_if([$2], [noext], [], [dnl
+  if test x$ac_success = xno; then
+    for alternative in ${ax_cxx_compile_alternatives}; do
+      switch="-std=gnu++${alternative}"
+      cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
+      AC_CACHE_CHECK(whether $CXX supports C++$1 features with $switch,
+                     $cachevar,
+        [ac_save_CXX="$CXX"
+         CXX="$CXX $switch"
+         AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
+          [eval $cachevar=yes],
+          [eval $cachevar=no])
+         CXX="$ac_save_CXX"])
+      if eval test x\$$cachevar = xyes; then
+        CXX="$CXX $switch"
+        if test -n "$CXXCPP" ; then
+          CXXCPP="$CXXCPP $switch"
+        fi
+        ac_success=yes
+        break
+      fi
+    done
+  fi])
+
+  m4_if([$2], [ext], [], [dnl
+  if test x$ac_success = xno; then
+    dnl HP's aCC needs +std=c++11 according to:
+    dnl http://h21007.www2.hp.com/portal/download/files/unprot/aCxx/PDF_Release_Notes/769149-001.pdf
+    dnl Cray's crayCC needs "-h std=c++11"
+    dnl MSVC needs -std:c++NN for C++17 and later (default is C++14)
+    for alternative in ${ax_cxx_compile_alternatives}; do
+      for switch in -std=c++${alternative} +std=c++${alternative} "-h std=c++${alternative}" MSVC; do
+        if test x"$switch" = xMSVC; then
+          dnl AS_TR_SH maps both `:` and `=` to `_` so -std:c++17 would collide
+          dnl with -std=c++17.  We suffix the cache variable name with _MSVC to
+          dnl avoid this.
+          switch=-std:c++${alternative}
+          cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_${switch}_MSVC])
+        else
+          cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
+        fi
+        AC_CACHE_CHECK(whether $CXX supports C++$1 features with $switch,
+                       $cachevar,
+          [ac_save_CXX="$CXX"
+           CXX="$CXX $switch"
+           AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
+            [eval $cachevar=yes],
+            [eval $cachevar=no])
+           CXX="$ac_save_CXX"])
+        if eval test x\$$cachevar = xyes; then
+          CXX="$CXX $switch"
+          if test -n "$CXXCPP" ; then
+            CXXCPP="$CXXCPP $switch"
+          fi
+          ac_success=yes
+          break
+        fi
+      done
+      if test x$ac_success = xyes; then
+        break
+      fi
+    done
+  fi])
+  AC_LANG_POP([C++])
+  if test x$ax_cxx_compile_cxx$1_required = xtrue; then
+    if test x$ac_success = xno; then
+      AC_MSG_ERROR([*** A compiler with support for C++$1 language features is required.])
+    fi
+  fi
+  if test x$ac_success = xno; then
+    HAVE_CXX$1=0
+    AC_MSG_NOTICE([No compiler with C++$1 support was found])
+  else
+    HAVE_CXX$1=1
+    AC_DEFINE(HAVE_CXX$1,1,
+              [define if the compiler supports basic C++$1 syntax])
+  fi
+  AC_SUBST(HAVE_CXX$1)
+])
+
+
+dnl  Test body for checking C++11 support
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_11],
+  [_AX_CXX_COMPILE_STDCXX_testbody_new_in_11]
+)
+
+dnl  Test body for checking C++14 support
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_14],
+  [_AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_14]
+)
+
+dnl  Test body for checking C++17 support
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_17],
+  [_AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_17]
+)
+
+dnl  Test body for checking C++20 support
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_20],
+  [_AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_17
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_20]
+)
+
+dnl  Test body for checking C++23 support
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_23],
+  [_AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_17
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_20
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_23]
+)
+
+
+dnl  Tests for new features in C++11
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_11], [[
+
+// If the compiler admits that it is not ready for C++11, why torture it?
+// Hopefully, this will speed up the test.
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+// MSVC always sets __cplusplus to 199711L in older versions; newer versions
+// only set it correctly if /Zc:__cplusplus is specified as well as a
+// /std:c++NN switch:
+//
+// https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/
+//
+// The value __cplusplus ought to have is available in _MSVC_LANG since
+// Visual Studio 2015 Update 3:
+//
+// https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros
+//
+// This was also the first MSVC version to support C++14 so we can't use the
+// value of either __cplusplus or _MSVC_LANG to quickly rule out MSVC having
+// C++11 or C++14 support, but we can check _MSVC_LANG for C++17 and later.
+#elif __cplusplus < 201103L && !defined _MSC_VER
+
+#error "This is not a C++11 compiler"
+
+#else
+
+namespace cxx11
+{
+
+  namespace test_static_assert
+  {
+
+    template <typename T>
+    struct check
+    {
+      static_assert(sizeof(int) <= sizeof(T), "not big enough");
+    };
+
+  }
+
+  namespace test_final_override
+  {
+
+    struct Base
+    {
+      virtual ~Base() {}
+      virtual void f() {}
+    };
+
+    struct Derived : public Base
+    {
+      virtual ~Derived() override {}
+      virtual void f() override {}
+    };
+
+  }
+
+  namespace test_double_right_angle_brackets
+  {
+
+    template < typename T >
+    struct check {};
+
+    typedef check<void> single_type;
+    typedef check<check<void>> double_type;
+    typedef check<check<check<void>>> triple_type;
+    typedef check<check<check<check<void>>>> quadruple_type;
+
+  }
+
+  namespace test_decltype
+  {
+
+    int
+    f()
+    {
+      int a = 1;
+      decltype(a) b = 2;
+      return a + b;
+    }
+
+  }
+
+  namespace test_type_deduction
+  {
+
+    template < typename T1, typename T2 >
+    struct is_same
+    {
+      static const bool value = false;
+    };
+
+    template < typename T >
+    struct is_same<T, T>
+    {
+      static const bool value = true;
+    };
+
+    template < typename T1, typename T2 >
+    auto
+    add(T1 a1, T2 a2) -> decltype(a1 + a2)
+    {
+      return a1 + a2;
+    }
+
+    int
+    test(const int c, volatile int v)
+    {
+      static_assert(is_same<int, decltype(0)>::value == true, "");
+      static_assert(is_same<int, decltype(c)>::value == false, "");
+      static_assert(is_same<int, decltype(v)>::value == false, "");
+      auto ac = c;
+      auto av = v;
+      auto sumi = ac + av + 'x';
+      auto sumf = ac + av + 1.0;
+      static_assert(is_same<int, decltype(ac)>::value == true, "");
+      static_assert(is_same<int, decltype(av)>::value == true, "");
+      static_assert(is_same<int, decltype(sumi)>::value == true, "");
+      static_assert(is_same<int, decltype(sumf)>::value == false, "");
+      static_assert(is_same<int, decltype(add(c, v))>::value == true, "");
+      return (sumf > 0.0) ? sumi : add(c, v);
+    }
+
+  }
+
+  namespace test_noexcept
+  {
+
+    int f() { return 0; }
+    int g() noexcept { return 0; }
+
+    static_assert(noexcept(f()) == false, "");
+    static_assert(noexcept(g()) == true, "");
+
+  }
+
+  namespace test_constexpr
+  {
+
+    template < typename CharT >
+    unsigned long constexpr
+    strlen_c_r(const CharT *const s, const unsigned long acc) noexcept
+    {
+      return *s ? strlen_c_r(s + 1, acc + 1) : acc;
+    }
+
+    template < typename CharT >
+    unsigned long constexpr
+    strlen_c(const CharT *const s) noexcept
+    {
+      return strlen_c_r(s, 0UL);
+    }
+
+    static_assert(strlen_c("") == 0UL, "");
+    static_assert(strlen_c("1") == 1UL, "");
+    static_assert(strlen_c("example") == 7UL, "");
+    static_assert(strlen_c("another\0example") == 7UL, "");
+
+  }
+
+  namespace test_rvalue_references
+  {
+
+    template < int N >
+    struct answer
+    {
+      static constexpr int value = N;
+    };
+
+    answer<1> f(int&)       { return answer<1>(); }
+    answer<2> f(const int&) { return answer<2>(); }
+    answer<3> f(int&&)      { return answer<3>(); }
+
+    void
+    test()
+    {
+      int i = 0;
+      const int c = 0;
+      static_assert(decltype(f(i))::value == 1, "");
+      static_assert(decltype(f(c))::value == 2, "");
+      static_assert(decltype(f(0))::value == 3, "");
+    }
+
+  }
+
+  namespace test_uniform_initialization
+  {
+
+    struct test
+    {
+      static const int zero {};
+      static const int one {1};
+    };
+
+    static_assert(test::zero == 0, "");
+    static_assert(test::one == 1, "");
+
+  }
+
+  namespace test_lambdas
+  {
+
+    void
+    test1()
+    {
+      auto lambda1 = [](){};
+      auto lambda2 = lambda1;
+      lambda1();
+      lambda2();
+    }
+
+    int
+    test2()
+    {
+      auto a = [](int i, int j){ return i + j; }(1, 2);
+      auto b = []() -> int { return '0'; }();
+      auto c = [=](){ return a + b; }();
+      auto d = [&](){ return c; }();
+      auto e = [a, &b](int x) mutable {
+        const auto identity = [](int y){ return y; };
+        for (auto i = 0; i < a; ++i)
+          a += b--;
+        return x + identity(a + b);
+      }(0);
+      return a + b + c + d + e;
+    }
+
+    int
+    test3()
+    {
+      const auto nullary = [](){ return 0; };
+      const auto unary = [](int x){ return x; };
+      using nullary_t = decltype(nullary);
+      using unary_t = decltype(unary);
+      const auto higher1st = [](nullary_t f){ return f(); };
+      const auto higher2nd = [unary](nullary_t f1){
+        return [unary, f1](unary_t f2){ return f2(unary(f1())); };
+      };
+      return higher1st(nullary) + higher2nd(nullary)(unary);
+    }
+
+  }
+
+  namespace test_variadic_templates
+  {
+
+    template <int...>
+    struct sum;
+
+    template <int N0, int... N1toN>
+    struct sum<N0, N1toN...>
+    {
+      static constexpr auto value = N0 + sum<N1toN...>::value;
+    };
+
+    template <>
+    struct sum<>
+    {
+      static constexpr auto value = 0;
+    };
+
+    static_assert(sum<>::value == 0, "");
+    static_assert(sum<1>::value == 1, "");
+    static_assert(sum<23>::value == 23, "");
+    static_assert(sum<1, 2>::value == 3, "");
+    static_assert(sum<5, 5, 11>::value == 21, "");
+    static_assert(sum<2, 3, 5, 7, 11, 13>::value == 41, "");
+
+  }
+
+  // http://stackoverflow.com/questions/13728184/template-aliases-and-sfinae
+  // Clang 3.1 fails with headers of libstd++ 4.8.3 when using std::function
+  // because of this.
+  namespace test_template_alias_sfinae
+  {
+
+    struct foo {};
+
+    template<typename T>
+    using member = typename T::member_type;
+
+    template<typename T>
+    void func(...) {}
+
+    template<typename T>
+    void func(member<T>*) {}
+
+    void test();
+
+    void test() { func<foo>(0); }
+
+  }
+
+}  // namespace cxx11
+
+#endif  // __cplusplus >= 201103L
+
+]])
+
+
+dnl  Tests for new features in C++14
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_14], [[
+
+// If the compiler admits that it is not ready for C++14, why torture it?
+// Hopefully, this will speed up the test.
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+#elif __cplusplus < 201402L && !defined _MSC_VER
+
+#error "This is not a C++14 compiler"
+
+#else
+
+namespace cxx14
+{
+
+  namespace test_polymorphic_lambdas
+  {
+
+    int
+    test()
+    {
+      const auto lambda = [](auto&&... args){
+        const auto istiny = [](auto x){
+          return (sizeof(x) == 1UL) ? 1 : 0;
+        };
+        const int aretiny[] = { istiny(args)... };
+        return aretiny[0];
+      };
+      return lambda(1, 1L, 1.0f, '1');
+    }
+
+  }
+
+  namespace test_binary_literals
+  {
+
+    constexpr auto ivii = 0b0000000000101010;
+    static_assert(ivii == 42, "wrong value");
+
+  }
+
+  namespace test_generalized_constexpr
+  {
+
+    template < typename CharT >
+    constexpr unsigned long
+    strlen_c(const CharT *const s) noexcept
+    {
+      auto length = 0UL;
+      for (auto p = s; *p; ++p)
+        ++length;
+      return length;
+    }
+
+    static_assert(strlen_c("") == 0UL, "");
+    static_assert(strlen_c("x") == 1UL, "");
+    static_assert(strlen_c("test") == 4UL, "");
+    static_assert(strlen_c("another\0test") == 7UL, "");
+
+  }
+
+  namespace test_lambda_init_capture
+  {
+
+    int
+    test()
+    {
+      auto x = 0;
+      const auto lambda1 = [a = x](int b){ return a + b; };
+      const auto lambda2 = [a = lambda1(x)](){ return a; };
+      return lambda2();
+    }
+
+  }
+
+  namespace test_digit_separators
+  {
+
+    constexpr auto ten_million = 100'000'000;
+    static_assert(ten_million == 100000000, "");
+
+  }
+
+  namespace test_return_type_deduction
+  {
+
+    auto f(int& x) { return x; }
+    decltype(auto) g(int& x) { return x; }
+
+    template < typename T1, typename T2 >
+    struct is_same
+    {
+      static constexpr auto value = false;
+    };
+
+    template < typename T >
+    struct is_same<T, T>
+    {
+      static constexpr auto value = true;
+    };
+
+    int
+    test()
+    {
+      auto x = 0;
+      static_assert(is_same<int, decltype(f(x))>::value, "");
+      static_assert(is_same<int&, decltype(g(x))>::value, "");
+      return x;
+    }
+
+  }
+
+}  // namespace cxx14
+
+#endif  // __cplusplus >= 201402L
+
+]])
+
+
+dnl  Tests for new features in C++17
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_17], [[
+
+// If the compiler admits that it is not ready for C++17, why torture it?
+// Hopefully, this will speed up the test.
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+#elif (defined _MSVC_LANG ? _MSVC_LANG : __cplusplus) < 201703L
+
+#error "This is not a C++17 compiler"
+
+#else
+
+#include <initializer_list>
+#include <utility>
+#include <type_traits>
+
+namespace cxx17
+{
+
+  namespace test_constexpr_lambdas
+  {
+
+    constexpr int foo = [](){return 42;}();
+
+  }
+
+  namespace test::nested_namespace::definitions
+  {
+
+  }
+
+  namespace test_fold_expression
+  {
+
+    template<typename... Args>
+    int multiply(Args... args)
+    {
+      return (args * ... * 1);
+    }
+
+    template<typename... Args>
+    bool all(Args... args)
+    {
+      return (args && ...);
+    }
+
+  }
+
+  namespace test_extended_static_assert
+  {
+
+    static_assert (true);
+
+  }
+
+  namespace test_auto_brace_init_list
+  {
+
+    auto foo = {5};
+    auto bar {5};
+
+    static_assert(std::is_same<std::initializer_list<int>, decltype(foo)>::value);
+    static_assert(std::is_same<int, decltype(bar)>::value);
+  }
+
+  namespace test_typename_in_template_template_parameter
+  {
+
+    template<template<typename> typename X> struct D;
+
+  }
+
+  namespace test_fallthrough_nodiscard_maybe_unused_attributes
+  {
+
+    int f1()
+    {
+      return 42;
+    }
+
+    [[nodiscard]] int f2()
+    {
+      [[maybe_unused]] auto unused = f1();
+
+      switch (f1())
+      {
+      case 17:
+        f1();
+        [[fallthrough]];
+      case 42:
+        f1();
+      }
+      return f1();
+    }
+
+  }
+
+  namespace test_extended_aggregate_initialization
+  {
+
+    struct base1
+    {
+      int b1, b2 = 42;
+    };
+
+    struct base2
+    {
+      base2() {
+        b3 = 42;
+      }
+      int b3;
+    };
+
+    struct derived : base1, base2
+    {
+        int d;
+    };
+
+    derived d1 {{1, 2}, {}, 4};  // full initialization
+    derived d2 {{}, {}, 4};      // value-initialized bases
+
+  }
+
+  namespace test_general_range_based_for_loop
+  {
+
+    struct iter
+    {
+      int i;
+
+      int& operator* ()
+      {
+        return i;
+      }
+
+      const int& operator* () const
+      {
+        return i;
+      }
+
+      iter& operator++()
+      {
+        ++i;
+        return *this;
+      }
+    };
+
+    struct sentinel
+    {
+      int i;
+    };
+
+    bool operator== (const iter& i, const sentinel& s)
+    {
+      return i.i == s.i;
+    }
+
+    bool operator!= (const iter& i, const sentinel& s)
+    {
+      return !(i == s);
+    }
+
+    struct range
+    {
+      iter begin() const
+      {
+        return {0};
+      }
+
+      sentinel end() const
+      {
+        return {5};
+      }
+    };
+
+    void f()
+    {
+      range r {};
+
+      for (auto i : r)
+      {
+        [[maybe_unused]] auto v = i;
+      }
+    }
+
+  }
+
+  namespace test_lambda_capture_asterisk_this_by_value
+  {
+
+    struct t
+    {
+      int i;
+      int foo()
+      {
+        return [*this]()
+        {
+          return i;
+        }();
+      }
+    };
+
+  }
+
+  namespace test_enum_class_construction
+  {
+
+    enum class byte : unsigned char
+    {};
+
+    byte foo {42};
+
+  }
+
+  namespace test_constexpr_if
+  {
+
+    template <bool cond>
+    int f ()
+    {
+      if constexpr(cond)
+      {
+        return 13;
+      }
+      else
+      {
+        return 42;
+      }
+    }
+
+  }
+
+  namespace test_selection_statement_with_initializer
+  {
+
+    int f()
+    {
+      return 13;
+    }
+
+    int f2()
+    {
+      if (auto i = f(); i > 0)
+      {
+        return 3;
+      }
+
+      switch (auto i = f(); i + 4)
+      {
+      case 17:
+        return 2;
+
+      default:
+        return 1;
+      }
+    }
+
+  }
+
+  namespace test_template_argument_deduction_for_class_templates
+  {
+
+    template <typename T1, typename T2>
+    struct pair
+    {
+      pair (T1 p1, T2 p2)
+        : m1 {p1},
+          m2 {p2}
+      {}
+
+      T1 m1;
+      T2 m2;
+    };
+
+    void f()
+    {
+      [[maybe_unused]] auto p = pair{13, 42u};
+    }
+
+  }
+
+  namespace test_non_type_auto_template_parameters
+  {
+
+    template <auto n>
+    struct B
+    {};
+
+    B<5> b1;
+    B<'a'> b2;
+
+  }
+
+  namespace test_structured_bindings
+  {
+
+    int arr[2] = { 1, 2 };
+    std::pair<int, int> pr = { 1, 2 };
+
+    auto f1() -> int(&)[2]
+    {
+      return arr;
+    }
+
+    auto f2() -> std::pair<int, int>&
+    {
+      return pr;
+    }
+
+    struct S
+    {
+      int x1 : 2;
+      volatile double y1;
+    };
+
+    S f3()
+    {
+      return {};
+    }
+
+    auto [ x1, y1 ] = f1();
+    auto& [ xr1, yr1 ] = f1();
+    auto [ x2, y2 ] = f2();
+    auto& [ xr2, yr2 ] = f2();
+    const auto [ x3, y3 ] = f3();
+
+  }
+
+  namespace test_exception_spec_type_system
+  {
+
+    struct Good {};
+    struct Bad {};
+
+    void g1() noexcept;
+    void g2();
+
+    template<typename T>
+    Bad
+    f(T*, T*);
+
+    template<typename T1, typename T2>
+    Good
+    f(T1*, T2*);
+
+    static_assert (std::is_same_v<Good, decltype(f(g1, g2))>);
+
+  }
+
+  namespace test_inline_variables
+  {
+
+    template<class T> void f(T)
+    {}
+
+    template<class T> inline T g(T)
+    {
+      return T{};
+    }
+
+    template<> inline void f<>(int)
+    {}
+
+    template<> int g<>(int)
+    {
+      return 5;
+    }
+
+  }
+
+}  // namespace cxx17
+
+#endif  // (defined _MSVC_LANG ? _MSVC_LANG : __cplusplus) < 201703L
+
+]])
+
+
+dnl  Tests for new features in C++20
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_20], [[
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+#elif (defined _MSVC_LANG ? _MSVC_LANG : __cplusplus) < 202002L
+
+#error "This is not a C++20 compiler"
+
+#else
+
+#include <version>
+
+namespace cxx20
+{
+
+// As C++20 supports feature test macros in the standard, there is no
+// immediate need to actually test for feature availability on the
+// Autoconf side.
+
+}  // namespace cxx20
+
+#endif  // (defined _MSVC_LANG ? _MSVC_LANG : __cplusplus) < 202002L
+
+]])
+
+
+dnl  Tests for new features in C++23
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_23], [[
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+#elif (defined _MSVC_LANG ? _MSVC_LANG : __cplusplus) < 202302L
+
+#error "This is not a C++23 compiler"
+
+#else
+
+#include <version>
+
+namespace cxx23
+{
+
+// As C++23 supports feature test macros in the standard, there is no
+// immediate need to actually test for feature availability on the
+// Autoconf side.
+
+}  // namespace cxx23
+
+#endif  // (defined _MSVC_LANG ? _MSVC_LANG : __cplusplus) < 202302L
+
+]])

--- a/m4/nfft_lib_codspeed.m4
+++ b/m4/nfft_lib_codspeed.m4
@@ -1,0 +1,133 @@
+# Copyright (c) 2025 Jens Keiner, Stefan Kunis, Daniel Potts
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 2 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# @synopsis NFFT_LIB_CODSPEED
+# @summary Check configure options and assign variables related to the CodSpeed integration library.
+# @category C++
+#
+# @version 2025-09-02
+# @license GPLWithACException
+# @author Jens Keiner <jens@nfft.org>
+#
+# If we find the CodSpeed integration library, set the shell variable `nfft_cv_codspeed' to `yes'
+# and also set `nfft_codspeed_CPPFLAGS`, `nfft_codspeed_CXXFLAGS`, `nfft_codspeed_LDFLAGS`, and `nfft_codspeed_LIBS`
+# to the respective flags nneded to compile and link with the library.
+# Otherwise, set `ax_have_codspeed' to `no'.
+
+AC_DEFUN([NFFT_CXX_COMPILE_STDCXX_17], [
+    AX_CXX_COMPILE_STDCXX([17], [noext], [mandatory])
+])
+
+AC_DEFUN([NFFT_LIB_CODSPEED],
+[
+  AC_LANG_PUSH([C++])
+
+  AC_REQUIRE([AC_PROG_CXX])
+  AC_REQUIRE([AX_CXX_COMPILE_STDCXX_17])
+
+  AC_ARG_WITH(codspeed, [AS_HELP_STRING([--with-codspeed=DIR],
+  [use CodSpeed C++ library project (https://github.com/CodSpeedHQ/codspeed-cpp) in DIR])], with_codspeed=$withval, with_codspeed="no")
+  
+  if test "x$with_codspeed" != "xno"; then
+    nfft_codspeed_CPPFLAGS="-I${with_codspeed}/google_benchmark/include -I${with_codspeed}/core/include -I${with_codspeed}/core/instrument-hooks/includes"
+    nfft_codspeed_LDFLAGS="-L${with_codspeed}/google_benchmark/src -L${with_codspeed}/google_benchmark/codspeed"
+  else
+    nfft_codspeed_CPPFLAGS=""
+    nfft_codspeed_LDFLAGS=""
+  fi
+
+  nfft_codspeed_CPPFLAGS="-DBENCHMARK_STATIC_DEFINE -DCODSPEED_ENABLED -DCODSPEED_INSTRUMENTATION $nfft_codspeed_CPPFLAGS"
+  nfft_codspeed_CXXFLAGS=""
+  nfft_codspeed_LDFLAGS="$nfft_codspeed_LDFLAGS"
+  nfft_codspeed_LIBS="-lbenchmark -lcodspeed -linstrument_hooks"
+  
+  saved_CPPFLAGS="$CPPFLAGS"
+  saved_CXXFLAGS="$CXXFLAGS"
+  saved_LDFLAGS="$LDFLAGS"
+  saved_LIBS="$LIBS"
+  
+  CPPFLAGS="$nfft_codspeed_CPPFLAGS $CPPFLAGS"
+  CXXFLAGS="$nfft_codspeed_CXXFLAGS $CXXFLAGS"
+  LDFLAGS="$nfft_codspeed_LDFLAGS $LDFLAGS"
+  LIBS="$nfft_codspeed_LIBS $LIBS"
+
+  AC_CHECK_HEADER([benchmark/benchmark.h], [nfft_codspeed_header=yes], [nfft_codspeed_header=no])
+
+  AC_MSG_CHECKING([whether CodSpeed C++ integration library test code compiles])
+  AC_COMPILE_IFELSE([
+    AC_LANG_SOURCE([[
+      #include <benchmark/benchmark.h>
+      #include <cstring>
+      
+      static void BM_StringCreation(benchmark::State& state) {
+        for (auto _ : state)
+          std::string empty_string;
+      }
+      BENCHMARK(BM_StringCreation);
+      
+      BENCHMARK_MAIN();
+    ]])
+  ], [
+    AC_MSG_RESULT([yes])
+    nfft_codspeed_compiles=yes
+  ], [
+    AC_MSG_RESULT([no])
+    nfft_codspeed_compiles=no
+  ])
+
+  AC_MSG_CHECKING([whether CodSpeed C++ integration library test code links])
+  AC_LINK_IFELSE([
+    AC_LANG_SOURCE([[
+      #include <benchmark/benchmark.h>
+      #include <cstring>
+      
+      static void BM_StringCreation(benchmark::State& state) {
+        for (auto _ : state)
+          std::string empty_string;
+      }
+      BENCHMARK(BM_StringCreation);
+      
+      BENCHMARK_MAIN();
+    ]])
+  ], [
+    AC_MSG_RESULT([yes])
+    nfft_codspeed_links=yes
+  ], [
+    AC_MSG_RESULT([no])
+    nfft_codspeed_links=no
+  ])
+
+  # Restore saved flags.
+  CPPFLAGS="$saved_CPPFLAGS"
+  CXXFLAGS="$saved_CXXFLAGS"
+  LDFLAGS="$saved_LDFLAGS"
+  LIBS="$saved_LIBS"
+
+  if test "x$nfft_codspeed_header" == "xyes" -a "x$nfft_codspeed_compiles" == "xyes" -a "x$nfft_codspeed_links" == "xyes"; then
+    nfft_cv_codspeed=yes
+  else
+    nfft_cv_codspeed=no
+    nfft_codspeed_CPPFLAGS=""
+    nfft_codspeed_CXXFLAGS=""
+    nfft_codspeed_LDFLAGS=""
+    nfft_codspeed_LIBS=""
+  fi
+
+  AC_MSG_CHECKING([for CodSpeed C++ integration library])
+  AC_MSG_RESULT([$nfft_cv_codspeed])
+
+  AC_LANG_POP([C++])
+])


### PR DESCRIPTION
This PR adds support for optionally building benchmark programs.

Benchmarks use a custom variant of the [Google Benchmark C++ Library](https://github.com/google/benchmark) that integrates with [CodSpeed](https://codspeed.io).

CodSpeed is a continuous benchmark platform that is free for open-source projects and allows for tracking the performance of benchmarks over time and across code changes. This can help uncover inadvertent performance regressions as well as help confirm potential efficiency improvements.

There's also a new GitHub workflow to automatically run benchmarks in CI.