### PR TITLE
Fix array size in PRE_FG_PSI mode.

### DIFF
--- a/kernel/nfct/nfct.c
+++ b/kernel/nfct/nfct.c
@@ -503,7 +503,7 @@ static inline void B_ ## which_one (X(plan) *ths) \
   R *fj; /* local copy */ \
   R y[ths->d]; \
   R fg_psi[ths->d][2*ths->m+2]; \
-  R fg_exp_l[ths->d][2*ths->m+2]; \
+  R fg_exp_l[ths->d][2*ths->m+2+1]; \
   INT l_fg,lj_fg; \
   R tmpEXP1, tmpEXP2, tmpEXP2sq, tmp1, tmp2, tmp3; \
   R ip_w; \

--- a/kernel/nfft/nfft.c
+++ b/kernel/nfft/nfft.c
@@ -802,7 +802,7 @@ static inline void B_serial_ ## which_one (X(plan) *ths) \
   R phi_prod[ths->d+1]; /* postfix product of PHI */ \
   R y[ths->d]; \
   R fg_psi[ths->d][2*ths->m+2]; \
-  R fg_exp_l[ths->d][2*ths->m+2]; \
+  R fg_exp_l[ths->d][2*ths->m+2+1]; \
   INT l_fg,lj_fg; \
   R tmpEXP1, tmpEXP2, tmpEXP2sq, tmp1, tmp2, tmp3; \
   R ip_w; \
