### PR TITLE
CodSpeed toolchain, git-lfs, and preinstalled Cl Claude Code extensions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -32,9 +32,10 @@ RUN groupadd --gid 2000 vscode \
     clang \
     libomp-dev \
     libatomic1 \
-    git \
+    valgrind \
     curl \
     wget \
+    git-lfs \
     ca-certificates \
     autotools-dev \
     autoconf \
@@ -70,3 +71,19 @@ RUN curl -fsSL https://install.julialang.org | sh -s -- -y \
 
 # Install RTK.
 RUN curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh
+
+# Install the CodSpeed CLI (drives the instrumented benchmarks on the CodSpeed /
+# simulation track). Installs to ~/.cargo/bin and adds it to PATH.
+RUN curl -fsSL https://codspeed.io/install.sh | sh
+ENV PATH="/home/vscode/.cargo/bin:${PATH}"
+
+# Install CodSpeed's Valgrind fork — the simulation/instrumentation instrument
+# requires it (stock valgrind is rejected as "not a CodSpeed build"). On Ubuntu the
+# CLI fetches and apt-installs the prebuilt .deb (resolving deps) over /usr/bin/valgrind;
+# run as root so it installs without sudo — `codspeed setup` checks geteuid and skips
+# sudo when already root (the vscode user only gains sudo later, via the common-utils
+# feature). The stock `valgrind` from apt above is the safety net if this step is
+# skipped; `codspeed setup status` should then report a "codspeed build" of valgrind.
+USER root
+RUN /home/vscode/.cargo/bin/codspeed setup --mode simulation
+USER vscode

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,7 @@
         "ghcr.io/devcontainers/features/github-cli:1.1.0": {},
         "ghcr.io/anthropics/devcontainer-features/claude-code:1.0.5": {}
     },
-    "postCreateCommand": "mkdir -p ~/.claude && sh -c 'echo \"n\" | rtk init -g --auto-patch' && sh -c 'touch ~/.gitignore && grep -qxF .DS_Store ~/.gitignore || printf \"%s\\n\" .DS_Store >> ~/.gitignore'",
+    "postCreateCommand": "mkdir -p ~/.claude && sh -c 'echo \"n\" | rtk init -g --auto-patch' && sh -c 'touch ~/.gitignore && grep -qxF .DS_Store ~/.gitignore || printf \"%s\\n\" .DS_Store >> ~/.gitignore' && bash .devcontainer/setup-claude-extensions.sh",
     "remoteUser": "vscode",
     "containerUser": "vscode"
 }

