### PR TITLE
Improve direct adjoint NDFT transform performance.

### DIFF
--- a/kernel/nfft/nfft.c
+++ b/kernel/nfft/nfft.c
@@ -226,7 +226,7 @@ void X(adjoint_direct)(const X(plan) *ths)
         for (j = 0; j < ths->M_total; j++)
         {
           R omega = K2PI * ((R)(k_L - (ths->N_total/2))) * ths->x[j];
-          f_hat[k_L] += f[j] * BASE(II * omega);
+          f_hat[k_L] += f[j] * (COS(omega) + II * SIN(omega));
         }
       }
 #else
@@ -237,7 +237,7 @@ void X(adjoint_direct)(const X(plan) *ths)
         for (k_L = 0; k_L < ths->N_total; k_L++)
         {
           R omega = K2PI * ((R)(k_L - ths->N_total / 2)) * ths->x[j];
-          f_hat[k_L] += f[j] * BASE(II * omega);
+          f_hat[k_L] += f[j] * (COS(omega) + II * SIN(omega));
         }
       }
 #endif
@@ -265,7 +265,7 @@ void X(adjoint_direct)(const X(plan) *ths)
         R omega = K(0.0);
         for (t = 0; t < ths->d; t++)
           omega += k[t] * K2PI * ths->x[j * ths->d + t];
-        f_hat[k_L] += f[j] * BASE(II * omega);
+        f_hat[k_L] += f[j] * (COS(omega) + II * SIN(omega));
       }
     }
 #else
@@ -283,7 +283,7 @@ void X(adjoint_direct)(const X(plan) *ths)
       omega = Omega[ths->d];
       for (k_L = 0; k_L < ths->N_total; k_L++)
       {
-        f_hat[k_L] += f[j] * BASE(II * omega);
+        f_hat[k_L] += f[j] * (COS(omega) + II * SIN(omega));
 
         for (t = ths->d-1; (t >= 1) && (k[t] == ths->N[t]/2-1); t--)
           k[t]-= ths->N[t]-1;


### PR DESCRIPTION
This PR applies optimizations to the direct adjoint NDFT transform implementation. Similar optimizations were added previously to the respective forward algorithm in #149 and #142.

Most of the speedup comes from replacing a call to the complex exponential `cexp` with calls to `sin` and `cos`. Calls to `cexp` are relatively expensive since the implementation must cover the case where not only the output, but also the input is complex with a non-zero real and imaginary part. However, our calls are always with a purely imaginary argument, so we can replace with two calls to `sin` and `cos`, respectively, which are real-valued and also expect a real-valued argument.

This PR should be reviewed after #150 which provides the base for this PR. Benchmark analysis via CodSpeed should show improvements, but since #150 changed the names of benchmarks, this may only become visible here once #150 has been merged to develop.