### PR TITLE
Add more compiler versions to CI and dev container.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,9 +8,16 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Create the vscode user and install dependencies.
 RUN groupadd --gid 2000 vscode \
     && useradd --uid 2000 --gid vscode --shell /bin/bash --create-home vscode \
+    && apt update \
+    && apt install -y --no-install-recommends\
+    software-properties-common \
+    && add-apt-repository universe \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
     build-essential \
+    gcc-snapshot \
+    gcc-14 \
+    g++-14 \
     cmake \
     libfftw3-dev \
     libfftw3-single3 \

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -16,12 +16,37 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest"] # TODO: Add more Ubuntu versions, e.g. "ubuntu-20.04", "ubuntu-18.04".
-        compiler: ["gcc", "clang"]
+        compiler: ["gcc"]
         window: ["kaiserbessel", "gaussian", "bspline", "sinc"] # TODO: Add dirac.
         precision_opt: ["", "--enable-float", "--enable-long-double"]
         openmp: [0, 1]
         build_octave: [0] # TODO: Re-activate Octave build and tests.
         build_julia: [1]
+        include:
+          # Clang
+          - os: "ubuntu-latest"
+            compiler: "clang"
+            window: "kaiserbessel"
+            precision_opt: ""
+            openmp: 1
+            build_octave: 0
+            build_julia: 0
+          # GCC 14
+          - os: "ubuntu-latest"
+            compiler: "gcc-14"
+            window: "kaiserbessel"
+            precision_opt: ""
+            openmp: 1
+            build_octave: 0
+            build_julia: 0
+          # GCC Snapshot
+          - os: "ubuntu-latest"
+            compiler: "gcc-snapshot"
+            window: "kaiserbessel"
+            precision_opt: ""
+            openmp: 1
+            build_octave: 0
+            build_julia: 0
     steps:    
     - uses: actions/checkout@v5
 
@@ -30,12 +55,24 @@ jobs:
 
     - name: Disable man-db update
       run: sudo rm -f /var/lib/man-db/auto-update        
+    
+    - name: Install dependencies
+      uses: dsx137/deb-cache@main
+      with:
+        PACKAGES: |
+          software-properties-common
+
+    - name: Add universe repo
+      run: sudo add-apt-repository universe
 
     - name: Install dependencies
       uses: dsx137/deb-cache@main
       with:
         PACKAGES: |
           build-essential
+          gcc-snapshot
+          gcc-14
+          g++-14
           cmake
           libfftw3-dev
           libcunit1-dev 
@@ -97,8 +134,23 @@ jobs:
       
     - name: Set up compiler
       run: |
-        echo "CC=${{ matrix.compiler }}" >> $GITHUB_ENV
-        echo "CXX=${{ matrix.compiler == 'gcc' && 'g++' || 'clang++' }}" >> $GITHUB_ENV
+        if [ "${{ matrix.compiler }}" = "clang" ]; then
+          echo "CC=${{ matrix.compiler }}" >> $GITHUB_ENV
+          echo "CXX=clang++" >> $GITHUB_ENV
+        elif [ "${{ matrix.compiler }}" = "gcc" ]; then
+          echo "CC=${{ matrix.compiler }}" >> $GITHUB_ENV
+          echo "CXX=g++" >> $GITHUB_ENV
+        elif [ "${{ matrix.compiler }}" = "gcc-snapshot" ]; then
+          echo "CC=/usr/lib/gcc-snapshot/bin/gcc" >> $GITHUB_ENV
+          echo "CXX=/usr/lib/gcc-snapshot/bin/g++" >> $GITHUB_ENV
+        elif echo "${{ matrix.compiler }}" | grep -qE '^gcc-[0-9]+$'; then
+          echo "CC=${{ matrix.compiler }}" >> $GITHUB_ENV
+          GCC_VERSION=$(echo "${{ matrix.compiler }}" | sed 's/gcc-//')
+          echo "CXX=g++-${GCC_VERSION}" >> $GITHUB_ENV
+        else
+          echo "Error: Unknown compiler '${{ matrix.compiler }}'. Supported compilers are: gcc, clang, gcc-snapshot, gcc-<version>" >&2
+          exit 1
+        fi
         
     - name: Bootstrap
       run: ./bootstrap.sh

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -30,7 +30,21 @@ jobs:
             precision_opt: ""
             openmp: 1
             build_octave: 0
-            build_julia: 0
+            build_julia: 1
+          - os: "ubuntu-latest"
+            compiler: "clang"
+            window: "kaiserbessel"
+            precision_opt: "--enable-float"
+            openmp: 1
+            build_octave: 0
+            build_julia: 1
+          - os: "ubuntu-latest"
+            compiler: "clang"
+            window: "kaiserbessel"
+            precision_opt: "--enable-long-double"
+            openmp: 1
+            build_octave: 0
+            build_julia: 1
           # GCC 14
           - os: "ubuntu-latest"
             compiler: "gcc-14"
@@ -38,7 +52,7 @@ jobs:
             precision_opt: ""
             openmp: 1
             build_octave: 0
-            build_julia: 0
+            build_julia: 1
           # GCC Snapshot
           - os: "ubuntu-latest"
             compiler: "gcc-snapshot"
@@ -46,7 +60,7 @@ jobs:
             precision_opt: ""
             openmp: 1
             build_octave: 0
-            build_julia: 0
+            build_julia: 1
     steps:    
     - uses: actions/checkout@v5
 


### PR DESCRIPTION
This adds additional GCC versions to the dev container images. Also, the Linux CI workflow will run against these additional versions as well. To avoid a combinatorial explosion of jobs in the matrix configuration, only the standard GCC version runs for different window functions et cetera. The other compilers, i.e. Clang and other GCC versions, only run a single configuration.