### PR TITLE
Improve direct NDFT forward transform for d > 1.

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -3,6 +3,8 @@ name: CodSpeed Benchmarks
 on:
   pull_request:
     branches: [ develop, master ]
+  push:
+    branches: [ develop, master ]
   workflow_dispatch:
 
 jobs:

--- a/kernel/nfft/nfft.c
+++ b/kernel/nfft/nfft.c
@@ -189,7 +189,7 @@ void X(trafo_direct)(const X(plan) *ths)
 
       for (k_L = 0; k_L < ths->N_total; k_L++)
       {
-        v += f_hat[k_L] * BASE(-II * omega);
+        v += f_hat[k_L] * (COS(omega) - II * SIN(omega));
         {
           for (t = ths->d - 1; (t >= 1) && (k[t] == ths->N[t]/2 - 1); t--)
             k[t]-= ths->N[t]-1;

--- a/kernel/nfft/nfft.c
+++ b/kernel/nfft/nfft.c
@@ -168,9 +168,6 @@ void X(trafo_direct)(const X(plan) *ths)
   }
   else
   {
-
-    memset(f, 0, (size_t)(ths->M_total) * sizeof(C));
-
     /* multivariate case */
     INT j;
 #ifdef _OPENMP
@@ -178,6 +175,7 @@ void X(trafo_direct)(const X(plan) *ths)
 #endif
     for (j = 0; j < ths->M_total; j++)
     {
+      C v = K(0.0);
       R x[ths->d], omega, Omega[ths->d + 1];
       INT t, t2, k_L, k[ths->d];
       Omega[0] = K(0.0);
@@ -191,7 +189,7 @@ void X(trafo_direct)(const X(plan) *ths)
 
       for (k_L = 0; k_L < ths->N_total; k_L++)
       {
-        f[j] += f_hat[k_L] * BASE(-II * omega);
+        v += f_hat[k_L] * BASE(-II * omega);
         {
           for (t = ths->d - 1; (t >= 1) && (k[t] == ths->N[t]/2 - 1); t--)
             k[t]-= ths->N[t]-1;
@@ -204,6 +202,8 @@ void X(trafo_direct)(const X(plan) *ths)
           omega = Omega[ths->d];
         }
       }
+
+      f[j] = v;
     }
   }
 }


### PR DESCRIPTION
This PR improves the performance of the direct NDFT forward transform for d > 1 by
- removing the unnecessary call to `memset` to initialize the result array with zeros, and by
- replacing a call to `cexp` for purely imaginary arguments with two calls to real-valued `sin` and `cos` functions, respectively.

The gains are similar to those seen previously for the case d = 1. Interestingly, the major part of the improvements comes from replacing `cexp` with `sin` and `cos`.

Note that this PR also changes the trigger of the CodSpeed benchmarks workflow to run on pushes to `master` and `develop`. I had forgotten this previously, but these runs will provide the baseline to compare PR benchmark results to going forward.

For now, a comparison of benchmark results from this PR and `develop`can be found here: https://codspeed.io/NFFT/nfft/runs/compare/68b9fbca3d067d8ad7a7e160..68ba045dd98ef5b530b76720