--- a/.devcontainer/setup-claude-extensions.sh
+++ b/.devcontainer/setup-claude-extensions.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# Install a well-defined set of Claude Code plugins and skills into the dev
+# container so a freshly started container has them by default.
+#
+# Runs from devcontainer.json's postCreateCommand, i.e. AFTER the
+# ghcr.io/anthropics/devcontainer-features/claude-code feature has installed the
+# `claude` CLI and Node/npx. Scope is user-level (~/.claude); the script is
+# idempotent (safe to re-run) and never aborts container creation on a failed
+# install — it warns and continues, then re-running picks up whatever is missing.
+#
+# What it installs:
+#   Plugins (via `claude plugin install`, from the auto-known official marketplace):
+#     - superpowers@claude-plugins-official   (Anthropic's Superpowers)
+#     - codspeed@claude-plugins-official       (CodSpeed)
+#   Skills (via Vercel's `skills` CLI, https://github.com/vercel-labs/skills):
+#     - mattpocock/skills                      (Matt Pocock's skills)
+#     - shadcn/improve                         (shadcn Improve skill)
+
+set -u
+
+MARKETPLACE="claude-plugins-official"
+PLUGINS=(
+  "superpowers@${MARKETPLACE}"
+  "codspeed@${MARKETPLACE}"
+)
+# GitHub owner/repo[/subpath] shorthand resolved by the `skills` CLI.
+SKILL_SOURCES=(
+  "mattpocock/skills"
+  "shadcn/improve"
+)
+
+failures=0
+
+log()  { printf '[claude-extensions] %s\n' "$*"; }
+warn() { printf '[claude-extensions] WARNING: %s\n' "$*" >&2; failures=$((failures + 1)); }
+
+# Run a command; log ✓/✗ but never abort the script.
+try() {
+  local label="$1"; shift
+  if "$@"; then
+    log "✓ ${label}"
+  else
+    warn "✗ ${label} (exit $?) — continuing; re-run this script to retry"
+  fi
+}
+
+# --- Preflight -------------------------------------------------------------
+# Tooling is provided by the claude-code devcontainer feature. If it's absent,
+# the feature ordering is wrong; warn loudly but don't fail container creation.
+if ! command -v claude >/dev/null 2>&1; then
+  warn "'claude' CLI not found on PATH — skipping plugin install."
+  CLAUDE_OK=0
+else
+  CLAUDE_OK=1
+fi
+if ! command -v npx >/dev/null 2>&1; then
+  warn "'npx' not found on PATH — skipping skills install."
+  NPX_OK=0
+else
+  NPX_OK=1
+fi
+
+# --- Plugins ---------------------------------------------------------------
+if [ "${CLAUDE_OK}" = "1" ]; then
+  # The official marketplace is auto-known, but ensure it's registered so a
+  # pristine ~/.claude still resolves plugin@marketplace. `marketplace add` on an
+  # already-known marketplace is a no-op-ish error, so tolerate it.
+  if ! claude plugin marketplace list 2>/dev/null | grep -q "${MARKETPLACE}"; then
+    try "marketplace add ${MARKETPLACE}" \
+      claude plugin marketplace add "anthropics/${MARKETPLACE}"
+  fi
+
+  # Snapshot already-installed plugins to keep re-runs quiet.
+  installed_plugins="$(claude plugin list 2>/dev/null || true)"
+  for plugin in "${PLUGINS[@]}"; do
+    if printf '%s\n' "${installed_plugins}" | grep -q "${plugin%@*}"; then
+      log "• ${plugin} already installed — skipping"
+      continue
+    fi
+    try "install ${plugin}" \
+      claude plugin install "${plugin}" --scope user
+  done
+fi
+
+# --- Skills ----------------------------------------------------------------
+if [ "${NPX_OK}" = "1" ]; then
+  for src in "${SKILL_SOURCES[@]}"; do
+    # --skill '*'        : take every skill in the source repo
+    # --agent claude-code: deterministic target (don't rely on auto-detection)
+    # --global           : install into ~/.claude/skills
+    # --yes              : accept defaults, no prompts
+    try "skills add ${src}" \
+      npx -y skills@latest add "${src}" \
+        --skill '*' --agent claude-code --global --yes
+  done
+fi
+
+# --- Summary ---------------------------------------------------------------
+if [ "${failures}" -eq 0 ]; then
+  log "All plugins and skills installed."
+else
+  log "Finished with ${failures} issue(s); container creation not blocked. Re-run to retry."
+fi
+
+# Always succeed: a transient install failure must not break the dev environment.
+exit 0


### PR DESCRIPTION
Consolidates the .devcontainer changes developed on feature/coding-agents so they can land independently of that branch's test/docs work.

Dockerfile:
- Use git from the devcontainer feature (drop the manual install).
- Install the CodSpeed CLI and CodSpeed's Valgrind fork (required by the simulation/instrumentation benchmark instrument; stock valgrind is rejected).
- Add git-lfs (the CodSpeed plugin marketplace repo is LFS-backed; plugin install fails with "git-lfs: not found" without it).

devcontainer.json / setup-claude-extensions.sh:
- New idempotent postCreate installer that preinstalls a defined set of Claude Code extensions unattended: superpowers and codspeed plugins via `claude plugin install --scope user`, plus mattpocock/skills and shadcn/improve via Vercel's `skills` CLI. Failures warn and continue so a transient network issue never blocks container creation.