### PR TITLE
Link against libatomic where required for OpenMP atomic operations on floating-point type.

### DIFF
--- a/applications/fastsum/Makefile.am
+++ b/applications/fastsum/Makefile.am
@@ -25,8 +25,8 @@ libkernels_la_SOURCES = kernels.c
 
 if ENABLE_OPENMP
   libfastsum_threads_la_SOURCES = fastsum.c fastsum.h kernels.h
-  libfastsum_threads_la_LIBADD = @fftw3_LIBS_omp@ @fftw3_LIBS@  -latomic
-  libfastsum_threads_la_LDFLAGS = @fftw3_threads_LDFLAGS@
+  libfastsum_threads_la_LIBADD = @fftw3_LIBS_omp@ @fftw3_LIBS@ $(OPENMP_LIBS)
+  libfastsum_threads_la_LDFLAGS = @fftw3_threads_LDFLAGS@ $(OPENMP_CFLAGS)
   libfastsum_threads_la_CFLAGS = $(OPENMP_CFLAGS)
 endif
 
@@ -46,14 +46,14 @@ if ENABLE_OPENMP
   fastsum_test_threads_SOURCES = fastsum_test.c
   fastsum_test_threads_CFLAGS = $(OPENMP_CFLAGS)
   fastsum_test_threads_LDFLAGS = $(OPENMP_CFLAGS) @fftw3_LDFLAGS@
-  fastsum_test_threads_LDADD = libfastsum_threads.la libkernels.la $(top_builddir)/libnfft3@PREC_SUFFIX@_omp.la @fftw3_LIBS_omp@ @fftw3_LIBS@ -latomic 
+  fastsum_test_threads_LDADD = libfastsum_threads.la libkernels.la $(top_builddir)/libnfft3@PREC_SUFFIX@_omp.la @fftw3_LIBS_omp@ @fftw3_LIBS@ $(OPENMP_LIBS)
 endif
 
 if ENABLE_OPENMP
 fastsum_benchomp_SOURCES = fastsum_benchomp.c
 fastsum_benchomp_CFLAGS = $(OPENMP_CFLAGS)
 fastsum_benchomp_LDLAGS = $(OPENMP_CFLAGS) @fftw3_LDFLAGS@
-fastsum_benchomp_LDADD = libfastsum_threads.la libkernels.la $(top_builddir)/libnfft3@PREC_SUFFIX@_omp.la @fftw3_LIBS_omp@ @fftw3_LIBS@ -latomic
+fastsum_benchomp_LDADD = libfastsum_threads.la libkernels.la $(top_builddir)/libnfft3@PREC_SUFFIX@_omp.la @fftw3_LIBS_omp@ @fftw3_LIBS@ $(OPENMP_LIBS)
 
 fastsum_benchomp_createdataset_SOURCES = fastsum_benchomp_createdataset.c
 fastsum_benchomp_createdataset_LDFLAGS = @fftw3_LDFLAGS@

--- a/configure.ac
+++ b/configure.ac
@@ -362,6 +362,21 @@ if test "x$enable_threads" = "xyes" -a "x$ax_cv_[]_AC_LANG_ABBREV[]_openmp" = "x
   AC_MSG_ERROR([You have enabled building NFFT with OpenMP multi-threading support, but your compiler does not seem to support OpenMP.])
 fi
 
+OPENMP_LIBS=""
+
+if test "x$enable_threads" = "xyes"; then
+  NFFT_OPENMP_ATOMIC_FLOAT
+  if test "x$OPENMP_ATOMIC_FLOAT_LIBS" = "xunknown"; then
+    AC_MSG_ERROR([OpenMP atomic operations do not work.])
+  elif test "x$OPENMP_ATOMIC_FLOAT_LIBS" = "x"; then
+    # No additional flags required.
+    :
+  else
+    # Add additional flags.
+    OPENMP_LIBS="$OPENMP_ATOMIC_FLOAT_LIBS"
+  fi
+fi
+
 ################################################################################
 # 3rd party libraries
 ################################################################################
