### PR TITLE
Add multi-threaded benchmarks.

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -29,7 +29,7 @@ jobs:
         compiler: ["gcc"]
         window: ["kaiserbessel", "gaussian", "bspline", "sinc"] # TODO: Add dirac.
         precision_opt: ["", "--enable-float", "--enable-long-double"]
-        openmp: [0, 1]
+        openmp: [1]
         build_octave: [0] # TODO: Re-activate Octave build and tests.
         build_julia: [1]
         include:

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -390,7 +390,11 @@ jobs:
         # instrumentation/simulation/memory to the same CODSPEED_ANALYSIS build,
         # so this is behavior- and benchmark-name-identical to the old value.
         mode: simulation
-        run: ./build-cmake/benchmarks/bench_nfft_direct
+        run: |
+          ./build-cmake/benchmarks/bench_nfft_direct
+          if [ -x ./build-cmake/benchmarks/bench_nfft_direct_omp ]; then
+            ./build-cmake/benchmarks/bench_nfft_direct_omp
+          fi
 
     - name: CMake — run-verify Julia staged simple_tests
       if: matrix.build_julia == '1' && matrix.precision_opt == ''
@@ -587,96 +591,3 @@ jobs:
           set -o pipefail
           ctest --test-dir build-cmake -L octave --output-on-failure 2>&1 \
             | tee build-cmake/ctest-octave.log
-
-  # Standalone run-once smoke: fresh-FetchContent codspeed build (the only place the
-  # GitHub-clone download path runs) + find_package consumer compile. NO CodSpeed
-  # upload (no CodSpeedHQ/action wrapper) — cannot perturb the CodSpeed profile.
-  # Deliberately NOT folded into the build matrix (single-shot smoke, not coverage).
-  cmake-bench:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y cmake ninja-build gcc g++ \
-            libfftw3-dev libfftw3-double3 libomp-dev
-
-      - name: Configure
-        run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DNFFT_ENABLE_BENCHMARKS=ON
-
-      - name: Build library + benchmark
-        run: cmake --build build -j
-
-      - name: Run benchmark (smoke only — NO CodSpeed upload)
-        run: ./build/benchmarks/bench_nfft_direct --benchmark_min_time=0.01s
-
-      - name: Install to staging prefix
-        run: |
-          cmake --install build --prefix "${{ github.workspace }}/_install"
-          test -f "${{ github.workspace }}/_install/include/nfft3.h"
-          ls "${{ github.workspace }}"/_install/lib*/cmake/nfft3/NFFT3Config.cmake
-
-      - name: Consumer find_package test
-        run: |
-          cmake -S cmake/consumer-tests/find_package -B build-consumer \
-            -DCMAKE_PREFIX_PATH="${{ github.workspace }}/_install"
-          cmake --build build-consumer -j
-          LD_LIBRARY_PATH="${{ github.workspace }}/_install/lib:${{ github.workspace }}/_install/lib/x86_64-linux-gnu" \
-            ./build-consumer/use_nfft3
-
-  # Standalone run-once smoke: per-precision symbol assertion + find_package probe.
-  # Deliberately NOT folded into the build matrix (single-shot smoke, not coverage).
-  cmake-precision:
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: float
-            flag: "-DNFFT_ENABLE_FLOAT=ON"
-            suffix: "f"
-          - name: long-double
-            flag: "-DNFFT_ENABLE_LONG_DOUBLE=ON"
-            suffix: "l"
-    name: "cmake-${{ matrix.name }}"
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y cmake ninja-build gcc \
-            libfftw3-dev libfftw3-single3 libfftw3-long3 libomp-dev
-
-      - name: Configure (${{ matrix.name }}, OpenMP on, no benchmarks)
-        run: |
-          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            ${{ matrix.flag }} -DNFFT_ENABLE_OPENMP=ON -DNFFT_ENABLE_BENCHMARKS=OFF
-
-      - name: Build (library + OpenMP variant)
-        run: cmake --build build -j
-
-      - name: Assert precision-mangled symbols
-        run: |
-          nm -D --defined-only build/kernel/libnfft3${{ matrix.suffix }}.so \
-            | grep -m1 " nfft${{ matrix.suffix }}_init$"
-
-      - name: Install to staging prefix
-        run: |
-          cmake --install build --prefix "${{ github.workspace }}/_install"
-          ls "${{ github.workspace }}"/_install/lib*/cmake/nfft3${{ matrix.suffix }}/NFFT3${{ matrix.suffix }}Config.cmake
-
-      - name: Per-precision find_package probe
-        run: |
-          cmake -S cmake/consumer-tests/precision_probe -B build-probe \
-            -DNFFT_PROBE_SUFFIX=${{ matrix.suffix }} \
-            -DCMAKE_PREFIX_PATH="${{ github.workspace }}/_install"
-          cmake --build build-probe -j
-          LD_LIBRARY_PATH="${{ github.workspace }}/_install/lib:${{ github.workspace }}/_install/lib/x86_64-linux-gnu" \
-            ./build-probe/use_nfft3_precision

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -19,7 +19,7 @@ jobs:
         compiler: ["gcc"]
         window: ["kaiserbessel", "gaussian", "bspline", "sinc"] # TODO: Add dirac.
         precision_opt: ["", "--enable-float", "--enable-long-double"]