@@ -1211,7 +1211,7 @@ static inline void B_openmp_A (X(plan) *ths)
   if (ths->flags & PRE_FG_PSI)
   {
     INT t, t2; /* index dimensions */
-    R fg_exp_l[ths->d][2*ths->m+2];
+    R fg_exp_l[ths->d][2*ths->m+2+1];
 
     MACRO_B_openmp_A_COMPUTE_INIT_FG_PSI
 
@@ -1230,7 +1230,7 @@ static inline void B_openmp_A (X(plan) *ths)
   if (ths->flags & FG_PSI)
   {
     INT t, t2; /* index dimensions */
-    R fg_exp_l[ths->d][2*ths->m+2];
+    R fg_exp_l[ths->d][2*ths->m+2+1];
 
     sort(ths);
 
@@ -2009,7 +2009,7 @@ static inline void B_openmp_T(X(plan) *ths)
   if (ths->flags & PRE_FG_PSI)
   {
     INT t, t2; /* index dimensions */
-    R fg_exp_l[ths->d][2*ths->m+2];
+    R fg_exp_l[ths->d][2*ths->m+2+1];
     for(t2 = 0; t2 < ths->d; t2++)
     {
       INT lj_fg;
@@ -2040,7 +2040,7 @@ static inline void B_openmp_T(X(plan) *ths)
   if (ths->flags & FG_PSI)
   {
     INT t, t2; /* index dimensions */
-    R fg_exp_l[ths->d][2*ths->m+2];
+    R fg_exp_l[ths->d][2*ths->m+2+1];
 
     sort(ths);
 
@@ -2324,7 +2324,7 @@ static void nfft_trafo_1d_B(X(plan) *ths)
   if (ths->flags & PRE_FG_PSI)
   {
     INT k;
-    R fg_exp_l[m2p2];
+    R fg_exp_l[m2p2+1];
 
     nfft_1d_init_fg_exp_l(fg_exp_l, m, ths->b[0]);
 
@@ -2356,7 +2356,7 @@ static void nfft_trafo_1d_B(X(plan) *ths)
   if (ths->flags & FG_PSI)
   {
     INT k;
-    R fg_exp_l[m2p2];
+    R fg_exp_l[m2p2+1];
 
     sort(ths);
 
@@ -2625,7 +2625,7 @@ static void nfft_adjoint_1d_B(X(plan) *ths)
 
   if (ths->flags & PRE_FG_PSI)
   {
-    R fg_exp_l[2 * m + 2];
+    R fg_exp_l[2 * m + 2 + 1];
 
     nfft_1d_init_fg_exp_l(fg_exp_l, m, ths->b[0]);
 
@@ -2665,7 +2665,7 @@ static void nfft_adjoint_1d_B(X(plan) *ths)
 
   if (ths->flags & FG_PSI)
   {
-    R fg_exp_l[2 * m + 2];
+    R fg_exp_l[2 * m + 2 + 1];
 
     nfft_1d_init_fg_exp_l(fg_exp_l, m, ths->b[0]);
 
@@ -3265,7 +3265,7 @@ static void nfft_trafo_2d_B(X(plan) *ths)
 
   if(ths->flags & PRE_FG_PSI)
   {
-    R fg_exp_l[2*(2*m+2)];
+    R fg_exp_l[2*(2*m+2+1)];
 
     nfft_2d_init_fg_exp_l(fg_exp_l, m, ths->b[0]);
     nfft_2d_init_fg_exp_l(fg_exp_l+2*m+2, m, ths->b[1]);
@@ -3307,7 +3307,7 @@ static void nfft_trafo_2d_B(X(plan) *ths)
 
   if(ths->flags & FG_PSI)
   {
-    R fg_exp_l[2*(2*m+2)];
+    R fg_exp_l[2*(2*m+2+1)];
 
     nfft_2d_init_fg_exp_l(fg_exp_l, m, ths->b[0]);
     nfft_2d_init_fg_exp_l(fg_exp_l+2*m+2, m, ths->b[1]);
@@ -3625,7 +3625,7 @@ static void nfft_adjoint_2d_B(X(plan) *ths)
 
   if(ths->flags & PRE_FG_PSI)
   {
-    R fg_exp_l[2*(2*m+2)];
+    R fg_exp_l[2*(2*m+2+1)];
 
     nfft_2d_init_fg_exp_l(fg_exp_l, m, ths->b[0]);
     nfft_2d_init_fg_exp_l(fg_exp_l+2*m+2, m, ths->b[1]);
@@ -3676,7 +3676,7 @@ static void nfft_adjoint_2d_B(X(plan) *ths)
 
   if(ths->flags & FG_PSI)
   {
-    R fg_exp_l[2*(2*m+2)];
+    R fg_exp_l[2*(2*m+2+1)];
 
     nfft_2d_init_fg_exp_l(fg_exp_l, m, ths->b[0]);
     nfft_2d_init_fg_exp_l(fg_exp_l+2*m+2, m, ths->b[1]);
@@ -4732,7 +4732,7 @@ static void nfft_trafo_3d_B(X(plan) *ths)
 
   if(ths->flags & PRE_FG_PSI)
   {
-    R fg_exp_l[3*(2*m+2)];
+    R fg_exp_l[3*(2*m+2+1)];
 
     nfft_3d_init_fg_exp_l(fg_exp_l, m, ths->b[0]);
     nfft_3d_init_fg_exp_l(fg_exp_l+2*m+2, m, ths->b[1]);
@@ -4785,7 +4785,7 @@ static void nfft_trafo_3d_B(X(plan) *ths)
 
   if(ths->flags & FG_PSI)
   {
-    R fg_exp_l[3*(2*m+2)];
+    R fg_exp_l[3*(2*m+2+1)];
 
     nfft_3d_init_fg_exp_l(fg_exp_l, m, ths->b[0]);
     nfft_3d_init_fg_exp_l(fg_exp_l+2*m+2, m, ths->b[1]);
@@ -5170,7 +5170,7 @@ static void nfft_adjoint_3d_B(X(plan) *ths)
 
   if(ths->flags & PRE_FG_PSI)
   {
-    R fg_exp_l[3*(2*m+2)];
+    R fg_exp_l[3*(2*m+2+1)];
 
     nfft_3d_init_fg_exp_l(fg_exp_l, m, ths->b[0]);
     nfft_3d_init_fg_exp_l(fg_exp_l+2*m+2, m, ths->b[1]);
@@ -5231,7 +5231,7 @@ static void nfft_adjoint_3d_B(X(plan) *ths)
 
   if(ths->flags & FG_PSI)
   {
-    R fg_exp_l[3*(2*m+2)];
+    R fg_exp_l[3*(2*m+2+1)];
 
     nfft_3d_init_fg_exp_l(fg_exp_l, m, ths->b[0]);
     nfft_3d_init_fg_exp_l(fg_exp_l+2*m+2, m, ths->b[1]);

--- a/kernel/nfst/nfst.c
+++ b/kernel/nfst/nfst.c
@@ -502,7 +502,7 @@ static inline void B_ ## which_one (X(plan) *ths) \
   R *fj; /* local copy */ \
   R y[ths->d]; \
   R fg_psi[ths->d][2*ths->m+2]; \
-  R fg_exp_l[ths->d][2*ths->m+2]; \
+  R fg_exp_l[ths->d][2*ths->m+2+1]; \
   INT l_fg,lj_fg; \
   R tmpEXP1, tmpEXP2, tmpEXP2sq, tmp1, tmp2, tmp3; \
   R ip_w; \

--- a/tests/util.c
+++ b/tests/util.c
@@ -48,35 +48,43 @@ void X(check_log2i)(void)
     INT j;
 
     {
-        INT r = Y(log2i)(0);
-        int ok = r == -1;
-        printf("log2i("__D__") = "__D__" -> %s\n", (INT)(0), r, ok ? "OK" : "FAIL");
-        CU_ASSERT(ok)
+      INT r = Y(log2i)(-1);
+      int ok = r == -1;
+      printf("log2i("__D__") = "__D__" -> %s\n", (INT)(-1), r, ok ? "OK" : "FAIL");
+      CU_ASSERT(ok)
     }
 
     {
-        INT r = Y(log2i)(-1);
-        int ok = r == -1;
-        printf("log2i("__D__") = "__D__" -> %s\n", (INT)(-1), r, ok ? "OK" : "FAIL");
-        CU_ASSERT(ok)
+      INT r = Y(log2i)(0);
+      int ok = r == -1;
+      printf("log2i("__D__") = "__D__" -> %s\n", (INT)(0), r, ok ? "OK" : "FAIL");
+      CU_ASSERT(ok)
     }
 
-    for (i = 0, j = 1; i < 8 * SIZEOF_PTRDIFF_T - 1; i++, j <<= 1)
     {
-        {
-            INT r = Y(log2i)(j);
-            INT r2 = _log2i(j);
-            int ok = r == r2;
-            printf("log2i("__D__") = "__D__" -> %s\n", j, r, ok ? "OK" : "FAIL");
-            CU_ASSERT(ok)
-        }
-        {
-            INT r = Y(log2i)(j - 1);
-            INT r2 = _log2i(j - 1);
-            int ok = r == r2;
-            printf("log2i("__D__") = "__D__" -> %s\n", j - 1, r, ok ? "OK" : "FAIL");
-            CU_ASSERT(ok)
-        }
+      INT r = Y(log2i)(1);
+      int ok = r == 0;
+      printf("log2i("__D__") = "__D__" -> %s\n", (INT)(1), r, ok ? "OK" : "FAIL");
+      CU_ASSERT(ok)
+    }
+
+    for (i = 0, j = 1; i < 8 * SIZEOF_PTRDIFF_T - 2; i++)
+    {
+      j <<= 1;
+      {
+        INT r = Y(log2i)(j);
+        INT r2 = _log2i(j);
+        int ok = r == r2;
+        printf("log2i("__D__") = "__D__" -> %s\n", j, r, ok ? "OK" : "FAIL");
+        CU_ASSERT(ok)
+      }
+      {
+        INT r = Y(log2i)(j - 1);
+        INT r2 = _log2i(j - 1);
+        int ok = r == r2;
+        printf("log2i("__D__") = "__D__" -> %s\n", j - 1, r, ok ? "OK" : "FAIL");
+        CU_ASSERT(ok)
+      }
     }
 }
 
@@ -119,35 +127,43 @@ void X(check_next_power_of_2)(void)
     INT j;
 
     {
-        INT r = Y(next_power_of_2)(0);
-        int ok = r == 1;
-        printf("next_power_of_2("__D__") = "__D__" -> %s\n", (INT)(0), r, ok ? "OK" : "FAIL");
-        CU_ASSERT(ok)
+      INT r = Y(next_power_of_2)(-1);
+      int ok = r == -1;
+      printf("next_power_of_2("__D__") = "__D__" -> %s\n", (INT)(-1), r, ok ? "OK" : "FAIL");
+      CU_ASSERT(ok)
     }
 
     {
-        INT r = Y(next_power_of_2)(-1);
-        int ok = r == -1;
-        printf("log2i("__D__") = "__D__" -> %s\n", (INT)(-1), r, ok ? "OK" : "FAIL");
-        CU_ASSERT(ok)
+      INT r = Y(next_power_of_2)(0);
+      int ok = r == 1;
+      printf("next_power_of_2("__D__") = "__D__" -> %s\n", (INT)(0), r, ok ? "OK" : "FAIL");
+      CU_ASSERT(ok)
     }
 
-    for (i = 0, j = 1; i < 8 * SIZEOF_PTRDIFF_T - 1; i++, j <<= 1)
     {
-        {
-            INT r = Y(next_power_of_2)(j);
-            INT r2 = _next_power_of_2(j);
-            int ok = r == r2;
-            printf("next_power_of_2("__D__") = "__D__" -> %s\n", j, r, ok ? "OK" : "FAIL");
-            CU_ASSERT(ok)
-        }
-        {
-            INT r = Y(next_power_of_2)(j - 1);
-            INT r2 = _next_power_of_2(j - 1);
-            int ok = r == r2;
-            printf("next_power_of_2("__D__") = "__D__" -> %s\n", j - 1, r, ok ? "OK" : "FAIL");
-            CU_ASSERT(ok)
-        }
+      INT r = Y(next_power_of_2)(1);
+      int ok = r == 2;
+      printf("next_power_of_2("__D__") = "__D__" -> %s\n", (INT)(1), r, ok ? "OK" : "FAIL");
+      CU_ASSERT(ok)
+    }
+
+    for (i = 0, j = 1; i < 8 * SIZEOF_PTRDIFF_T - 2; i++)
+    {
+      j <<= 1;
+      {
+        INT r = Y(next_power_of_2)(j);
+        INT r2 = _next_power_of_2(j);
+        int ok = r == r2;
+        printf("next_power_of_2("__D__") = "__D__" -> %s\n", j, r, ok ? "OK" : "FAIL");
+        CU_ASSERT(ok)
+      }
+      {
+        INT r = Y(next_power_of_2)(j - 1);
+        INT r2 = _next_power_of_2(j - 1);
+        int ok = r == r2;
+        printf("next_power_of_2("__D__") = "__D__" -> %s\n", j - 1, r, ok ? "OK" : "FAIL");
+        CU_ASSERT(ok)
+      }
     }
 }
 


### PR DESCRIPTION
When compiled with the Gaussian window function, the flag `PRE_FG_PSI` can be used to enable a particularly efficent pre-computation for NFFT/NFCT/NFST transformations. However, the two-dimensional array `fg_exp_l` which is used in this scheme seems to be too small by one element in the second dimension. This can result in out-of-bounds write access.

This PR bumps the size of the respective array so that no illegal access occurs anymore.

This fixes a segmentation fault that was first seen only under specific conditions on Linux/arm64.

I'm not sure the last element for each dimension is actually used in any computation. It's also possible that the array could actually be made smaller again by one element per dimension, but then the loops that write to the array would need to be adjusted.

Other changes in this PR:
- Set compiler flags in debugging mode that enable some sanitizers for checking array bounds et cetera. This can help find similar issues even when compiling with optimization flags.
- Fix an overflow issue in some unit tests.