@@ -403,6 +418,7 @@ AC_SUBST(fftw3_LIBS_omp)
 
 AM_CONDITIONAL(ENABLE_OPENMP, test "x$enable_threads" = "xyes" )
 AC_SUBST(OPENMP_CFLAGS)
+AC_SUBST(OPENMP_LIBS)
 
 # Check for MATLAB.
 AX_PROG_MATLAB

--- a/configure.ac
+++ b/configure.ac
@@ -310,7 +310,7 @@ AC_LANG(C)
 AX_COMPILER_VENDOR
 
 # check for C99 compliant mode (possibly with GNU extensions)
-AC_PROG_CC_C99
+AC_PROG_CC
 
 # per-target flags
 AM_PROG_CC_C_O
@@ -350,6 +350,43 @@ AC_PROG_MKDIR_P
 
 # whether ln -s works
 AC_PROG_LN_S
+
+################################################################################
+# compiler options
+################################################################################
+
+# Try to choose good compiler options.
+if test "x$ac_test_CFLAGS" != "xset"; then
+  AX_CC_MAXOPT
+fi
+
+# override CFLAGS selection when debugging
+if test "x${enable_debug}" = "xyes"; then
+  CFLAGS="-g -O2 -fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer -fno-sanitize-recover=all -v"
+#  if test "x$ax_cv_c_compiler_vendor" = "xapple"; then
+#    CFLAGS="$CFLAGS $ax_cv_apple_gcc_archflag"
+#  fi
+fi
+
+# add gcc warnings, in debug/maintainer mode only
+if test "x${enable_debug}" = "xyes" || test "x$USE_MAINTAINER_MODE" = "xyes";
+then
+  if test "x$ac_cv_c_compiler_gnu" = "xyes"; then
+    CFLAGS="$CFLAGS -Wall -W -Wcast-qual -Wpointer-arith -Wcast-align -pedantic"
+    CFLAGS="$CFLAGS -Wno-long-long -Wshadow -Wbad-function-cast -Wwrite-strings"
+    CFLAGS="$CFLAGS -Wstrict-prototypes -Wredundant-decls -Wnested-externs"
+    CFLAGS="$CFLAGS -Wundef -Wconversion -Wmissing-prototypes "
+    CFLAGS="$CFLAGS -Wmissing-declarations"
+  fi
+fi
+
+# option to accept C99
+CFLAGS="$CFLAGS $ac_cv_prog_cc_c99"
+
+# use MinGW implementation of printf
+if test "x${host_os}" = "xmingw32" -o "x${host_os}" = "xmingw64"; then
+  CFLAGS="$CFLAGS -D__USE_MINGW_ANSI_STDIO=1"
+fi  
 
 ################################################################################
 # OpenMP support
@@ -431,59 +468,8 @@ if test "x$matlab_threads" = "xyes" -a "x$enable_threads" != "xyes"; then
   AC_MSG_ERROR([The NFFT Matlab interface with thread support requires the threaded NFFT to be built. Please re-run configure with --enable-openmp.])
 fi
 