-        openmp: [0, 1]
+        openmp: [1]
         build_octave: [0] # TODO: Re-activate Octave build and tests.
         build_julia: [1]
         include:
@@ -132,7 +132,7 @@ jobs:
       if: steps.cache-codspeed.outputs.cache-hit != 'true'
       run: |
         cd codspeed-cpp/google_benchmark
-        cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON -DCODSPEED_MODE=instrumentation -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_EXTENSIONS=OFF.
+        cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON -DCODSPEED_MODE=instrumentation -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_EXTENSIONS=OFF .
 
     - name: Build CodSpeed integration library
       if: steps.cache-codspeed.outputs.cache-hit != 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,6 @@ build/
 
 # macOS
 .DS_Store
+
+# JetBrains IDEs
+.idea

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -60,3 +60,26 @@ target_link_libraries(bench_nfft_direct PRIVATE nfft3 FFTW3::fftw3 benchmark::be
 if(UNIX)
   target_link_libraries(bench_nfft_direct PRIVATE m)
 endif()
+
+# OpenMP (threaded) benchmark variant.
+if(NFFT_ENABLE_OPENMP)
+  # The benchmark TU is C++, so it needs the CXX OpenMP flags — OpenMP::OpenMP_C
+  # (used for the library) gates -fopenmp on $<COMPILE_LANGUAGE:C> and would leave
+  # _OPENMP undefined here, collapsing SUFFIX to "" and silently producing a second
+  # copy of the *serial*-named benchmarks.
+  find_package(OpenMP COMPONENTS CXX REQUIRED)
+  add_executable(bench_nfft_direct_omp bench_nfft_direct.cpp util.h)
+  target_include_directories(bench_nfft_direct_omp PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+    ${NFFT_GENERATED_INCLUDE_DIR})            # config.h (BENCHMARKS_PREFIX, HAVE_FFTW_THREADS)
+  target_link_libraries(bench_nfft_direct_omp PRIVATE
+    nfft3_omp OpenMP::OpenMP_CXX FFTW3::fftw3 ${NFFT_OPENMP_ATOMIC_LIBS} benchmark::benchmark)
+  if(FFTW3_OMP_FOUND)
+    target_link_libraries(bench_nfft_direct_omp PRIVATE FFTW3::fftw3_omp)
+  elseif(FFTW3_THREADS_FOUND)
+    target_link_libraries(bench_nfft_direct_omp PRIVATE FFTW3::fftw3_threads)
+  endif()
+  if(UNIX)
+    target_link_libraries(bench_nfft_direct_omp PRIVATE m)
+  endif()
+endif()

--- a/benchmarks/Makefile.am
+++ b/benchmarks/Makefile.am
@@ -7,21 +7,38 @@ bench_nfft_direct_SOURCES = bench_nfft_direct.cpp util.h
 bench_nfft_direct_CXXFLAGS = @nfft_benchmarks_CXXFLAGS@ @CXXFLAGS@
 bench_nfft_direct_LDFLAGS = @nfft_benchmarks_LDFLAGS@ @fftw3_LDFLAGS@ @LDFLAGS@
 bench_nfft_direct_LDADD = @nfft_benchmarks_LIBS@ $(top_builddir)/libnfft3@PREC_SUFFIX@.la @fftw3_LIBS@ @LIBS@
-else
-  NFFT_BENCHMARKS_DIRECT =
+if ENABLE_OPENMP
+NFFT_BENCHMARKS_DIRECT_OMP = bench_nfft_direct_omp
+bench_nfft_direct_omp_SOURCES = bench_nfft_direct.cpp util.h
+bench_nfft_direct_omp_CXXFLAGS = @nfft_benchmarks_CXXFLAGS@ $(OPENMP_CFLAGS) @CXXFLAGS@
+bench_nfft_direct_omp_LDFLAGS = @nfft_benchmarks_LDFLAGS@ @fftw3_LDFLAGS@ $(OPENMP_CFLAGS) @LDFLAGS@
+bench_nfft_direct_omp_LDADD = @nfft_benchmarks_LIBS@ $(top_builddir)/libnfft3@PREC_SUFFIX@_omp.la @fftw3_LIBS_omp@ @fftw3_LIBS@ $(OPENMP_LIBS)
 endif
 else
   NFFT_BENCHMARKS_DIRECT =
+  NFFT_BENCHMARKS_DIRECT_OMP =
+endif
+else
+  NFFT_BENCHMARKS_DIRECT =
+  NFFT_BENCHMARKS_DIRECT_OMP =
 endif
 
 # Aggregate all benchmarks
 NFFT_BENCHMARKS = $(NFFT_BENCHMARKS_DIRECT)
 
-noinst_PROGRAMS = $(NFFT_BENCHMARKS)
+if ENABLE_OPENMP
+NFFT_BENCHMARKS_OMP = $(NFFT_BENCHMARKS_DIRECT_OMP)
+endif
+
+noinst_PROGRAMS = $(NFFT_BENCHMARKS) $(NFFT_BENCHMARKS_OMP)
 
 # Run all built benchmarks
-bench: $(NFFT_BENCHMARKS)
+bench: $(NFFT_BENCHMARKS) $(NFFT_BENCHMARKS_OMP)
 	for bench in $(NFFT_BENCHMARKS); do \
+		echo "Running $$bench..."; \
+		./$$bench; \
+	done
+	for bench in $(NFFT_BENCHMARKS_OMP); do \
 		echo "Running $$bench..."; \
 		./$$bench; \
 	done

--- a/benchmarks/bench_nfft_direct.cpp
+++ b/benchmarks/bench_nfft_direct.cpp
@@ -27,8 +27,30 @@
 
 #include "util.h"
 
+#ifdef _OPENMP
+  #define SUFFIX "_omp"
+#else
+  #define SUFFIX ""
+#endif
+
+static void DoSetup(const benchmark::State& state) {
+    #ifdef _OPENMP
+    #ifdef HAVE_FFTW_THREADS
+    FFTW(init_threads)();
+    #endif  
+    #endif
+}
+
+static void DoTeardown(const benchmark::State& state) {
+    #ifdef _OPENMP
+    #ifdef HAVE_FFTW_THREADS
+    FFTW(cleanup_threads)();
+    #endif
+    #endif
+}
+
 // Helper function to initialize random data
-static void NFFT(init_random_data)(NFFT(plan)* plan) {
+static void init_random_data(NFFT(plan)* plan) {
     NFFT(vrand_shifted_unit_double)(plan->x, plan->d * plan->M_total);
     NFFT(vrand_unit_complex)(plan->f_hat, plan->N_total);
     NFFT(vrand_unit_complex)(plan->f, plan->M_total);
@@ -41,7 +63,7 @@ static void nfft_forward_direct_1d(benchmark::State& state) {
     
     NFFT(plan) plan;
     NFFT(init_1d)(&plan, N, M);
-    NFFT(init_random_data)(&plan);
+    init_random_data(&plan);
     
     for (auto _ : state) {
         NFFT(trafo_direct)(&plan);
@@ -58,7 +80,7 @@ static void nfft_adjoint_direct_1d(benchmark::State& state) {
     
     NFFT(plan) plan;
     NFFT(init_1d)(&plan, N, M);
-    NFFT(init_random_data)(&plan);
+    init_random_data(&plan);
     
     for (auto _ : state) {
         NFFT(adjoint_direct)(&plan);
@@ -76,7 +98,7 @@ static void nfft_forward_direct_2d(benchmark::State& state) {
     
     NFFT(plan) plan;
     NFFT(init_2d)(&plan, N1, N2, M);
-    NFFT(init_random_data)(&plan);
+    init_random_data(&plan);
     
     for (auto _ : state) {
         NFFT(trafo_direct)(&plan);
@@ -94,7 +116,7 @@ static void nfft_adjoint_direct_2d(benchmark::State& state) {
     
     NFFT(plan) plan;
     NFFT(init_2d)(&plan, N1, N2, M);
-    NFFT(init_random_data)(&plan);
+    init_random_data(&plan);
     
     for (auto _ : state) {
         NFFT(adjoint_direct)(&plan);
@@ -113,7 +135,7 @@ static void nfft_forward_direct_3d(benchmark::State& state) {
     
     NFFT(plan) plan;
     NFFT(init_3d)(&plan, N1, N2, N3, M);
-    NFFT(init_random_data)(&plan);
+    init_random_data(&plan);
     
     for (auto _ : state) {
         NFFT(trafo_direct)(&plan);
@@ -132,7 +154,7 @@ static void nfft_adjoint_direct_3d(benchmark::State& state) {
     
     NFFT(plan) plan;
     NFFT(init_3d)(&plan, N1, N2, N3, M);
-    NFFT(init_random_data)(&plan);
+    init_random_data(&plan);
     
     for (auto _ : state) {
         NFFT(adjoint_direct)(&plan);
@@ -143,44 +165,56 @@ static void nfft_adjoint_direct_3d(benchmark::State& state) {
 }
 
 // Register benchmarks for direct transforms
-BENCH(nfft_forward_direct_1d)
+BENCH(nfft_forward_direct_1d, SUFFIX)
     ->Args({32, 100})
     ->Args({64, 200})
     ->Args({128, 400})
     ->Args({256, 800})
     ->Args({512, 1600})
+    ->Setup(DoSetup)
+    ->Teardown(DoTeardown)
     ->Complexity();
 
-BENCH(nfft_adjoint_direct_1d)
+BENCH(nfft_adjoint_direct_1d, SUFFIX)
     ->Args({32, 100})
     ->Args({64, 200})
     ->Args({128, 400})
     ->Args({256, 800})
     ->Args({512, 1600})
+    ->Setup(DoSetup)
+    ->Teardown(DoTeardown)
     ->Complexity();
 
-BENCH(nfft_forward_direct_2d)
+BENCH(nfft_forward_direct_2d, SUFFIX)
     ->Args({16, 16, 500})
     ->Args({32, 32, 1000})
     ->Args({64, 64, 2000})
+    ->Setup(DoSetup)
+    ->Teardown(DoTeardown)
     ->Complexity();
 
-BENCH(nfft_adjoint_direct_2d)
+BENCH(nfft_adjoint_direct_2d, SUFFIX)
     ->Args({16, 16, 500})
     ->Args({32, 32, 1000})
     ->Args({64, 64, 2000})
+    ->Setup(DoSetup)
+    ->Teardown(DoTeardown)
     ->Complexity();
 
-BENCH(nfft_forward_direct_3d)
+BENCH(nfft_forward_direct_3d, SUFFIX)
     ->Args({4, 4, 4, 250})
     ->Args({8, 8, 8, 500})
     ->Args({16, 16, 16, 1000})
+    ->Setup(DoSetup)
+    ->Teardown(DoTeardown)
     ->Complexity();
 
-BENCH(nfft_adjoint_direct_3d)
+BENCH(nfft_adjoint_direct_3d, SUFFIX)
     ->Args({4, 4, 4, 250})
     ->Args({8, 8, 8, 500})
     ->Args({16, 16, 16, 1000})
+    ->Setup(DoSetup)
+    ->Teardown(DoTeardown)
     ->Complexity();
 
 // Main function.

--- a/benchmarks/util.h
+++ b/benchmarks/util.h
@@ -22,6 +22,6 @@
 #include "config.h"
 
 // Macro to register benchmark with optional prefix.
-#define BENCH(function) BENCHMARK(function)->Name(BENCHMARKS_PREFIX #function)
+#define BENCH(function) BENCHMARK(function, suffix)->Name(BENCHMARKS_PREFIX #function suffix)
 
 #endif // NFFT_BENCHMARKS_UTIL_H

--- a/benchmarks/util.h
+++ b/benchmarks/util.h
@@ -22,6 +22,6 @@
 #include "config.h"
 
 // Macro to register benchmark with optional prefix.
-#define BENCH(function) BENCHMARK(function, suffix)->Name(BENCHMARKS_PREFIX #function suffix)
+#define BENCH(function, suffix) BENCHMARK(function)->Name(BENCHMARKS_PREFIX #function suffix)
 
 #endif // NFFT_BENCHMARKS_UTIL_H

--- a/benchmarks/util.h
+++ b/benchmarks/util.h
@@ -22,6 +22,6 @@
 #include "config.h"
      
 // Macro to register benchmark with optional prefix
-#define BENCH(function) BENCHMARK(function)->Name("benchmarks/" __FILE__ "::" BENCHMARKS_PREFIX #function)
+#define BENCH(function, suffix) BENCHMARK(function)->Name("benchmarks/" __FILE__ "::" BENCHMARKS_PREFIX #function suffix)
 
 #endif // NFFT_BENCHMARKS_UTIL_H


### PR DESCRIPTION
This PR adds threaded versions of the existing NDFT benchmarks.

I have removed the non-OpenMP build jobs where an OpenMP version is available since building with OpenMP is only additive. There's no benefit of keeping the non-OpenMP jobs because we will now just run multi-threaded benchmarks if possible, in addition to the regular ones.