### PR TITLE
Add release drafter workflow.

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -1,0 +1,29 @@
+name-template: '$NEXT_PATCH_VERSION'
+tag-template: '$NEXT_PATCH_VERSION'
+categories:
+  - title: 'Added'
+    labels:
+      - 'feat'
+  - title: 'Changed'
+    labels:
+      - 'refactor'
+      - 'style'
+  - title: 'Removed'
+    labels:
+      - 'removal'
+  - title: 'Fixed'
+    labels:
+      - 'bug'
+      - 'fix'
+  - title: 'Deprecated'
+    labels:
+      - 'deprecation'
+  - title: Documentation
+    labels:
+      - 'docs'
+  - title: Chores
+    labels:
+      - 'chore'
+template: |
+  # What’s Changed
+  $CHANGES

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,24 @@
+name: Draft Release
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  draft-release:
+    name: Draft a new release
+    permissions:
+      # Write permissions are required to create a GitHub release.
+      contents: write
+      # Write permissions are required for autolabeler
+      # otherwise, read permissions are required, at least.
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "develop"
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter-config.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a new workflow that runs on every merge to `develop`. It then creates or updates a draft GitHub release for the next patch version with a changelog based on PRs merged.

I have used this action in other projects and it was a good way to keep a list of changes since the last release. However, one must typically review and adjust the change log before a release since PR titles and descriptions are not always best suited for a changelog.