### PR TITLE
Remove the softlink the README.md

### DIFF
--- a/README
+++ b/README
@@ -1,1 +1,0 @@
-README.md


### PR DESCRIPTION
Removes the softlink, as it seems to be not needed and it may cause problems when checking it out on Windows, where softlinks are by default not used in git.