-
-################################################################################
-# compiler options
-################################################################################
-
-# Try to choose good compiler options.
-if test "x$ac_test_CFLAGS" != "xset"; then
-  saved_CPPFLAGS="$CPPFLAGS"
-  saved_LDFLAGS="$LDFLAGS"
-  saved_LIBS="$LIBS"
-  CPPFLAGS="$CPPFLAGS $nfft_fftw3_CPPFLAGS"
-  LIBS="$LIBS $fftw3_LIBS"
-  LDFLAGS="$LDFLAGS $nfft_fftw3_LDFLAGS"
-  AX_CC_MAXOPT
-  CPPFLAGS="$saved_CPPFLAGS"
-  LDFLAGS="$saved_LDFLAGS"
-  LIBS="$saved_LIBS"
-fi
-
-# override CFLAGS selection when debugging
-if test "x${enable_debug}" = "xyes"; then
-  CFLAGS="-g"
-#  if test "x$ax_cv_c_compiler_vendor" = "xapple"; then
-#    CFLAGS="$CFLAGS $ax_cv_apple_gcc_archflag"
-#  fi
-fi
-
-# add gcc warnings, in debug/maintainer mode only
-if test "x${enable_debug}" = "xyes" || test "x$USE_MAINTAINER_MODE" = "xyes";
-then
-  if test "x$ac_cv_c_compiler_gnu" = "xyes"; then
-    CFLAGS="$CFLAGS -Wall -W -Wcast-qual -Wpointer-arith -Wcast-align -pedantic"
-    CFLAGS="$CFLAGS -Wno-long-long -Wshadow -Wbad-function-cast -Wwrite-strings"
-    CFLAGS="$CFLAGS -Wstrict-prototypes -Wredundant-decls -Wnested-externs"
-    CFLAGS="$CFLAGS -Wundef -Wconversion -Wmissing-prototypes "
-    CFLAGS="$CFLAGS -Wmissing-declarations"
-  fi
-fi
-
-# option to accept C99
-CFLAGS="$CFLAGS $ac_cv_prog_cc_c99"
-
-# use MinGW implementation of printf
-if test "x${host_os}" = "xmingw32" -o "x${host_os}" = "xmingw64"; then
-  CFLAGS="$CFLAGS -D__USE_MINGW_ANSI_STDIO=1"
-fi  
-
+# Add FFTW preprocessor flags.
 CPPFLAGS="$CPPFLAGS $nfft_fftw3_CPPFLAGS"
-
-# add Matlab CFLAGS
-if test "x$ax_prog_matlab" = "xyes"; then
-  CFLAGS="$CFLAGS $matlab_CFLAGS"
-fi
 
 ################################################################################
 # check if mex.h can be included without undefinition of

--- a/examples/nfft/Makefile.am
+++ b/examples/nfft/Makefile.am
@@ -17,7 +17,7 @@ noinst_PROGRAMS = simple_test $(SIMPLE_TEST_THREADS) ndft_fast taylor_nfft flags
 if ENABLE_OPENMP
   simple_test_threads_SOURCES = simple_test_threads.c
   simple_test_threads_LDFLAGS = @fftw3_LDFLAGS@
-  simple_test_threads_LDADD = $(top_builddir)/libnfft3@PREC_SUFFIX@_omp.la @fftw3_LIBS_omp@ @fftw3_LIBS@ -latomic
+  simple_test_threads_LDADD = $(top_builddir)/libnfft3@PREC_SUFFIX@_omp.la @fftw3_LIBS_omp@ @fftw3_LIBS@ $(OPENMP_LIBS)
 endif
 
 simple_test_SOURCES = simple_test.c
@@ -44,20 +44,20 @@ if ENABLE_OPENMP
 nfft_benchomp_SOURCES = nfft_benchomp.c
 nfft_benchomp_CFLAGS = $(OPENMP_CFLAGS)
 nfft_benchomp_LDFLAGS = $(OPENMP_CFLAGS) @fftw3_LDFLAGS@
-nfft_benchomp_LDADD = $(top_builddir)/libnfft3@PREC_SUFFIX@_omp.la @fftw3_LIBS_omp@ @fftw3_LIBS@ -latomic
+nfft_benchomp_LDADD = $(top_builddir)/libnfft3@PREC_SUFFIX@_omp.la @fftw3_LIBS_omp@ @fftw3_LIBS@ $(OPENMP_LIBS)
 
 nfft_benchomp_createdataset_SOURCES = nfft_benchomp_createdataset.c
 nfft_benchomp_createdataset_LDFLAGS = @fftw3_LDFLAGS@
-nfft_benchomp_createdataset_LDADD = $(top_builddir)/libnfft3@PREC_SUFFIX@.la @fftw3_LIBS@ -latomic
+nfft_benchomp_createdataset_LDADD = $(top_builddir)/libnfft3@PREC_SUFFIX@.la @fftw3_LIBS@ $(OPENMP_LIBS) 
 
 nfft_benchomp_detail_single_SOURCES = nfft_benchomp_detail.c
 nfft_benchomp_detail_single_LDFLAGS = @fftw3_LDFLAGS@
