### PR TITLE
Run benchmarks agnostic to certain parameters only for default values.

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -102,8 +102,13 @@ jobs:
     
     - name: Configure
       run: |
+        AGNOSTIC_FLAGS=""
+        [ "${{ matrix.window }}" = "kaiserbessel" ] && AGNOSTIC_FLAGS="window:1" || AGNOSTIC_FLAGS="window:0"
+        [ "${{ matrix.openmp }}" = "0" ] && AGNOSTIC_FLAGS="$AGNOSTIC_FLAGS,openmp:1" || AGNOSTIC_FLAGS="$AGNOSTIC_FLAGS,openmp:0"
+        [ "${{ matrix.precision_opt }}" = "" ] && AGNOSTIC_FLAGS="$AGNOSTIC_FLAGS,precision:1" || AGNOSTIC_FLAGS="$AGNOSTIC_FLAGS,precision:0"
         ./configure --with-window=${{ matrix.window }} ${{ matrix.precision_opt }} --enable-all --enable-exhaustive-unit-tests \
         --enable-benchmarks --with-benchmarks-prefix=${{ env.BUILD_CONFIG }}/ --with-codspeed=$(pwd)/codspeed-cpp \
+        --with-agnostic-benchmarks="$AGNOSTIC_FLAGS" \
         $(if [ "${{ matrix.openmp }}" = "1" ]; then echo "--enable-openmp"; else echo ""; fi) \
         $(if [ "${{ matrix.build_octave }}" = "1" ]; then echo "--with-octave=$OCTAVEDIR"; else echo ""; fi) \
         $(if [ "${{ matrix.build_julia }}" = "1" ] && [ "${{ matrix.precision_opt }}" = "" ]; then echo "--enable-julia"; else echo ""; fi)
@@ -122,7 +127,7 @@ jobs:
       uses: CodSpeedHQ/action@v4
       with:
         mode: instrumentation
-        run: benchmarks/bench_nfft_direct
+        run: cd benchmarks && make bench
   
     - name: Test Julia
       if: matrix.build_julia == '1' && matrix.precision_opt == ''

--- a/benchmarks/Makefile.am
+++ b/benchmarks/Makefile.am
@@ -1,15 +1,27 @@
 AM_CPPFLAGS = -I$(top_srcdir)/include @nfft_benchmarks_CPPFLAGS@ @CPPFLAGS@
 
 if HAVE_BENCHMARKS
-  NFFT_BENCHMARKS = bench_nfft_direct
-else
-  NFFT_BENCHMARKS =
-endif
-
-noinst_PROGRAMS = $(NFFT_BENCHMARKS)
-
-# NFFT direct benchmarks
+if BENCHMARK_AGNOSTIC_WINDOW
+NFFT_BENCHMARKS_DIRECT = bench_nfft_direct
 bench_nfft_direct_SOURCES = bench_nfft_direct.cpp util.h
 bench_nfft_direct_CXXFLAGS = @nfft_benchmarks_CXXFLAGS@ @CXXFLAGS@
 bench_nfft_direct_LDFLAGS = @nfft_benchmarks_LDFLAGS@ @fftw3_LDFLAGS@ @LDFLAGS@
 bench_nfft_direct_LDADD = @nfft_benchmarks_LIBS@ $(top_builddir)/libnfft3@PREC_SUFFIX@.la @fftw3_LIBS@ @LIBS@
+else
+  NFFT_BENCHMARKS_DIRECT =
+endif
+else
+  NFFT_BENCHMARKS_DIRECT =
+endif
+
+# Aggregate all benchmarks
+NFFT_BENCHMARKS = $(NFFT_BENCHMARKS_DIRECT)
+
+noinst_PROGRAMS = $(NFFT_BENCHMARKS)
+
+# Run all built benchmarks
+bench: $(NFFT_BENCHMARKS)
+	for bench in $(NFFT_BENCHMARKS); do \
+		echo "Running $$bench..."; \
+		./$$bench; \
+	done

--- a/configure.ac
+++ b/configure.ac
@@ -271,6 +271,37 @@ AC_ARG_ENABLE(benchmarks, [AS_HELP_STRING([--enable-benchmarks],[enable building
 AC_ARG_WITH(benchmarks-prefix, [AS_HELP_STRING([--with-benchmarks-prefix=PREFIX],[prefix for benchmark names])], benchmarks_prefix=$withval, benchmarks_prefix="")
 AC_DEFINE_UNQUOTED(BENCHMARKS_PREFIX, "${benchmarks_prefix}", [Prefix for benchmark names])
 
+# Flags for benchmarks agnostic to certain parameters. Used only in CI.
+AC_ARG_WITH(agnostic-benchmarks, [AS_HELP_STRING([--with-agnostic-benchmarks=FLAGS],[specify which benchmarks should be built based on agnostic parameters. FLAGS should be a comma-separated list of parameter:flag pairs, e.g., window:1,openmp:0,precision:1,os:0,compiler:1])], agnostic_benchmarks=$withval, agnostic_benchmarks="")
+
+# Parse agnostic benchmarks flags.
+if test -z "$agnostic_benchmarks"; then
+  # All on by default.
+  BENCHMARK_AGNOSTIC_WINDOW=1 BENCHMARK_AGNOSTIC_OPENMP=1 BENCHMARK_AGNOSTIC_PRECISION=1
+else
+  # All off by default, unless specified otherwise.
+  BENCHMARK_AGNOSTIC_WINDOW=0 BENCHMARK_AGNOSTIC_OPENMP=0 BENCHMARK_AGNOSTIC_PRECISION=0
+  saved_IFS="$IFS"; IFS=','
+  for flag in $agnostic_benchmarks; do
+    case "$flag" in
+      precision:1) BENCHMARK_AGNOSTIC_PRECISION=1 ;;
+      precision:0) BENCHMARK_AGNOSTIC_PRECISION=0 ;;
+      window:1) BENCHMARK_AGNOSTIC_WINDOW=1 ;;
+      window:0) BENCHMARK_AGNOSTIC_WINDOW=0 ;;
+      openmp:1) BENCHMARK_AGNOSTIC_OPENMP=1 ;;
+      openmp:0) BENCHMARK_AGNOSTIC_OPENMP=0 ;;
+      '') ;;
+      *) AC_MSG_ERROR([Unknown agnostic benchmark flag "$flag". Valid flags are: precision:0/1, window:0/1, openmp:0/1]) ;;
+    esac
+  done
+  IFS="$saved_IFS"
+fi
+
+# Create automake conditionals for agnostic benchmark flags.
+AM_CONDITIONAL(BENCHMARK_AGNOSTIC_PRECISION, test "x$BENCHMARK_AGNOSTIC_PRECISION" = "x1")
+AM_CONDITIONAL(BENCHMARK_AGNOSTIC_WINDOW, test "x$BENCHMARK_AGNOSTIC_WINDOW" = "x1")
+AM_CONDITIONAL(BENCHMARK_AGNOSTIC_OPENMP, test "x$BENCHMARK_AGNOSTIC_OPENMP" = "x1")
+
 ################################################################################
 # C compiler characteristis
 ################################################################################


### PR DESCRIPTION
This PR reduces the noise generated by benchmarks that run indiscriminately of e.g. the window funtion configured, but that actually do not depend on the parameter.

This way, such benchmarks can be run only for parameter combinations like float data type, window function, compiler etc. that are really relevant for each benchmark.

Currently, we only have benchmarks for direct NDFT algorithms. SInce these do not depend on the window function, it should be enough to run them only for the default window function `kaiserbessel`.