### PR TITLE
Do not modify LIBS in the detection of cunit

### DIFF
--- a/m4/nfft_lib_cunit.m4
+++ b/m4/nfft_lib_cunit.m4
@@ -50,6 +50,7 @@ AC_DEFUN([NFFT_LIB_CUNIT],
   # Save current flags.
   saved_CPPFLAGS="$CPPFLAGS"
   saved_LDFLAGS="$LDFLAGS"
+  saved_LIBSS="$LIBS"
 
   cunit_have_lib="no"
   cunit_CPPFLAGS=""
@@ -97,4 +98,5 @@ AC_DEFUN([NFFT_LIB_CUNIT],
   # Restore saved flags.
   CPPFLAGS="$saved_CPPFLAGS"
   LDFLAGS="$saved_LDFLAGS"
+  LIBS="$saved_LIBS"
 ])dnl NFFT_CUNIT


### PR DESCRIPTION
Previously, when detecting cunit, the LIBS variable was set to -lcunit and so all files including the libnfft3 were linked to it