-nfft_benchomp_detail_single_LDADD = $(top_builddir)/libnfft3@PREC_SUFFIX@.la @fftw3_LIBS@ -latomic
+nfft_benchomp_detail_single_LDADD = $(top_builddir)/libnfft3@PREC_SUFFIX@.la @fftw3_LIBS@ $(OPENMP_LIBS) 
 
 nfft_benchomp_detail_threads_SOURCES = nfft_benchomp_detail.c
 nfft_benchomp_detail_threads_CFLAGS = $(OPENMP_CFLAGS)
 nfft_benchomp_detail_threads_LDFLAGS = $(OPENMP_CFLAGS) @fftw3_LDFLAGS@
-nfft_benchomp_detail_threads_LDADD = $(top_builddir)/libnfft3@PREC_SUFFIX@_omp.la @fftw3_LIBS_omp@ @fftw3_LIBS@ -latomic
+nfft_benchomp_detail_threads_LDADD = $(top_builddir)/libnfft3@PREC_SUFFIX@_omp.la @fftw3_LIBS_omp@ @fftw3_LIBS@ $(OPENMP_LIBS) 
 endif
 
 EXTRA_DIST = flags.m ndft_fast.m taylor_nfft.m README

--- a/examples/nfsft/Makefile.am
+++ b/examples/nfsft/Makefile.am
@@ -30,7 +30,7 @@ endif
 if ENABLE_OPENMP
 nfsft_benchomp_SOURCES = nfsft_benchomp.c
 nfsft_benchomp_CFLAGS = $(OPENMP_CFLAGS)
-nfsft_benchomp_LDFLAGS = $(OPENMP_LDFLAGS) @fftw3_LDFLAGS@
+nfsft_benchomp_LDFLAGS = $(OPENMP_CFLAGS) @fftw3_LDFLAGS@
 nfsft_benchomp_LDADD = $(top_builddir)/libnfft3@PREC_SUFFIX@_omp.la @fftw3_LIBS_omp@ @fftw3_LIBS@ 
 
 nfsft_benchomp_createdataset_SOURCES = nfsft_benchomp_createdataset.c

