### PR TITLE
Fix an issue where makedist would fail because doxygen always builds documentation in srcdir, not builddir.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -96,10 +96,7 @@ pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = nfft3@PREC_SUFFIX@.pc
 
 install-data-hook:
-	if test -f "$(abs_top_builddir)/doc/html/index.html"; then \
-		$(MKDIR_P) $(DESTDIR)$(docdir); \
-		cp -Rf $(abs_top_builddir)/doc/html $(DESTDIR)$(docdir)/; \
-	elif test -f "$(abs_top_srcdir)/doc/html/index.html"; then \
+	if test -f "$(abs_top_srcdir)/doc/html/index.html"; then \
 		$(MKDIR_P) $(DESTDIR)$(docdir); \
 		cp -Rf $(abs_top_srcdir)/doc/html $(DESTDIR)$(docdir)/; \
 	fi
@@ -118,14 +115,14 @@ clean-local:
 dist-hook: doc
 	rm -f @DX_DOCDIR@/@PACKAGE@.tag
 	chmod -R u+w $(distdir)
-	cp -R $(abs_top_builddir)/doc $(distdir)/
+	cp -R $(abs_top_srcdir)/doc $(distdir)/
 
 include aminclude.am
 
 if DX_COND_doc
 doc: doxygen-doc
-	rm -f $(abs_top_builddir)/doc/html/*.md5
-	rm -f $(abs_top_builddir)/doc/html/*.map
+	rm -f $(abs_top_srcdir)/doc/html/*.md5
+	rm -f $(abs_top_srcdir)/doc/html/*.map
 endif
 
 # Flags to be passed to aclocal.

--- a/Makefile.am
+++ b/Makefile.am
@@ -102,8 +102,10 @@ install-data-hook:
 	fi
 
 uninstall-hook:
-	chmod -Rf u+rwX $(DESTDIR)$(docdir)
-	rm -Rf $(DESTDIR)$(docdir)
+	if test -d "$(DESTDIR)$(docdir)"; then \
+		chmod -Rf u+rwX $(DESTDIR)$(docdir); \
+		rm -Rf $(DESTDIR)$(docdir); \
+	fi
 
 clean-local:
 	rm -f $(abs_top_builddir)/doc/doxygen_sqlite3.db

--- a/Makefile.am
+++ b/Makefile.am
@@ -114,17 +114,17 @@ clean-local:
 	rm -Rf $(abs_top_builddir)/doc/html
 	rm -Rf $(abs_top_builddir)/doc/latex
 
-dist-hook: doc
-	rm -f @DX_DOCDIR@/@PACKAGE@.tag
-	chmod -R u+w $(distdir)
-	cp -R $(abs_top_srcdir)/doc $(distdir)/
-
 include aminclude.am
 
 if DX_COND_doc
 doc: doxygen-doc
 	rm -f $(abs_top_srcdir)/doc/html/*.md5
 	rm -f $(abs_top_srcdir)/doc/html/*.map
+
+dist-hook: doc
+	rm -f @DX_DOCDIR@/@PACKAGE@.tag
+	chmod -R u+w $(distdir)
+	cp -R $(abs_top_srcdir)/doc $(distdir)/
 endif
 
 # Flags to be passed to aclocal.


### PR DESCRIPTION
I noticed that `make distcheck` was working in CI but not in my local dev environment. It seems the Doxygen documentation is always generated into `srcdir/doc/`, not `builddir/doc/`. THerefore, the `dist-hook` was failing when trying to build the distribution again from an unpacked distribution (`make distcheck` does that to verify the distribution is self-contained).

I have changed references to `abs_top_builddir` to `abs_top_srcdir` wherever Doxygen docs are involved. This has fixed the issue for me.