--- a/m4/nfft_openmp_atomic_float.m4
+++ b/m4/nfft_openmp_atomic_float.m4
@@ -78,14 +78,14 @@ AC_DEFUN([NFFT_OPENMP_ATOMIC_FLOAT],
       LDFLAGS_bak=$LDFLAGS
       LDFLAGS="$LDFLAGS $atomic_flag"
       
-      AC_RUN_IFELSE([
+      AC_LINK_IFELSE([
         OMP_ATOMIC_TEST_PROGRAM
       ], [
         OPENMP_ATOMIC_FLOAT_LIBS="$atomic_flag"
       ], [
         # Test failed, continue to next iteration
         :
-      ], [])
+      ])
 
       # Restore flags.
       LDFLAGS="$LDFLAGS_bak"

--- a/m4/nfft_openmp_atomic_float.m4
+++ b/m4/nfft_openmp_atomic_float.m4
@@ -1,0 +1,108 @@
+# Copyright (c) 2025 Jens Keiner, Stefan Kunis, Daniel Potts
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 2 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# @synopsis NFFT_OPENMP_ATOMIC_FLOAT
+# @summary Check whether using "#pragma omp atomic" with the selected floating-point data type requires linking additional libraries.
+# @category C
+#
+# @version 2025-09-23
+# @license GPLWithACException
+# @author Jens Keiner <jens@nfft.org>
+#
+#  Set shell variable `OPENMP_ATOMIC_FLOAT_LIBS' to the additional libraries needed for OpenMP
+#  atomic operations on floating point type to work. If no valid configuration is found, set
+#  `OPENMP_ATOMIC_FLOAT_LIBS' to "unknown".
+AC_DEFUN([NFFT_OPENMP_ATOMIC_FLOAT],
+[
+  AC_MSG_CHECKING([which additional libraries are needed for OpenMP atomic operations on floating point type to work])
+  
+  # Save current flags.
+  ac_save_CFLAGS="$CFLAGS"
+  ac_save_LDFLAGS="$LDFLAGS"
+  
+  # Add OpenMP flags.
+  CFLAGS="$CFLAGS $OPENMP_CFLAGS"
+  LDFLAGS="$LDFLAGS $OPENMP_CFLAGS"
+  
+  # Define test program as a macro for reuse.
+  m4_define([OMP_ATOMIC_TEST_PROGRAM], [
+    AC_LANG_PROGRAM([
+      #include <omp.h>
+      #include <stdint.h>
+    ], [
+      /* Test atomic operation on floating point type. */
+      #if defined(NFFT_LDOUBLE)
+      long double r = 0.0L;
+      long double increment = 2.0L;
+      #elif defined(NFFT_SINGLE)
+      float r = 0.0f;
+      float increment = 2.0f;
+      #else
+      double r = 0.0;
+      double increment = 2.0;
+      #endif
+      int i;
+
+      #pragma omp parallel for
+      for (i = 0; i < 100; i++) {
+        #pragma omp atomic
+        r += increment;
+      }
+      
+      /* Ensure the compiler doesn't optimize away our operations */
+      if (r < 0.0) {
+        return 1; /* This should never happen */
+      }
+      
+      return 0;
+    ])
+  ])
+
+  # Try different LDFLAGS options for atomic operations.
+  OPENMP_ATOMIC_FLOAT_LIBS="unknown"
+  for atomic_flag in "" "-latomic"; do
+    if test "x$OPENMP_ATOMIC_FLOAT_LIBS" = "xunknown"; then
+      LDFLAGS_bak=$LDFLAGS
+      LDFLAGS="$LDFLAGS $atomic_flag"
+      
+      AC_RUN_IFELSE([
+        OMP_ATOMIC_TEST_PROGRAM
+      ], [
+        OPENMP_ATOMIC_FLOAT_LIBS="$atomic_flag"
+      ], [
+        # Test failed, continue to next iteration
+        :
+      ], [])
+
+      # Restore flags.
+      LDFLAGS="$LDFLAGS_bak"
+    fi
+  done
+
+  if test "x$OPENMP_ATOMIC_FLOAT_LIBS" = "xunknown"; then
+    AC_MSG_RESULT([unknown])
+  else
+    if test "x$OPENMP_ATOMIC_FLOAT_LIBS" = "x"; then
+      AC_MSG_RESULT([none])
+    else
+      AC_MSG_RESULT([$OPENMP_ATOMIC_FLOAT_LIBS])
+    fi
+  fi
+  
+  # Restore original flags.
+  CFLAGS="$ac_save_CFLAGS"
+  LDFLAGS="$ac_save_LDFLAGS"
+])

--- a/m4/nfft_openmp_atomic_float.m4
+++ b/m4/nfft_openmp_atomic_float.m4
@@ -32,10 +32,20 @@ AC_DEFUN([NFFT_OPENMP_ATOMIC_FLOAT],
   # Save current flags.
   ac_save_CFLAGS="$CFLAGS"
   ac_save_LDFLAGS="$LDFLAGS"
-  
+  ac_save_LIBS="$LIBS"
+
   # Add OpenMP flags.
   CFLAGS="$CFLAGS $OPENMP_CFLAGS"
   LDFLAGS="$LDFLAGS $OPENMP_CFLAGS"
+
+  # Add OpenMP flags.
+  #if test "x$CC" = "xclang"; then
+  #  CFLAGS="$CFLAGS -g -Rpass=.* -Rpass-missed=.* -fsave-optimization-record -foptimization-record-file=opt.txt $OPENMP_CFLAGS"
+  #  LDFLAGS="$LDFLAGS $OPENMP_CFLAGS"
+  #else
+  #  CFLAGS="$CFLAGS -g -fopt-info-all=opt.txt $OPENMP_CFLAGS"
+  #  LDFLAGS="$LDFLAGS $OPENMP_CFLAGS"
+  #fi
   
   # Define test program as a macro for reuse.
   m4_define([OMP_ATOMIC_TEST_PROGRAM], [
@@ -43,28 +53,33 @@ AC_DEFUN([NFFT_OPENMP_ATOMIC_FLOAT],
       #include <omp.h>
       #include <stdint.h>
     ], [
-      /* Test atomic operation on floating point type. */
       #if defined(NFFT_LDOUBLE)
       long double r = 0.0L;
       long double increment = 2.0L;
+      long double expected_min = 150.0L;
       #elif defined(NFFT_SINGLE)
       float r = 0.0f;
       float increment = 2.0f;
+      float expected_min = 150.0f;
       #else
       double r = 0.0;
       double increment = 2.0;
+      double expected_min = 150.0;
       #endif
       int i;
+      // Make loop count unpredictable to compiler by using address arithmetic.
+      volatile int loop_count = (int)((uintptr_t)&r % 50) + 75;
+      // Make increment unpredictable by using address-based modification.
+      increment += (((uintptr_t)&i % 3) == 0) ? 0.0 : 0.0;
 
       #pragma omp parallel for
-      for (i = 0; i < 100; i++) {
+      for (i = 0; i < loop_count; i++) {
         #pragma omp atomic
         r += increment;
       }
       
-      /* Ensure the compiler doesn't optimize away our operations */
-      if (r < 0.0) {
-        return 1; /* This should never happen */
+      if (r < expected_min) {
+        return 1;
       }
       
       return 0;
@@ -75,8 +90,8 @@ AC_DEFUN([NFFT_OPENMP_ATOMIC_FLOAT],
   OPENMP_ATOMIC_FLOAT_LIBS="unknown"
   for atomic_flag in "" "-latomic"; do
     if test "x$OPENMP_ATOMIC_FLOAT_LIBS" = "xunknown"; then
-      LDFLAGS_bak=$LDFLAGS
-      LDFLAGS="$LDFLAGS $atomic_flag"
+      LIBS_bak=$LIBS
+      LIBS="$LIBS $atomic_flag"
       
       AC_LINK_IFELSE([
         OMP_ATOMIC_TEST_PROGRAM
@@ -88,7 +103,7 @@ AC_DEFUN([NFFT_OPENMP_ATOMIC_FLOAT],
       ])
 
       # Restore flags.
-      LDFLAGS="$LDFLAGS_bak"
+      LIBS="$LIBS_bak"
     fi
   done
 
@@ -105,4 +120,5 @@ AC_DEFUN([NFFT_OPENMP_ATOMIC_FLOAT],
   # Restore original flags.
   CFLAGS="$ac_save_CFLAGS"
   LDFLAGS="$ac_save_LDFLAGS"
+  LIBS="$ac_save_LIBS"
 ])

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -43,7 +43,7 @@ checkall_threads_SOURCES = $(checkall_SOURCES)
 checkall_threads_CPPFLAGS = $(cunit_CPPFLAGS)
 checkall_threads_CFLAGS = $(OPENMP_CFLAGS)
 checkall_threads_LDFLAGS = $(OPENMP_CFLAGS) @fftw3_LDFLAGS@ @cunit_LDFLAGS@
-checkall_threads_LDADD = $(top_builddir)/libnfft3@PREC_SUFFIX@_omp.la @fftw3_LIBS_omp@ @fftw3_LIBS@ -latomic @cunit_LIBS@
+checkall_threads_LDADD = $(top_builddir)/libnfft3@PREC_SUFFIX@_omp.la @fftw3_LIBS_omp@ @fftw3_LIBS@  $(OPENMP_LIBS) @cunit_LIBS@
 endif
 
 clean-local:


### PR DESCRIPTION
I had added `-latomic` previously for some programs that link against the OpenMP-enabled NFFT version.

It turns out that `libatomic` is only needed on some platforms to implement `#pragma omp atomic` for the chosen floating-point data type which is used in parts of the multi-threaded NFFT code.

This seems to be a fallback when other means of implementation are not available.

On some platforms however, linking against `libatomic` may not be needed at all and the library may even be absent from the system, so breaks occur if we just always try to link against it.

This PR adds proper checking whether additional linking against the library is actually needed.

Since the NFFT code only uses atomic primitives on variables of the chosen floating-point data type, it should be enough to check these operations in the configure script.

