### PR TITLE
Optimize 1D direct NFFT by carrying the phase by recurrence.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@
 
 # Log files
 *.log
+# ...but keep curated perf-engineering run logs (test/benchmark evidence under docs/perfeng/)
+!docs/perfeng/**/*.log
 
 # Autosave files
 *.asv

--- a/docs/perfeng/0001-trafo-direct/README.md
+++ b/docs/perfeng/0001-trafo-direct/README.md
@@ -1,0 +1,29 @@
+# Perf: `X(trafo_direct)` — reduce per-call cost of the direct NDFT
+
+- **Target:** `X(trafo_direct)()` — kernel/nfft/nfft.c:145
+- **Track:** walltime
+- **Baseline commit:** a692216c
+- **Status:** complete (with caveat)   <!-- in-progress | complete | reverted -->
+- **Outcome:** Phase recurrence (cos/sin → one complex multiply) on the 1d forward path: **~1.3× double, ~1.6× float, ~3.9× long double**; 116-case net green in all three precisions. **Caveat:** a reproducible **+8% float regression** on the untouched `adjoint_direct_1d[32/100]` micro-benchmark (code-layout/i-cache effect) trips the exit gate — reviewer decides ship/fix/revert. Double-only would have missed it.
+
+## Phase status
+
+| Phase | Status | Deliverable | Exit signal |
+|-------|--------|-------------|-------------|
+| Preflight          | ✅ | [preflight.md](preflight.md)                         | track = walltime |
+| Phase A — baseline | ✅ | [phase-a-baseline.md](phase-a-baseline.md)           | green d/f/l (1854/1843/1854); 22 cases × 3 |
+| Phase B — net      | ✅ | [phase-b-correctness-net.md](phase-b-correctness-net.md) | 116-case net pinned (suite `nfft`) |
+| Phase C — metric   | ✅ | [phase-c-performance-metric.md](phase-c-performance-metric.md) | metric = `nfft_forward_direct_1d[*]` (10× under slowdown) |
+| Phase D — inner    | ✅ | [phase-d-inner-loop.md](phase-d-inner-loop.md)       | recurrence; net green d/f/l; 1.3×/1.6×/3.9× |
+| Phase E — exit     | ✅ | [phase-e-exit-gate.md](phase-e-exit-gate.md)         | landed-with-caveat: target 1.3×/1.6×/3.9×; 1 float layout regression |
+
+<!-- Status: ⬜ todo · 🔄 in-progress · ✅ done · ⛔ blocked. A ⛔ on any row ⇒ header Status = reverted. -->
+
+## Log
+
+- 2026-06-16 — created; baseline commit a692216c; Preflight: walltime (no CodSpeed MCP/CLI).
+- 2026-06-16 — precision matrix enabled: build float·double·long-double (stale in-source config.h cleared first).
+- 2026-06-16 — Phase A green d/f/l (1854/1843/1854, 22 bench cases ×3). Long double ~250× slower than double (COSL/SINL).
+- 2026-06-16 — Phase B: 116-case net. Phase C: metric = forward_direct_1d[*].
+- 2026-06-16 — Phase D: recurrence; net green d/f/l; speedup 1.3×/1.6×/3.9× (precision-dependent).
+- 2026-06-16 — Phase E: tests green d/f/l; **float adjoint_1d[32/100] +8% layout regression (confirmed)**; landed-with-caveat. summary.html written.

--- a/docs/perfeng/0001-trafo-direct/artifacts/baseline-bench-d.json
+++ b/docs/perfeng/0001-trafo-direct/artifacts/baseline-bench-d.json
@@ -1,0 +1,564 @@
+[
+  {
+    "creator": {
+      "name": "codspeed-cpp",
+      "version": "2.3.0",
+      "pid": 50728
+    },
+    "instrument": {
+      "type": "walltime"
+    },
+    "benchmarks": [
+      {
+        "name": "nfft_forward_direct_1d[32/100]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_1d[32/100]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 7661.16,
+          "max_ns": 7727.52,
+          "mean_ns": 7695.52,
+          "stdev_ns": 24.3813,
+          "q1_ns": 7678.07,
+          "median_ns": 7693.88,
+          "q3_ns": 7716.98,
+          "rounds": 5,
+          "total_time": 3.27645,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 85152,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_1d[64/200]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_1d[64/200]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 29290.3,
+          "max_ns": 29632.7,
+          "mean_ns": 29425.1,
+          "stdev_ns": 149.791,
+          "q1_ns": 29297.7,
+          "median_ns": 29323.6,
+          "q3_ns": 29581.3,
+          "rounds": 5,
+          "total_time": 3.52925,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 23988,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_1d[128/400]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_1d[128/400]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 116309,
+          "max_ns": 117016,
+          "mean_ns": 116590,
+          "stdev_ns": 264.622,
+          "q1_ns": 116410,
+          "median_ns": 116439,
+          "q3_ns": 116774,
+          "rounds": 5,
+          "total_time": 3.35545,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 5756,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_1d[256/800]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_1d[256/800]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 463261,
+          "max_ns": 466618,
+          "mean_ns": 464915,
+          "stdev_ns": 1207.09,
+          "q1_ns": 463855,
+          "median_ns": 465332,
+          "q3_ns": 465510,
+          "rounds": 5,
+          "total_time": 3.47292,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 1494,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_1d[512/1600]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_1d[512/1600]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 1.85209E+6,
+          "max_ns": 1.86811E+6,
+          "mean_ns": 1.85996E+6,
+          "stdev_ns": 6586.13,
+          "q1_ns": 1.85231E+6,
+          "median_ns": 1.86245E+6,
+          "q3_ns": 1.86484E+6,
+          "rounds": 5,
+          "total_time": 3.53392,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 380,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_1d[32/100]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_1d[32/100]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 8437.45,
+          "max_ns": 8719.07,
+          "mean_ns": 8506.78,
+          "stdev_ns": 106.718,
+          "q1_ns": 8446.15,
+          "median_ns": 8463.92,
+          "q3_ns": 8467.31,
+          "rounds": 5,
+          "total_time": 3.54205,
+          "iqr_outlier_rounds": 1,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 83276,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_1d[64/200]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_1d[64/200]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 31323.8,
+          "max_ns": 31572.9,
+          "mean_ns": 31426,
+          "stdev_ns": 87.5386,
+          "q1_ns": 31367.8,
+          "median_ns": 31395.3,
+          "q3_ns": 31470.3,
+          "rounds": 5,
+          "total_time": 3.49819,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 22263,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_1d[128/400]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_1d[128/400]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 123992,
+          "max_ns": 125055,
+          "mean_ns": 124509,
+          "stdev_ns": 423.166,
+          "q1_ns": 124172,
+          "median_ns": 124373,
+          "q3_ns": 124954,
+          "rounds": 5,
+          "total_time": 3.44082,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 5527,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_1d[256/800]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_1d[256/800]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 501252,
+          "max_ns": 505685,
+          "mean_ns": 502936,
+          "stdev_ns": 1537.04,
+          "q1_ns": 501753,
+          "median_ns": 502903,
+          "q3_ns": 503085,
+          "rounds": 5,
+          "total_time": 2.51468,
+          "iqr_outlier_rounds": 1,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 1000,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_1d[512/1600]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_1d[512/1600]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 1.99246E+6,
+          "max_ns": 2.01474E+6,
+          "mean_ns": 2.00283E+6,
+          "stdev_ns": 8600.61,
+          "q1_ns": 1.9934E+6,
+          "median_ns": 2.00618E+6,
+          "q3_ns": 2.00736E+6,
+          "rounds": 5,
+          "total_time": 3.51496,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 351,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_2d[16/16/500]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_2d[16/16/500]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 1.29936E+6,
+          "max_ns": 1.34049E+6,
+          "mean_ns": 1.31756E+6,
+          "stdev_ns": 15962,
+          "q1_ns": 1.30394E+6,
+          "median_ns": 1.3122E+6,
+          "q3_ns": 1.3318E+6,
+          "rounds": 5,
+          "total_time": 3.62329,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 550,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_2d[32/32/1000]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_2d[32/32/1000]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 1.03005E+7,
+          "max_ns": 1.06289E+7,
+          "mean_ns": 1.03768E+7,
+          "stdev_ns": 127132,
+          "q1_ns": 1.0304E+7,
+          "median_ns": 1.03051E+7,
+          "q3_ns": 1.03456E+7,
+          "rounds": 5,
+          "total_time": 3.47624,
+          "iqr_outlier_rounds": 1,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 67,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_2d[64/64/2000]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_2d[64/64/2000]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 6.66119E+7,
+          "max_ns": 6.72823E+7,
+          "mean_ns": 6.69241E+7,
+          "stdev_ns": 224405,
+          "q1_ns": 6.67983E+7,
+          "median_ns": 6.69046E+7,
+          "q3_ns": 6.70233E+7,
+          "rounds": 5,
+          "total_time": 3.3462,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 10,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_2d[16/16/500]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_2d[16/16/500]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 1.21702E+6,
+          "max_ns": 1.3167E+6,
+          "mean_ns": 1.2627E+6,
+          "stdev_ns": 33902.5,
+          "q1_ns": 1.24046E+6,
+          "median_ns": 1.26093E+6,
+          "q3_ns": 1.2784E+6,
+          "rounds": 5,
+          "total_time": 3.30828,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 524,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_2d[32/32/1000]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_2d[32/32/1000]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 9.86135E+6,
+          "max_ns": 9.9757E+6,
+          "mean_ns": 9.90422E+6,
+          "stdev_ns": 41631.8,
+          "q1_ns": 9.8772E+6,
+          "median_ns": 9.8812E+6,
+          "q3_ns": 9.92565E+6,
+          "rounds": 5,
+          "total_time": 3.516,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 71,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_2d[64/64/2000]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_2d[64/64/2000]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 6.53818E+7,
+          "max_ns": 6.59444E+7,
+          "mean_ns": 6.5579E+7,
+          "stdev_ns": 199041,
+          "q1_ns": 6.54464E+7,
+          "median_ns": 6.55001E+7,
+          "q3_ns": 6.56226E+7,
+          "rounds": 5,
+          "total_time": 3.60685,
+          "iqr_outlier_rounds": 1,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 11,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_3d[4/4/4/250]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_3d[4/4/4/250]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 94925.2,
+          "max_ns": 99549.1,
+          "mean_ns": 96833.4,
+          "stdev_ns": 1643.77,
+          "q1_ns": 95599.4,
+          "median_ns": 96383.2,
+          "q3_ns": 97709.9,
+          "rounds": 5,
+          "total_time": 3.42015,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 7064,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_3d[8/8/8/500]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_3d[8/8/8/500]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 3.19037E+6,
+          "max_ns": 3.21671E+6,
+          "mean_ns": 3.20771E+6,
+          "stdev_ns": 9131.03,
+          "q1_ns": 3.20849E+6,
+          "median_ns": 3.20968E+6,
+          "q3_ns": 3.21327E+6,
+          "rounds": 5,
+          "total_time": 3.44828,
+          "iqr_outlier_rounds": 1,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 215,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_3d[16/16/16/1000]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_3d[16/16/16/1000]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 4.19548E+7,
+          "max_ns": 4.2237E+7,
+          "mean_ns": 4.21111E+7,
+          "stdev_ns": 108844,
+          "q1_ns": 4.20413E+7,
+          "median_ns": 4.20938E+7,
+          "q3_ns": 4.22285E+7,
+          "rounds": 5,
+          "total_time": 3.36888,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 16,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_3d[4/4/4/250]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_3d[4/4/4/250]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 95799.5,
+          "max_ns": 98639.6,
+          "mean_ns": 97874.6,
+          "stdev_ns": 1056.46,
+          "q1_ns": 98054.4,
+          "median_ns": 98345.6,
+          "q3_ns": 98534.1,
+          "rounds": 5,
+          "total_time": 3.57536,
+          "iqr_outlier_rounds": 1,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 7306,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_3d[8/8/8/500]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_3d[8/8/8/500]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 3.03878E+6,
+          "max_ns": 3.09745E+6,
+          "mean_ns": 3.07476E+6,
+          "stdev_ns": 20589.7,
+          "q1_ns": 3.06708E+6,
+          "median_ns": 3.08132E+6,
+          "q3_ns": 3.08919E+6,
+          "rounds": 5,
+          "total_time": 3.30537,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 215,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_3d[16/16/16/1000]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_3d[16/16/16/1000]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 4.01034E+7,
+          "max_ns": 4.05597E+7,
+          "mean_ns": 4.02677E+7,
+          "stdev_ns": 165137,
+          "q1_ns": 4.01173E+7,
+          "median_ns": 4.02548E+7,
+          "q3_ns": 4.03034E+7,
+          "rounds": 5,
+          "total_time": 3.42276,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 17,
+          "warmup_iters": 0
+        }
+      }
+    ]
+  }
+]

--- a/docs/perfeng/0001-trafo-direct/artifacts/baseline-bench-f.json
+++ b/docs/perfeng/0001-trafo-direct/artifacts/baseline-bench-f.json
@@ -1,0 +1,564 @@
+[
+  {
+    "creator": {
+      "name": "codspeed-cpp",
+      "version": "2.3.0",
+      "pid": 51233
+    },
+    "instrument": {
+      "type": "walltime"
+    },
+    "benchmarks": [
+      {
+        "name": "nfft_forward_direct_1d[32/100]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_1d[32/100]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 7713.39,
+          "max_ns": 7883.14,
+          "mean_ns": 7788.92,
+          "stdev_ns": 55.9682,
+          "q1_ns": 7762.57,
+          "median_ns": 7779.41,
+          "q3_ns": 7806.11,
+          "rounds": 5,
+          "total_time": 3.51074,
+          "iqr_outlier_rounds": 1,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 90147,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_1d[64/200]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_1d[64/200]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 32779.9,
+          "max_ns": 33190.7,
+          "mean_ns": 32893.3,
+          "stdev_ns": 151.184,
+          "q1_ns": 32804.7,
+          "median_ns": 32829.2,
+          "q3_ns": 32861.9,
+          "rounds": 5,
+          "total_time": 3.49622,
+          "iqr_outlier_rounds": 1,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 21258,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_1d[128/400]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_1d[128/400]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 132960,
+          "max_ns": 133887,
+          "mean_ns": 133406,
+          "stdev_ns": 321.715,
+          "q1_ns": 133244,
+          "median_ns": 133304,
+          "q3_ns": 133633,
+          "rounds": 5,
+          "total_time": 3.4432,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 5162,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_1d[256/800]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_1d[256/800]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 539193,
+          "max_ns": 542747,
+          "mean_ns": 540795,
+          "stdev_ns": 1403.1,
+          "q1_ns": 539211,
+          "median_ns": 541102,
+          "q3_ns": 541723,
+          "rounds": 5,
+          "total_time": 3.50976,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 1298,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_1d[512/1600]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_1d[512/1600]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 2.21986E+6,
+          "max_ns": 2.23529E+6,
+          "mean_ns": 2.2247E+6,
+          "stdev_ns": 5655.61,
+          "q1_ns": 2.22013E+6,
+          "median_ns": 2.22293E+6,
+          "q3_ns": 2.22529E+6,
+          "rounds": 5,
+          "total_time": 3.52615,
+          "iqr_outlier_rounds": 1,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 317,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_1d[32/100]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_1d[32/100]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 7822.6,
+          "max_ns": 7915.78,
+          "mean_ns": 7854.56,
+          "stdev_ns": 33.1722,
+          "q1_ns": 7828.13,
+          "median_ns": 7849.3,
+          "q3_ns": 7856.96,
+          "rounds": 5,
+          "total_time": 3.50997,
+          "iqr_outlier_rounds": 1,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 89374,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_1d[64/200]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_1d[64/200]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 33145.9,
+          "max_ns": 33433.6,
+          "mean_ns": 33247.2,
+          "stdev_ns": 113.337,
+          "q1_ns": 33155.9,
+          "median_ns": 33176.6,
+          "q3_ns": 33323.9,
+          "rounds": 5,
+          "total_time": 3.51506,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 21145,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_1d[128/400]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_1d[128/400]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 134315,
+          "max_ns": 134983,
+          "mean_ns": 134766,
+          "stdev_ns": 245.744,
+          "q1_ns": 134729,
+          "median_ns": 134820,
+          "q3_ns": 134982,
+          "rounds": 5,
+          "total_time": 3.51267,
+          "iqr_outlier_rounds": 1,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 5213,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_1d[256/800]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_1d[256/800]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 547110,
+          "max_ns": 549866,
+          "mean_ns": 547973,
+          "stdev_ns": 968.95,
+          "q1_ns": 547550,
+          "median_ns": 547651,
+          "q3_ns": 547687,
+          "rounds": 5,
+          "total_time": 3.50977,
+          "iqr_outlier_rounds": 2,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 1281,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_1d[512/1600]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_1d[512/1600]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 2.33772E+6,
+          "max_ns": 2.36085E+6,
+          "mean_ns": 2.34945E+6,
+          "stdev_ns": 7475.6,
+          "q1_ns": 2.34788E+6,
+          "median_ns": 2.34845E+6,
+          "q3_ns": 2.35237E+6,
+          "rounds": 5,
+          "total_time": 3.47719,
+          "iqr_outlier_rounds": 2,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 296,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_2d[16/16/500]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_2d[16/16/500]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 424392,
+          "max_ns": 429312,
+          "mean_ns": 426501,
+          "stdev_ns": 1957.42,
+          "q1_ns": 424425,
+          "median_ns": 426308,
+          "q3_ns": 428070,
+          "rounds": 5,
+          "total_time": 3.47385,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 1629,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_2d[32/32/1000]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_2d[32/32/1000]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 3.36655E+6,
+          "max_ns": 3.39906E+6,
+          "mean_ns": 3.38329E+6,
+          "stdev_ns": 10488.6,
+          "q1_ns": 3.38083E+6,
+          "median_ns": 3.38285E+6,
+          "q3_ns": 3.38715E+6,
+          "rounds": 5,
+          "total_time": 3.48479,
+          "iqr_outlier_rounds": 2,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 206,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_2d[64/64/2000]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_2d[64/64/2000]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 2.51779E+7,
+          "max_ns": 2.6291E+7,
+          "mean_ns": 2.55287E+7,
+          "stdev_ns": 412201,
+          "q1_ns": 2.52072E+7,
+          "median_ns": 2.5346E+7,
+          "q3_ns": 2.56214E+7,
+          "rounds": 5,
+          "total_time": 3.57402,
+          "iqr_outlier_rounds": 1,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 28,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_2d[16/16/500]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_2d[16/16/500]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 436181,
+          "max_ns": 438901,
+          "mean_ns": 437207,
+          "stdev_ns": 1053.3,
+          "q1_ns": 436427,
+          "median_ns": 436553,
+          "q3_ns": 437975,
+          "rounds": 5,
+          "total_time": 3.46924,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 1587,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_2d[32/32/1000]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_2d[32/32/1000]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 3.49021E+6,
+          "max_ns": 3.56108E+6,
+          "mean_ns": 3.52352E+6,
+          "stdev_ns": 25921.1,
+          "q1_ns": 3.5063E+6,
+          "median_ns": 3.51487E+6,
+          "q3_ns": 3.54515E+6,
+          "rounds": 5,
+          "total_time": 3.5059,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 199,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_2d[64/64/2000]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_2d[64/64/2000]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 2.62716E+7,
+          "max_ns": 2.68217E+7,
+          "mean_ns": 2.64739E+7,
+          "stdev_ns": 191134,
+          "q1_ns": 2.63377E+7,
+          "median_ns": 2.64364E+7,
+          "q3_ns": 2.65022E+7,
+          "rounds": 5,
+          "total_time": 3.44161,
+          "iqr_outlier_rounds": 1,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 26,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_3d[4/4/4/250]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_3d[4/4/4/250]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 61327.2,
+          "max_ns": 62155.2,
+          "mean_ns": 61816.4,
+          "stdev_ns": 269.901,
+          "q1_ns": 61839.4,
+          "median_ns": 61852.1,
+          "q3_ns": 61907.9,
+          "rounds": 5,
+          "total_time": 3.53342,
+          "iqr_outlier_rounds": 2,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 11432,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_3d[8/8/8/500]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_3d[8/8/8/500]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 921725,
+          "max_ns": 943450,
+          "mean_ns": 934744,
+          "stdev_ns": 7195.17,
+          "q1_ns": 934037,
+          "median_ns": 936773,
+          "q3_ns": 937736,
+          "rounds": 5,
+          "total_time": 3.49127,
+          "iqr_outlier_rounds": 2,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 747,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_3d[16/16/16/1000]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_3d[16/16/16/1000]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 1.31438E+7,
+          "max_ns": 1.33305E+7,
+          "mean_ns": 1.32568E+7,
+          "stdev_ns": 71192.1,
+          "q1_ns": 1.32066E+7,
+          "median_ns": 1.32841E+7,
+          "q3_ns": 1.3319E+7,
+          "rounds": 5,
+          "total_time": 3.51305,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 53,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_3d[4/4/4/250]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_3d[4/4/4/250]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 61396.8,
+          "max_ns": 62378.5,
+          "mean_ns": 61766.6,
+          "stdev_ns": 385.439,
+          "q1_ns": 61397.7,
+          "median_ns": 61621,
+          "q3_ns": 62039.2,
+          "rounds": 5,
+          "total_time": 3.51483,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 11381,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_3d[8/8/8/500]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_3d[8/8/8/500]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 951301,
+          "max_ns": 965288,
+          "mean_ns": 955918,
+          "stdev_ns": 5188.5,
+          "q1_ns": 952444,
+          "median_ns": 952768,
+          "q3_ns": 957790,
+          "rounds": 5,
+          "total_time": 3.52734,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 738,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_3d[16/16/16/1000]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_3d[16/16/16/1000]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 1.3647E+7,
+          "max_ns": 1.37043E+7,
+          "mean_ns": 1.3682E+7,
+          "stdev_ns": 24146.9,
+          "q1_ns": 1.36587E+7,
+          "median_ns": 1.36991E+7,
+          "q3_ns": 1.37008E+7,
+          "rounds": 5,
+          "total_time": 3.48891,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 51,
+          "warmup_iters": 0
+        }
+      }
+    ]
+  }
+]

--- a/docs/perfeng/0001-trafo-direct/artifacts/baseline-bench-l.json
+++ b/docs/perfeng/0001-trafo-direct/artifacts/baseline-bench-l.json
@@ -1,0 +1,564 @@
+[
+  {
+    "creator": {
+      "name": "codspeed-cpp",
+      "version": "2.3.0",
+      "pid": 51739
+    },
+    "instrument": {
+      "type": "walltime"
+    },
+    "benchmarks": [
+      {
+        "name": "nfft_forward_direct_1d[32/100]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_1d[32/100]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 1.87201E+6,
+          "max_ns": 1.93389E+6,
+          "mean_ns": 1.89773E+6,
+          "stdev_ns": 20273.1,
+          "q1_ns": 1.88871E+6,
+          "median_ns": 1.89559E+6,
+          "q3_ns": 1.89845E+6,
+          "rounds": 5,
+          "total_time": 3.52029,
+          "iqr_outlier_rounds": 2,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 371,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_1d[64/200]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_1d[64/200]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 7.97481E+6,
+          "max_ns": 8.03381E+6,
+          "mean_ns": 7.99606E+6,
+          "stdev_ns": 20593.7,
+          "q1_ns": 7.98521E+6,
+          "median_ns": 7.98581E+6,
+          "q3_ns": 8.00067E+6,
+          "rounds": 5,
+          "total_time": 3.2384,
+          "iqr_outlier_rounds": 1,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 81,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_1d[128/400]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_1d[128/400]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 3.26973E+7,
+          "max_ns": 3.29268E+7,
+          "mean_ns": 3.28304E+7,
+          "stdev_ns": 88814.7,
+          "q1_ns": 3.27534E+7,
+          "median_ns": 3.28861E+7,
+          "q3_ns": 3.28887E+7,
+          "rounds": 5,
+          "total_time": 3.4472,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 21,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_1d[256/800]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_1d[256/800]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 1.31037E+8,
+          "max_ns": 1.33628E+8,
+          "mean_ns": 1.32267E+8,
+          "stdev_ns": 944229,
+          "q1_ns": 1.31639E+8,
+          "median_ns": 1.31978E+8,
+          "q3_ns": 1.33052E+8,
+          "rounds": 5,
+          "total_time": 3.30667,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 5,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_1d[512/1600]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_1d[512/1600]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 5.25612E+8,
+          "max_ns": 5.3104E+8,
+          "mean_ns": 5.28676E+8,
+          "stdev_ns": 1.97365E+6,
+          "q1_ns": 5.27979E+8,
+          "median_ns": 5.28143E+8,
+          "q3_ns": 5.30608E+8,
+          "rounds": 5,
+          "total_time": 2.64338,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 1,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_1d[32/100]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_1d[32/100]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 1.91092E+6,
+          "max_ns": 1.9302E+6,
+          "mean_ns": 1.92033E+6,
+          "stdev_ns": 6588.99,
+          "q1_ns": 1.91641E+6,
+          "median_ns": 1.91988E+6,
+          "q3_ns": 1.92425E+6,
+          "rounds": 5,
+          "total_time": 3.495,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 364,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_1d[64/200]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_1d[64/200]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 8.0982E+6,
+          "max_ns": 8.27585E+6,
+          "mean_ns": 8.16531E+6,
+          "stdev_ns": 65000.9,
+          "q1_ns": 8.10766E+6,
+          "median_ns": 8.15029E+6,
+          "q3_ns": 8.19452E+6,
+          "rounds": 5,
+          "total_time": 3.51108,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 86,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_1d[128/400]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_1d[128/400]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 3.28108E+7,
+          "max_ns": 3.30191E+7,
+          "mean_ns": 3.29182E+7,
+          "stdev_ns": 74118.9,
+          "q1_ns": 3.28717E+7,
+          "median_ns": 3.29118E+7,
+          "q3_ns": 3.29777E+7,
+          "rounds": 5,
+          "total_time": 3.45641,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 21,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_1d[256/800]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_1d[256/800]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 1.31071E+8,
+          "max_ns": 1.31893E+8,
+          "mean_ns": 1.31467E+8,
+          "stdev_ns": 334137,
+          "q1_ns": 1.311E+8,
+          "median_ns": 1.31517E+8,
+          "q3_ns": 1.31754E+8,
+          "rounds": 5,
+          "total_time": 3.28668,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 5,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_1d[512/1600]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_1d[512/1600]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 5.2479E+8,
+          "max_ns": 5.33493E+8,
+          "mean_ns": 5.28244E+8,
+          "stdev_ns": 2.84854E+6,
+          "q1_ns": 5.27547E+8,
+          "median_ns": 5.27667E+8,
+          "q3_ns": 5.27722E+8,
+          "rounds": 5,
+          "total_time": 2.64122,
+          "iqr_outlier_rounds": 2,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 1,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_2d[16/16/500]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_2d[16/16/500]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 8.23416E+7,
+          "max_ns": 8.34751E+7,
+          "mean_ns": 8.28783E+7,
+          "stdev_ns": 446961,
+          "q1_ns": 8.24122E+7,
+          "median_ns": 8.29158E+7,
+          "q3_ns": 8.32471E+7,
+          "rounds": 5,
+          "total_time": 3.31513,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 8,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_2d[32/32/1000]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_2d[32/32/1000]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 6.65826E+8,
+          "max_ns": 6.7259E+8,
+          "mean_ns": 6.68842E+8,
+          "stdev_ns": 2.26412E+6,
+          "q1_ns": 6.67697E+8,
+          "median_ns": 6.68311E+8,
+          "q3_ns": 6.69788E+8,
+          "rounds": 5,
+          "total_time": 3.34421,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 1,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_2d[64/64/2000]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_2d[64/64/2000]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 5.328E+9,
+          "max_ns": 5.39994E+9,
+          "mean_ns": 5.35797E+9,
+          "stdev_ns": 2.34382E+7,
+          "q1_ns": 5.34888E+9,
+          "median_ns": 5.35608E+9,
+          "q3_ns": 5.35695E+9,
+          "rounds": 5,
+          "total_time": 26.7898,
+          "iqr_outlier_rounds": 2,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 1,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_2d[16/16/500]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_2d[16/16/500]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 8.15288E+7,
+          "max_ns": 8.5149E+7,
+          "mean_ns": 8.30066E+7,
+          "stdev_ns": 1.65146E+6,
+          "q1_ns": 8.16912E+7,
+          "median_ns": 8.17634E+7,
+          "q3_ns": 8.49005E+7,
+          "rounds": 5,
+          "total_time": 3.7353,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 9,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_2d[32/32/1000]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_2d[32/32/1000]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 6.61181E+8,
+          "max_ns": 6.70514E+8,
+          "mean_ns": 6.65678E+8,
+          "stdev_ns": 3.32322E+6,
+          "q1_ns": 6.63622E+8,
+          "median_ns": 6.64817E+8,
+          "q3_ns": 6.68254E+8,
+          "rounds": 5,
+          "total_time": 3.32839,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 1,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_2d[64/64/2000]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_2d[64/64/2000]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 5.32178E+9,
+          "max_ns": 5.34761E+9,
+          "mean_ns": 5.33132E+9,
+          "stdev_ns": 9.55196E+6,
+          "q1_ns": 5.32481E+9,
+          "median_ns": 5.32584E+9,
+          "q3_ns": 5.33655E+9,
+          "rounds": 5,
+          "total_time": 26.6566,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 1,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_3d[4/4/4/250]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_3d[4/4/4/250]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 9.45761E+6,
+          "max_ns": 9.62009E+6,
+          "mean_ns": 9.54113E+6,
+          "stdev_ns": 53050.5,
+          "q1_ns": 9.5193E+6,
+          "median_ns": 9.54998E+6,
+          "q3_ns": 9.55864E+6,
+          "rounds": 5,
+          "total_time": 3.53022,
+          "iqr_outlier_rounds": 2,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 74,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_3d[8/8/8/500]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_3d[8/8/8/500]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 1.61053E+8,
+          "max_ns": 1.61837E+8,
+          "mean_ns": 1.6131E+8,
+          "stdev_ns": 283571,
+          "q1_ns": 1.61075E+8,
+          "median_ns": 1.61259E+8,
+          "q3_ns": 1.61327E+8,
+          "rounds": 5,
+          "total_time": 3.22621,
+          "iqr_outlier_rounds": 1,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 4,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_3d[16/16/16/1000]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_3d[16/16/16/1000]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 2.62011E+9,
+          "max_ns": 2.63406E+9,
+          "mean_ns": 2.62459E+9,
+          "stdev_ns": 5.0969E+6,
+          "q1_ns": 2.6203E+9,
+          "median_ns": 2.62336E+9,
+          "q3_ns": 2.62513E+9,
+          "rounds": 5,
+          "total_time": 13.123,
+          "iqr_outlier_rounds": 1,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 1,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_3d[4/4/4/250]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_3d[4/4/4/250]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 9.39479E+6,
+          "max_ns": 9.45541E+6,
+          "mean_ns": 9.41969E+6,
+          "stdev_ns": 25130.4,
+          "q1_ns": 9.39507E+6,
+          "median_ns": 9.40985E+6,
+          "q3_ns": 9.44332E+6,
+          "rounds": 5,
+          "total_time": 3.48528,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 74,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_3d[8/8/8/500]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_3d[8/8/8/500]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 1.59934E+8,
+          "max_ns": 1.61388E+8,
+          "mean_ns": 1.60387E+8,
+          "stdev_ns": 555912,
+          "q1_ns": 1.59987E+8,
+          "median_ns": 1.60025E+8,
+          "q3_ns": 1.60603E+8,
+          "rounds": 5,
+          "total_time": 3.20775,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 4,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_3d[16/16/16/1000]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_3d[16/16/16/1000]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 2.62207E+9,
+          "max_ns": 2.63235E+9,
+          "mean_ns": 2.62655E+9,
+          "stdev_ns": 3.60515E+6,
+          "q1_ns": 2.62389E+9,
+          "median_ns": 2.6259E+9,
+          "q3_ns": 2.62852E+9,
+          "rounds": 5,
+          "total_time": 13.1327,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 1,
+          "warmup_iters": 0
+        }
+      }
+    ]
+  }
+]

--- a/docs/perfeng/0001-trafo-direct/artifacts/baseline-tests-d.log
+++ b/docs/perfeng/0001-trafo-direct/artifacts/baseline-tests-d.log
@@ -1,0 +1,10 @@
+Internal ctest changing into directory: /workspaces/nfft/build-cmake
+Test project /workspaces/nfft/build-cmake
+    Start 1: checkall
+1/2 Test #1: checkall .........................   Passed    1.12 sec
+    Start 2: checkall_threads
+2/2 Test #2: checkall_threads .................   Passed    0.95 sec
+
+100% tests passed, 0 tests failed out of 2
+
+Total Test time (real) =   2.08 sec

--- a/docs/perfeng/0001-trafo-direct/artifacts/baseline-tests-f.log
+++ b/docs/perfeng/0001-trafo-direct/artifacts/baseline-tests-f.log
@@ -1,0 +1,10 @@
+Internal ctest changing into directory: /workspaces/nfft/build-cmake-f
+Test project /workspaces/nfft/build-cmake-f
+    Start 1: checkall
+1/2 Test #1: checkall .........................   Passed    0.86 sec
+    Start 2: checkall_threads
+2/2 Test #2: checkall_threads .................   Passed    0.84 sec
+
+100% tests passed, 0 tests failed out of 2
+
+Total Test time (real) =   1.70 sec

--- a/docs/perfeng/0001-trafo-direct/artifacts/baseline-tests-l.log
+++ b/docs/perfeng/0001-trafo-direct/artifacts/baseline-tests-l.log
@@ -1,0 +1,10 @@
+Internal ctest changing into directory: /workspaces/nfft/build-cmake-l
+Test project /workspaces/nfft/build-cmake-l
+    Start 1: checkall
+1/2 Test #1: checkall .........................   Passed   65.36 sec
+    Start 2: checkall_threads
+2/2 Test #2: checkall_threads .................   Passed    7.26 sec
+
+100% tests passed, 0 tests failed out of 2
+
+Total Test time (real) =  72.63 sec

--- a/docs/perfeng/0001-trafo-direct/artifacts/change.diff
+++ b/docs/perfeng/0001-trafo-direct/artifacts/change.diff
@@ -1,0 +1,24 @@
+diff --git a/kernel/nfft/nfft.c b/kernel/nfft/nfft.c
+index 4ae7b392..47959af1 100644
+--- a/kernel/nfft/nfft.c
++++ b/kernel/nfft/nfft.c
+@@ -157,10 +157,17 @@ void X(trafo_direct)(const X(plan) *ths)
+     {
+       C v = K(0.0);
+       INT k_L;
++      /* omega_k = 2pi (k - N/2) x[j] advances by a constant increment as k grows, so the
++       * kernel e^{-i omega_k} is a geometric sequence: evaluate the two trig calls once per
++       * node and carry the phase by complex multiplication instead of per-iteration COS/SIN. */
++      R omega0 = K2PI * ((R)(-ths->N_total/2)) * ths->x[j];
++      R domega = K2PI * ths->x[j];
++      C w = COS(omega0) - II * SIN(omega0);
++      C dw = COS(domega) - II * SIN(domega);
+       for (k_L = 0; k_L < ths->N_total; k_L++)
+       {
+-        R omega = K2PI * ((R)(k_L - ths->N_total/2)) * ths->x[j];
+-        v += f_hat[k_L] * (COS(omega) - II * SIN(omega));
++        v += f_hat[k_L] * w;
++        w *= dw;
+       }
+ 
+       f[j] = v;

--- a/docs/perfeng/0001-trafo-direct/artifacts/fault.diff
+++ b/docs/perfeng/0001-trafo-direct/artifacts/fault.diff
@@ -1,0 +1,13 @@
+diff --git a/kernel/nfft/nfft.c b/kernel/nfft/nfft.c
+index 4ae7b392..98b74c87 100644
+--- a/kernel/nfft/nfft.c
++++ b/kernel/nfft/nfft.c
+@@ -160,7 +160,7 @@ void X(trafo_direct)(const X(plan) *ths)
+       for (k_L = 0; k_L < ths->N_total; k_L++)
+       {
+         R omega = K2PI * ((R)(k_L - ths->N_total/2)) * ths->x[j];
+-        v += f_hat[k_L] * (COS(omega) - II * SIN(omega));
++        v += f_hat[k_L] * (COS(omega) + II * SIN(omega));
+       }
+ 
+       f[j] = v;

--- a/docs/perfeng/0001-trafo-direct/artifacts/final-bench-d.json
+++ b/docs/perfeng/0001-trafo-direct/artifacts/final-bench-d.json
@@ -1,0 +1,564 @@
+[
+  {
+    "creator": {
+      "name": "codspeed-cpp",
+      "version": "2.3.0",
+      "pid": 57557
+    },
+    "instrument": {
+      "type": "walltime"
+    },
+    "benchmarks": [
+      {
+        "name": "nfft_forward_direct_1d[32/100]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_1d[32/100]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 5160,
+          "max_ns": 5215.03,
+          "mean_ns": 5195.99,
+          "stdev_ns": 19.4786,
+          "q1_ns": 5192.24,
+          "median_ns": 5204.09,
+          "q3_ns": 5208.61,
+          "rounds": 5,
+          "total_time": 3.107,
+          "iqr_outlier_rounds": 1,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 119592,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_1d[64/200]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_1d[64/200]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 22547.4,
+          "max_ns": 22790,
+          "mean_ns": 22668.5,
+          "stdev_ns": 87.0579,
+          "q1_ns": 22593.3,
+          "median_ns": 22703.1,
+          "q3_ns": 22708.6,
+          "rounds": 5,
+          "total_time": 3.50851,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 30955,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_1d[128/400]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_1d[128/400]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 91196.4,
+          "max_ns": 92694.9,
+          "mean_ns": 91867,
+          "stdev_ns": 501.97,
+          "q1_ns": 91591.7,
+          "median_ns": 91781.2,
+          "q3_ns": 92071,
+          "rounds": 5,
+          "total_time": 3.50519,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 7631,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_1d[256/800]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_1d[256/800]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 363378,
+          "max_ns": 372954,
+          "mean_ns": 367423,
+          "stdev_ns": 4083.75,
+          "q1_ns": 363682,
+          "median_ns": 365396,
+          "q3_ns": 371704,
+          "rounds": 5,
+          "total_time": 3.53645,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 1925,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_1d[512/1600]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_1d[512/1600]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 1.44813E+6,
+          "max_ns": 1.49149E+6,
+          "mean_ns": 1.4712E+6,
+          "stdev_ns": 17768,
+          "q1_ns": 1.45628E+6,
+          "median_ns": 1.46876E+6,
+          "q3_ns": 1.49135E+6,
+          "rounds": 5,
+          "total_time": 3.55295,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 483,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_1d[32/100]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_1d[32/100]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 8463.74,
+          "max_ns": 8518.49,
+          "mean_ns": 8487,
+          "stdev_ns": 20.0213,
+          "q1_ns": 8467.09,
+          "median_ns": 8490.96,
+          "q3_ns": 8494.74,
+          "rounds": 5,
+          "total_time": 3.4983,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 82439,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_1d[64/200]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_1d[64/200]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 31232.5,
+          "max_ns": 31511.1,
+          "mean_ns": 31378.1,
+          "stdev_ns": 89.8495,
+          "q1_ns": 31357.3,
+          "median_ns": 31379.1,
+          "q3_ns": 31410.4,
+          "rounds": 5,
+          "total_time": 3.50697,
+          "iqr_outlier_rounds": 2,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 22353,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_1d[128/400]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_1d[128/400]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 123761,
+          "max_ns": 124535,
+          "mean_ns": 124232,
+          "stdev_ns": 275.666,
+          "q1_ns": 124144,
+          "median_ns": 124247,
+          "q3_ns": 124474,
+          "rounds": 5,
+          "total_time": 3.51949,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 5666,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_1d[256/800]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_1d[256/800]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 498885,
+          "max_ns": 502257,
+          "mean_ns": 500652,
+          "stdev_ns": 1069.25,
+          "q1_ns": 500666,
+          "median_ns": 500677,
+          "q3_ns": 500777,
+          "rounds": 5,
+          "total_time": 3.51208,
+          "iqr_outlier_rounds": 2,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 1403,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_1d[512/1600]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_1d[512/1600]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 2.00082E+6,
+          "max_ns": 2.00829E+6,
+          "mean_ns": 2.00378E+6,
+          "stdev_ns": 2653.86,
+          "q1_ns": 2.00148E+6,
+          "median_ns": 2.00365E+6,
+          "q3_ns": 2.00467E+6,
+          "rounds": 5,
+          "total_time": 3.51664,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 351,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_2d[16/16/500]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_2d[16/16/500]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 1.2402E+6,
+          "max_ns": 1.33392E+6,
+          "mean_ns": 1.27465E+6,
+          "stdev_ns": 32713.3,
+          "q1_ns": 1.24913E+6,
+          "median_ns": 1.27477E+6,
+          "q3_ns": 1.27524E+6,
+          "rounds": 5,
+          "total_time": 3.59452,
+          "iqr_outlier_rounds": 1,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 564,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_2d[32/32/1000]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_2d[32/32/1000]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 9.92004E+6,
+          "max_ns": 1.00138E+7,
+          "mean_ns": 9.97025E+6,
+          "stdev_ns": 30889.3,
+          "q1_ns": 9.96012E+6,
+          "median_ns": 9.9713E+6,
+          "q3_ns": 9.98598E+6,
+          "rounds": 5,
+          "total_time": 3.53944,
+          "iqr_outlier_rounds": 1,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 71,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_2d[64/64/2000]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_2d[64/64/2000]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 6.48899E+7,
+          "max_ns": 6.53674E+7,
+          "mean_ns": 6.51243E+7,
+          "stdev_ns": 178627,
+          "q1_ns": 6.49804E+7,
+          "median_ns": 6.51036E+7,
+          "q3_ns": 6.52804E+7,
+          "rounds": 5,
+          "total_time": 3.58184,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 11,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_2d[16/16/500]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_2d[16/16/500]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 1.23792E+6,
+          "max_ns": 1.31542E+6,
+          "mean_ns": 1.26914E+6,
+          "stdev_ns": 30880.9,
+          "q1_ns": 1.24425E+6,
+          "median_ns": 1.25188E+6,
+          "q3_ns": 1.29623E+6,
+          "rounds": 5,
+          "total_time": 3.24266,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 511,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_2d[32/32/1000]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_2d[32/32/1000]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 9.83529E+6,
+          "max_ns": 9.97852E+6,
+          "mean_ns": 9.90238E+6,
+          "stdev_ns": 51697.5,
+          "q1_ns": 9.85451E+6,
+          "median_ns": 9.91857E+6,
+          "q3_ns": 9.92498E+6,
+          "rounds": 5,
+          "total_time": 3.51534,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 71,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_2d[64/64/2000]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_2d[64/64/2000]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 6.49285E+7,
+          "max_ns": 6.5217E+7,
+          "mean_ns": 6.5098E+7,
+          "stdev_ns": 133156,
+          "q1_ns": 6.49428E+7,
+          "median_ns": 6.51847E+7,
+          "q3_ns": 6.52169E+7,
+          "rounds": 5,
+          "total_time": 3.58039,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 11,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_3d[4/4/4/250]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_3d[4/4/4/250]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 93824.6,
+          "max_ns": 97340.2,
+          "mean_ns": 95127.2,
+          "stdev_ns": 1181.96,
+          "q1_ns": 94549.4,
+          "median_ns": 94932,
+          "q3_ns": 94989.6,
+          "rounds": 5,
+          "total_time": 3.49259,
+          "iqr_outlier_rounds": 2,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 7343,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_3d[8/8/8/500]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_3d[8/8/8/500]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 3.01985E+6,
+          "max_ns": 3.11701E+6,
+          "mean_ns": 3.0746E+6,
+          "stdev_ns": 34523.3,
+          "q1_ns": 3.0553E+6,
+          "median_ns": 3.07838E+6,
+          "q3_ns": 3.10246E+6,
+          "rounds": 5,
+          "total_time": 3.59729,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 234,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_3d[16/16/16/1000]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_3d[16/16/16/1000]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 3.98837E+7,
+          "max_ns": 4.02502E+7,
+          "mean_ns": 4.01035E+7,
+          "stdev_ns": 168978,
+          "q1_ns": 3.991E+7,
+          "median_ns": 4.02362E+7,
+          "q3_ns": 4.02373E+7,
+          "rounds": 5,
+          "total_time": 3.40879,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 17,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_3d[4/4/4/250]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_3d[4/4/4/250]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 95738,
+          "max_ns": 99477.7,
+          "mean_ns": 97870.4,
+          "stdev_ns": 1240.85,
+          "q1_ns": 97710.7,
+          "median_ns": 97820.3,
+          "q3_ns": 98605.1,
+          "rounds": 5,
+          "total_time": 3.31389,
+          "iqr_outlier_rounds": 1,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 6772,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_3d[8/8/8/500]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_3d[8/8/8/500]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 3.00287E+6,
+          "max_ns": 3.0877E+6,
+          "mean_ns": 3.04366E+6,
+          "stdev_ns": 35553,
+          "q1_ns": 3.0055E+6,
+          "median_ns": 3.04305E+6,
+          "q3_ns": 3.07916E+6,
+          "rounds": 5,
+          "total_time": 3.48499,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 229,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_3d[16/16/16/1000]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_3d[16/16/16/1000]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 3.99832E+7,
+          "max_ns": 4.01111E+7,
+          "mean_ns": 4.00565E+7,
+          "stdev_ns": 51237.2,
+          "q1_ns": 4.00141E+7,
+          "median_ns": 4.00636E+7,
+          "q3_ns": 4.01106E+7,
+          "rounds": 5,
+          "total_time": 3.40481,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 17,
+          "warmup_iters": 0
+        }
+      }
+    ]
+  }
+]

--- a/docs/perfeng/0001-trafo-direct/artifacts/final-bench-f.json
+++ b/docs/perfeng/0001-trafo-direct/artifacts/final-bench-f.json
@@ -1,0 +1,564 @@
+[
+  {
+    "creator": {
+      "name": "codspeed-cpp",
+      "version": "2.3.0",
+      "pid": 58053
+    },
+    "instrument": {
+      "type": "walltime"
+    },
+    "benchmarks": [
+      {
+        "name": "nfft_forward_direct_1d[32/100]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_1d[32/100]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 4595.03,
+          "max_ns": 4656.96,
+          "mean_ns": 4612.93,
+          "stdev_ns": 22.4322,
+          "q1_ns": 4600.34,
+          "median_ns": 4604.3,
+          "q3_ns": 4607.99,
+          "rounds": 5,
+          "total_time": 3.47496,
+          "iqr_outlier_rounds": 1,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 150662,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_1d[64/200]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_1d[64/200]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 20698.8,
+          "max_ns": 20974.5,
+          "mean_ns": 20826,
+          "stdev_ns": 105.828,
+          "q1_ns": 20712,
+          "median_ns": 20857.7,
+          "q3_ns": 20887.3,
+          "rounds": 5,
+          "total_time": 3.44838,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 33116,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_1d[128/400]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_1d[128/400]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 87736.1,
+          "max_ns": 90341.8,
+          "mean_ns": 88711.6,
+          "stdev_ns": 869.628,
+          "q1_ns": 88406.6,
+          "median_ns": 88442.1,
+          "q3_ns": 88631.6,
+          "rounds": 5,
+          "total_time": 3.48637,
+          "iqr_outlier_rounds": 2,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 7860,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_1d[256/800]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_1d[256/800]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 356987,
+          "max_ns": 363451,
+          "mean_ns": 359399,
+          "stdev_ns": 2692.43,
+          "q1_ns": 357120,
+          "median_ns": 357644,
+          "q3_ns": 361794,
+          "rounds": 5,
+          "total_time": 3.5311,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 1965,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_1d[512/1600]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_1d[512/1600]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 1.43564E+6,
+          "max_ns": 1.43998E+6,
+          "mean_ns": 1.43829E+6,
+          "stdev_ns": 1880.75,
+          "q1_ns": 1.43638E+6,
+          "median_ns": 1.43969E+6,
+          "q3_ns": 1.43977E+6,
+          "rounds": 5,
+          "total_time": 3.40875,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 474,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_1d[32/100]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_1d[32/100]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 8423.06,
+          "max_ns": 8535.51,
+          "mean_ns": 8489.14,
+          "stdev_ns": 44.2815,
+          "q1_ns": 8451.29,
+          "median_ns": 8507.94,
+          "q3_ns": 8527.9,
+          "rounds": 5,
+          "total_time": 3.5027,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 82522,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_1d[64/200]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_1d[64/200]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 33116.4,
+          "max_ns": 33430.1,
+          "mean_ns": 33237.6,
+          "stdev_ns": 106.007,
+          "q1_ns": 33176.6,
+          "median_ns": 33214.1,
+          "q3_ns": 33250.9,
+          "rounds": 5,
+          "total_time": 3.49494,
+          "iqr_outlier_rounds": 1,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 21030,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_1d[128/400]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_1d[128/400]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 133956,
+          "max_ns": 135457,
+          "mean_ns": 134777,
+          "stdev_ns": 555.01,
+          "q1_ns": 134448,
+          "median_ns": 134708,
+          "q3_ns": 135316,
+          "rounds": 5,
+          "total_time": 3.52846,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 5236,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_1d[256/800]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_1d[256/800]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 546673,
+          "max_ns": 589836,
+          "mean_ns": 561719,
+          "stdev_ns": 15128.2,
+          "q1_ns": 550598,
+          "median_ns": 559795,
+          "q3_ns": 561692,
+          "rounds": 5,
+          "total_time": 3.51636,
+          "iqr_outlier_rounds": 1,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 1252,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_1d[512/1600]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_1d[512/1600]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 2.23138E+6,
+          "max_ns": 2.30719E+6,
+          "mean_ns": 2.2755E+6,
+          "stdev_ns": 32924.7,
+          "q1_ns": 2.23981E+6,
+          "median_ns": 2.29519E+6,
+          "q3_ns": 2.30392E+6,
+          "rounds": 5,
+          "total_time": 3.57253,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 314,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_2d[16/16/500]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_2d[16/16/500]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 419504,
+          "max_ns": 425833,
+          "mean_ns": 422834,
+          "stdev_ns": 2191.22,
+          "q1_ns": 421881,
+          "median_ns": 422429,
+          "q3_ns": 424523,
+          "rounds": 5,
+          "total_time": 3.4905,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 1651,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_2d[32/32/1000]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_2d[32/32/1000]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 3.35865E+6,
+          "max_ns": 3.37997E+6,
+          "mean_ns": 3.37169E+6,
+          "stdev_ns": 9144.55,
+          "q1_ns": 3.36264E+6,
+          "median_ns": 3.37761E+6,
+          "q3_ns": 3.3796E+6,
+          "rounds": 5,
+          "total_time": 3.52342,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 209,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_2d[64/64/2000]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_2d[64/64/2000]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 2.51902E+7,
+          "max_ns": 2.5466E+7,
+          "mean_ns": 2.53256E+7,
+          "stdev_ns": 106413,
+          "q1_ns": 2.5267E+7,
+          "median_ns": 2.52697E+7,
+          "q3_ns": 2.54352E+7,
+          "rounds": 5,
+          "total_time": 3.54559,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 28,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_2d[16/16/500]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_2d[16/16/500]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 443258,
+          "max_ns": 449453,
+          "mean_ns": 445599,
+          "stdev_ns": 2117.42,
+          "q1_ns": 444193,
+          "median_ns": 445324,
+          "q3_ns": 445769,
+          "rounds": 5,
+          "total_time": 3.48904,
+          "iqr_outlier_rounds": 1,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 1566,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_2d[32/32/1000]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_2d[32/32/1000]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 3.48391E+6,
+          "max_ns": 3.54925E+6,
+          "mean_ns": 3.51451E+6,
+          "stdev_ns": 24494.3,
+          "q1_ns": 3.49559E+6,
+          "median_ns": 3.50795E+6,
+          "q3_ns": 3.53585E+6,
+          "rounds": 5,
+          "total_time": 3.51451,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 200,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_2d[64/64/2000]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_2d[64/64/2000]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 2.61513E+7,
+          "max_ns": 2.65622E+7,
+          "mean_ns": 2.63501E+7,
+          "stdev_ns": 136839,
+          "q1_ns": 2.6282E+7,
+          "median_ns": 2.63387E+7,
+          "q3_ns": 2.64161E+7,
+          "rounds": 5,
+          "total_time": 3.55726,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 27,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_3d[4/4/4/250]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_3d[4/4/4/250]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 61387.7,
+          "max_ns": 62530.1,
+          "mean_ns": 61780,
+          "stdev_ns": 399.867,
+          "q1_ns": 61502.1,
+          "median_ns": 61705.3,
+          "q3_ns": 61774.7,
+          "rounds": 5,
+          "total_time": 3.51281,
+          "iqr_outlier_rounds": 1,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 11372,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_3d[8/8/8/500]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_3d[8/8/8/500]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 929230,
+          "max_ns": 939273,
+          "mean_ns": 934115,
+          "stdev_ns": 3942.42,
+          "q1_ns": 929771,
+          "median_ns": 935945,
+          "q3_ns": 936357,
+          "rounds": 5,
+          "total_time": 3.51227,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 752,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_3d[16/16/16/1000]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_3d[16/16/16/1000]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 1.32054E+7,
+          "max_ns": 1.33307E+7,
+          "mean_ns": 1.32767E+7,
+          "stdev_ns": 43911.2,
+          "q1_ns": 1.32578E+7,
+          "median_ns": 1.32771E+7,
+          "q3_ns": 1.33126E+7,
+          "rounds": 5,
+          "total_time": 3.45195,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 52,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_3d[4/4/4/250]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_3d[4/4/4/250]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 61824,
+          "max_ns": 62313.5,
+          "mean_ns": 62122.4,
+          "stdev_ns": 187.455,
+          "q1_ns": 61983.5,
+          "median_ns": 62228.3,
+          "q3_ns": 62262.6,
+          "rounds": 5,
+          "total_time": 3.52296,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 11342,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_3d[8/8/8/500]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_3d[8/8/8/500]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 948363,
+          "max_ns": 959898,
+          "mean_ns": 954686,
+          "stdev_ns": 4162.01,
+          "q1_ns": 951494,
+          "median_ns": 956795,
+          "q3_ns": 956883,
+          "rounds": 5,
+          "total_time": 3.49893,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 733,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_3d[16/16/16/1000]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_3d[16/16/16/1000]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 1.36594E+7,
+          "max_ns": 1.39123E+7,
+          "mean_ns": 1.37752E+7,
+          "stdev_ns": 89861.6,
+          "q1_ns": 1.37111E+7,
+          "median_ns": 1.37571E+7,
+          "q3_ns": 1.38361E+7,
+          "rounds": 5,
+          "total_time": 3.51268,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 51,
+          "warmup_iters": 0
+        }
+      }
+    ]
+  }
+]

--- a/docs/perfeng/0001-trafo-direct/artifacts/final-bench-l.json
+++ b/docs/perfeng/0001-trafo-direct/artifacts/final-bench-l.json
@@ -1,0 +1,264 @@
+[
+  {
+    "creator": {
+      "name": "codspeed-cpp",
+      "version": "2.3.0",
+      "pid": 59067
+    },
+    "instrument": {
+      "type": "walltime"
+    },
+    "benchmarks": [
+      {
+        "name": "nfft_forward_direct_1d[32/100]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_1d[32/100]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 480996,
+          "max_ns": 560427,
+          "mean_ns": 526960,
+          "stdev_ns": 29850.6,
+          "q1_ns": 509240,
+          "median_ns": 527033,
+          "q3_ns": 557103,
+          "rounds": 5,
+          "total_time": 3.02212,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 1147,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_1d[64/200]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_1d[64/200]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 2.18391E+6,
+          "max_ns": 2.21576E+6,
+          "mean_ns": 2.19682E+6,
+          "stdev_ns": 12459.3,
+          "q1_ns": 2.18509E+6,
+          "median_ns": 2.19272E+6,
+          "q3_ns": 2.20664E+6,
+          "rounds": 5,
+          "total_time": 3.48197,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 317,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_1d[128/400]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_1d[128/400]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 8.69193E+6,
+          "max_ns": 8.81615E+6,
+          "mean_ns": 8.73156E+6,
+          "stdev_ns": 44187.4,
+          "q1_ns": 8.70296E+6,
+          "median_ns": 8.71683E+6,
+          "q3_ns": 8.72994E+6,
+          "rounds": 5,
+          "total_time": 3.53628,
+          "iqr_outlier_rounds": 1,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 81,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_1d[256/800]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_1d[256/800]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 3.38001E+7,
+          "max_ns": 3.42681E+7,
+          "mean_ns": 3.40273E+7,
+          "stdev_ns": 170385,
+          "q1_ns": 3.38699E+7,
+          "median_ns": 3.40838E+7,
+          "q3_ns": 3.41144E+7,
+          "rounds": 5,
+          "total_time": 3.40273,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 20,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_forward_direct_1d[512/1600]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_forward_direct_1d[512/1600]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 1.32256E+8,
+          "max_ns": 1.32771E+8,
+          "mean_ns": 1.32582E+8,
+          "stdev_ns": 196696,
+          "q1_ns": 1.32455E+8,
+          "median_ns": 1.32684E+8,
+          "q3_ns": 1.3274E+8,
+          "rounds": 5,
+          "total_time": 3.31454,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 5,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_1d[32/100]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_1d[32/100]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 1.80183E+6,
+          "max_ns": 1.83944E+6,
+          "mean_ns": 1.81716E+6,
+          "stdev_ns": 13208.8,
+          "q1_ns": 1.80596E+6,
+          "median_ns": 1.81747E+6,
+          "q3_ns": 1.82109E+6,
+          "rounds": 5,
+          "total_time": 3.48895,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 384,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_1d[64/200]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_1d[64/200]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 7.56752E+6,
+          "max_ns": 7.67461E+6,
+          "mean_ns": 7.6088E+6,
+          "stdev_ns": 35651.7,
+          "q1_ns": 7.59223E+6,
+          "median_ns": 7.60217E+6,
+          "q3_ns": 7.60745E+6,
+          "rounds": 5,
+          "total_time": 3.50005,
+          "iqr_outlier_rounds": 2,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 92,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_1d[128/400]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_1d[128/400]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 3.10266E+7,
+          "max_ns": 3.14439E+7,
+          "mean_ns": 3.11824E+7,
+          "stdev_ns": 142647,
+          "q1_ns": 3.10928E+7,
+          "median_ns": 3.11524E+7,
+          "q3_ns": 3.11962E+7,
+          "rounds": 5,
+          "total_time": 3.58598,
+          "iqr_outlier_rounds": 1,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 23,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_1d[256/800]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_1d[256/800]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 1.24206E+8,
+          "max_ns": 1.25754E+8,
+          "mean_ns": 1.24932E+8,
+          "stdev_ns": 491908,
+          "q1_ns": 1.24867E+8,
+          "median_ns": 1.24886E+8,
+          "q3_ns": 1.24948E+8,
+          "rounds": 5,
+          "total_time": 3.74796,
+          "iqr_outlier_rounds": 2,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 6,
+          "warmup_iters": 0
+        }
+      },
+      {
+        "name": "nfft_adjoint_direct_1d[512/1600]",
+        "uri": "benchmarks/bench_nfft_direct.cpp::nfft_adjoint_direct_1d[512/1600]",
+        "config": {
+          "warmup_time_ns": null,
+          "min_round_time_ns": null,
+          "max_time_ns": null,
+          "max_rounds": null
+        },
+        "stats": {
+          "min_ns": 4.99312E+8,
+          "max_ns": 5.02639E+8,
+          "mean_ns": 5.00801E+8,
+          "stdev_ns": 1.24651E+6,
+          "q1_ns": 4.99495E+8,
+          "median_ns": 5.01199E+8,
+          "q3_ns": 5.01358E+8,
+          "rounds": 5,
+          "total_time": 2.504,
+          "iqr_outlier_rounds": 0,
+          "stdev_outlier_rounds": 0,
+          "iter_per_round": 1,
+          "warmup_iters": 0
+        }
+      }
+    ]
+  }
+]

--- a/docs/perfeng/0001-trafo-direct/artifacts/final-tests-d.log
+++ b/docs/perfeng/0001-trafo-direct/artifacts/final-tests-d.log
@@ -1,0 +1,10 @@
+Internal ctest changing into directory: /workspaces/nfft/build-cmake
+Test project /workspaces/nfft/build-cmake
+    Start 1: checkall
+1/2 Test #1: checkall .........................   Passed    1.12 sec
+    Start 2: checkall_threads
+2/2 Test #2: checkall_threads .................   Passed    0.89 sec
+
+100% tests passed, 0 tests failed out of 2
+
+Total Test time (real) =   2.01 sec

--- a/docs/perfeng/0001-trafo-direct/artifacts/final-tests-f.log
+++ b/docs/perfeng/0001-trafo-direct/artifacts/final-tests-f.log
@@ -1,0 +1,10 @@
+Internal ctest changing into directory: /workspaces/nfft/build-cmake-f
+Test project /workspaces/nfft/build-cmake-f
+    Start 1: checkall
+1/2 Test #1: checkall .........................   Passed    0.86 sec
+    Start 2: checkall_threads
+2/2 Test #2: checkall_threads .................   Passed    1.00 sec
+
+100% tests passed, 0 tests failed out of 2
+
+Total Test time (real) =   1.86 sec

--- a/docs/perfeng/0001-trafo-direct/artifacts/final-tests-l.log
+++ b/docs/perfeng/0001-trafo-direct/artifacts/final-tests-l.log
@@ -1,0 +1,10 @@
+Internal ctest changing into directory: /workspaces/nfft/build-cmake-l
+Test project /workspaces/nfft/build-cmake-l
+    Start 1: checkall
+1/2 Test #1: checkall .........................   Passed   66.93 sec
+    Start 2: checkall_threads
+2/2 Test #2: checkall_threads .................   Passed    7.12 sec
+
+100% tests passed, 0 tests failed out of 2
+
+Total Test time (real) =  74.05 sec

--- a/docs/perfeng/0001-trafo-direct/artifacts/slowdown.diff
+++ b/docs/perfeng/0001-trafo-direct/artifacts/slowdown.diff
@@ -1,0 +1,24 @@
+diff --git a/kernel/nfft/nfft.c b/kernel/nfft/nfft.c
+index 4ae7b392..df60ebca 100644
+--- a/kernel/nfft/nfft.c
++++ b/kernel/nfft/nfft.c
+@@ -156,11 +156,15 @@ void X(trafo_direct)(const X(plan) *ths)
+     for (j = 0; j < ths->M_total; j++)
+     {
+       C v = K(0.0);
+-      INT k_L;
+-      for (k_L = 0; k_L < ths->N_total; k_L++)
++      INT k_L, rep;
++      for (rep = 0; rep < 10; rep++)
+       {
+-        R omega = K2PI * ((R)(k_L - ths->N_total/2)) * ths->x[j];
+-        v += f_hat[k_L] * (COS(omega) - II * SIN(omega));
++        v = K(0.0);
++        for (k_L = 0; k_L < ths->N_total; k_L++)
++        {
++          R omega = K2PI * ((R)(k_L - ths->N_total/2)) * ths->x[j];
++          v += f_hat[k_L] * (COS(omega) - II * SIN(omega));
++        }
+       }
+ 
+       f[j] = v;

--- a/docs/perfeng/0001-trafo-direct/phase-a-baseline.md
+++ b/docs/perfeng/0001-trafo-direct/phase-a-baseline.md
@@ -1,0 +1,91 @@
+# Phase A — baseline (the exit reference)
+
+- **Build:** three trees `build-cmake{,-f,-l}` — `-DNFFT_BENCHMARK_MODE=walltime -DNFFT_ENABLE_OPENMP=ON -DCMAKE_C_FLAGS="-O3 -g -fomit-frame-pointer -fstrict-aliasing -ffast-math"`, plus the per-tree precision flag. **Stale in-source `include/config.h` cleared first** (else the float/long-double trees mis-link — see precision-matrix.md).
+- **Baseline commit:** a692216c
+- **Track:** walltime
+- **Tests (per precision):** double 1854/1854 ✅ · float 1843/1843 ✅ · long double 1854/1854 ✅ (`checkall` + `checkall_threads`) — `artifacts/baseline-tests-{d,f,l}.log`
+- **Benchmark cases captured:** 22 × 3 precisions — `artifacts/baseline-bench-{d,f,l}.json`
+
+## Benchmark snapshot
+
+<!-- Benchmark snapshot (canonical format) — all 22 cases × 3 precisions (d/f/l), walltime medians over 5 rounds. -->
+| prec | case | median_ns | stdev_ns | rounds |
+|------|------|-----------|----------|--------|
+| d | nfft_forward_direct_1d[32/100] | 7694 | 24 | 5 |
+| d | nfft_forward_direct_1d[64/200] | 29324 | 150 | 5 |
+| d | nfft_forward_direct_1d[128/400] | 116439 | 265 | 5 |
+| d | nfft_forward_direct_1d[256/800] | 465332 | 1207 | 5 |
+| d | nfft_forward_direct_1d[512/1600] | 1862450 | 6586 | 5 |
+| d | nfft_adjoint_direct_1d[32/100] | 8464 | 107 | 5 |
+| d | nfft_adjoint_direct_1d[64/200] | 31395 | 88 | 5 |
+| d | nfft_adjoint_direct_1d[128/400] | 124373 | 423 | 5 |
+| d | nfft_adjoint_direct_1d[256/800] | 502903 | 1537 | 5 |
+| d | nfft_adjoint_direct_1d[512/1600] | 2006180 | 8601 | 5 |
+| d | nfft_forward_direct_2d[16/16/500] | 1312200 | 15962 | 5 |
+| d | nfft_forward_direct_2d[32/32/1000] | 10305100 | 127132 | 5 |
+| d | nfft_forward_direct_2d[64/64/2000] | 66904600 | 224405 | 5 |
+| d | nfft_adjoint_direct_2d[16/16/500] | 1260930 | 33903 | 5 |
+| d | nfft_adjoint_direct_2d[32/32/1000] | 9881200 | 41632 | 5 |
+| d | nfft_adjoint_direct_2d[64/64/2000] | 65500100 | 199041 | 5 |
+| d | nfft_forward_direct_3d[4/4/4/250] | 96383 | 1644 | 5 |
+| d | nfft_forward_direct_3d[8/8/8/500] | 3209680 | 9131 | 5 |
+| d | nfft_forward_direct_3d[16/16/16/1000] | 42093800 | 108844 | 5 |
+| d | nfft_adjoint_direct_3d[4/4/4/250] | 98346 | 1056 | 5 |
+| d | nfft_adjoint_direct_3d[8/8/8/500] | 3081320 | 20590 | 5 |
+| d | nfft_adjoint_direct_3d[16/16/16/1000] | 40254800 | 165137 | 5 |
+| f | nfft_forward_direct_1d[32/100] | 7779 | 56 | 5 |
+| f | nfft_forward_direct_1d[64/200] | 32829 | 151 | 5 |
+| f | nfft_forward_direct_1d[128/400] | 133304 | 322 | 5 |
+| f | nfft_forward_direct_1d[256/800] | 541102 | 1403 | 5 |
+| f | nfft_forward_direct_1d[512/1600] | 2222930 | 5656 | 5 |
+| f | nfft_adjoint_direct_1d[32/100] | 7849 | 33 | 5 |
+| f | nfft_adjoint_direct_1d[64/200] | 33177 | 113 | 5 |
+| f | nfft_adjoint_direct_1d[128/400] | 134820 | 246 | 5 |
+| f | nfft_adjoint_direct_1d[256/800] | 547651 | 969 | 5 |
+| f | nfft_adjoint_direct_1d[512/1600] | 2348450 | 7476 | 5 |
+| f | nfft_forward_direct_2d[16/16/500] | 426308 | 1957 | 5 |
+| f | nfft_forward_direct_2d[32/32/1000] | 3382850 | 10489 | 5 |
+| f | nfft_forward_direct_2d[64/64/2000] | 25346000 | 412201 | 5 |
+| f | nfft_adjoint_direct_2d[16/16/500] | 436553 | 1053 | 5 |
+| f | nfft_adjoint_direct_2d[32/32/1000] | 3514870 | 25921 | 5 |
+| f | nfft_adjoint_direct_2d[64/64/2000] | 26436400 | 191134 | 5 |
+| f | nfft_forward_direct_3d[4/4/4/250] | 61852 | 270 | 5 |
+| f | nfft_forward_direct_3d[8/8/8/500] | 936773 | 7195 | 5 |
+| f | nfft_forward_direct_3d[16/16/16/1000] | 13284100 | 71192 | 5 |
+| f | nfft_adjoint_direct_3d[4/4/4/250] | 61621 | 385 | 5 |
+| f | nfft_adjoint_direct_3d[8/8/8/500] | 952768 | 5189 | 5 |
+| f | nfft_adjoint_direct_3d[16/16/16/1000] | 13699100 | 24147 | 5 |
+| l | nfft_forward_direct_1d[32/100] | 1895590 | 20273 | 5 |
+| l | nfft_forward_direct_1d[64/200] | 7985810 | 20594 | 5 |
+| l | nfft_forward_direct_1d[128/400] | 32886100 | 88815 | 5 |
+| l | nfft_forward_direct_1d[256/800] | 131978000 | 944229 | 5 |
+| l | nfft_forward_direct_1d[512/1600] | 528143000 | 1973650 | 5 |
+| l | nfft_adjoint_direct_1d[32/100] | 1919880 | 6589 | 5 |
+| l | nfft_adjoint_direct_1d[64/200] | 8150290 | 65001 | 5 |
+| l | nfft_adjoint_direct_1d[128/400] | 32911800 | 74119 | 5 |
+| l | nfft_adjoint_direct_1d[256/800] | 131517000 | 334137 | 5 |
+| l | nfft_adjoint_direct_1d[512/1600] | 527667000 | 2848540 | 5 |
+| l | nfft_forward_direct_2d[16/16/500] | 82915800 | 446961 | 5 |
+| l | nfft_forward_direct_2d[32/32/1000] | 668311000 | 2264120 | 5 |
+| l | nfft_forward_direct_2d[64/64/2000] | 5356080000 | 23438200 | 5 |
+| l | nfft_adjoint_direct_2d[16/16/500] | 81763400 | 1651460 | 5 |
+| l | nfft_adjoint_direct_2d[32/32/1000] | 664817000 | 3323220 | 5 |
+| l | nfft_adjoint_direct_2d[64/64/2000] | 5325840000 | 9551960 | 5 |
+| l | nfft_forward_direct_3d[4/4/4/250] | 9549980 | 53051 | 5 |
+| l | nfft_forward_direct_3d[8/8/8/500] | 161259000 | 283571 | 5 |
+| l | nfft_forward_direct_3d[16/16/16/1000] | 2623360000 | 5096900 | 5 |
+| l | nfft_adjoint_direct_3d[4/4/4/250] | 9409850 | 25130 | 5 |
+| l | nfft_adjoint_direct_3d[8/8/8/500] | 160025000 | 555912 | 5 |
+| l | nfft_adjoint_direct_3d[16/16/16/1000] | 2625900000 | 3605150 | 5 |
+
+## Notes
+
+- **Long double is ~250–280× slower than double** on this target (e.g. forward_direct_1d[32/100]:
+  7694 ns d vs 1,895,590 ns l) because `COSL`/`SINL` are extended-precision and far costlier than
+  the double libm calls. Float is marginally *slower* than double here (no float-specific trig win,
+  same call count). This precision spread is exactly what the matrix exists to surface, and it makes
+  the cos/sin → complex-multiply recurrence especially valuable in long double.
+- Benchmark coverage is the **direct** transforms only (forward/adjoint, 1d/2d/3d). The fault/metric
+  pinning (Phases B/C) is done in double and applies to all precisions (same suite, same cases).
+- float reports 1843 test cases vs 1854 for double/long double — a handful of suite cases are
+  precision-gated; all run cases pass.

--- a/docs/perfeng/0001-trafo-direct/phase-b-correctness-net.md
+++ b/docs/perfeng/0001-trafo-direct/phase-b-correctness-net.md
@@ -1,0 +1,28 @@
+# Phase B — correctness net
+
+- **Outcome:** net pinned ✅
+- **Target:** `X(trafo_direct)()` — kernel/nfft/nfft.c:145 (1d branch)
+- **Fault injected:** imaginary-kernel sign flip in the 1d inner loop (line 163),
+  `(COS(omega) - II * SIN(omega))` → `(COS(omega) + II * SIN(omega))` — `artifacts/fault.diff`
+- **Suite to run in inner loop:** `nfft` (run in all three precisions in Phase D)
+- **Net size:** 116 cases (21 `nfft` test-data files: `nfft_1d_{2,4,10,20,50}_{1,10,20,50}` + `nfft_online`)
+
+## Correctness net
+
+<!-- Correctness net (canonical format). The fault flips the 1d `trafo_direct` cases of the
+     `nfft` suite; 2d/3d and all adjoint cases stay green (fault is 1d-only). Pinned in double;
+     the same suite/cases are the net in float and long double. -->
+| suite | case | error | bound |
+|-------|------|-------|-------|
+| nfft  | nfft_1d_2_1.txt … m=8, trafo_direct   | 7.21e-02 | 1.07e-14 |
+| nfft  | nfft_1d_50_50.txt … m=8, trafo_direct | (FAIL)   | 1.07e-14 |
+| nfft  | nfft_online … trafo_direct (32 cases) | (FAIL)   | 1.07e-14 |
+
+(116 `-> FAIL` lines total across 21 files; small N=2,4 files contribute 9 sub-cases each.)
+
+## Revert confirmation
+
+- suite green again: **yes** (`checkall` 1854/1854 `-> OK`, exit 0) · `git diff` empty: **yes**
+
+The net to run in the Phase D inner loop is the **`nfft`** suite (`checkall` / `checkall_threads`),
+run in **all three precisions** — the recurrence must keep it green in float, double, and long double.

--- a/docs/perfeng/0001-trafo-direct/phase-c-performance-metric.md
+++ b/docs/perfeng/0001-trafo-direct/phase-c-performance-metric.md
@@ -1,0 +1,33 @@
+# Phase C — performance metric
+
+- **Outcome:** metric pinned ✅
+- **Benchmark filter:** `--benchmark_filter='nfft_forward_direct_1d.*'` (target = 1d forward; `nfft_adjoint_direct_1d.*` as control)
+- **Slowdown injected:** 1d `trafo_direct` body wrapped in a 10× repeat loop (`v` reset each rep, results identical) — `artifacts/slowdown.diff`
+
+## Target baseline (double)
+
+| prec | case | median_ns | stdev_ns | rounds |
+|------|------|-----------|----------|--------|
+| d | nfft_forward_direct_1d[32/100]   | 7694    | 24  | 5 |
+| d | nfft_forward_direct_1d[128/400]  | 116439  | 265 | 5 |
+| d | nfft_forward_direct_1d[512/1600] | 1862450 | —   | 5 |
+
+## Metric — cases that moved under the slowdown (double)
+
+| case | median_ns base | median_ns slowed | moves the target? |
+|------|----------------|------------------|-------------------|
+| nfft_forward_direct_1d[32/100]   | 7694    | 72919    | yes — 9.5× |
+| nfft_forward_direct_1d[64/200]   | 29324   | 292944   | yes — 10.0× |
+| nfft_forward_direct_1d[128/400]  | 116439  | 1162350  | yes — 10.0× |
+| nfft_forward_direct_1d[256/800]  | 465332  | 4639490  | yes — 10.0× |
+| nfft_forward_direct_1d[512/1600] | 1862450 | 18496900 | yes — 9.9× |
+| nfft_adjoint_direct_1d[*] (control) | (5 cases) | unchanged | no — 1.0× |
+
+**Metric for the inner loop:** the five `nfft_forward_direct_1d[*]` cases, measured **in all
+three precisions** in Phase D. Pinned in double; the metric is the same case set per precision
+(the long-double baseline shows these cases are ~250× more expensive — the recurrence should pay
+off most there).
+
+## Revert confirmation
+
+- `git diff` empty: **yes**

--- a/docs/perfeng/0001-trafo-direct/phase-d-inner-loop.md
+++ b/docs/perfeng/0001-trafo-direct/phase-d-inner-loop.md
@@ -1,0 +1,38 @@
+# Phase D — inner loop (iteration journal)
+
+- **B-net:** `nfft` (116 cases; `checkall` + `checkall_threads`, **all three precisions**) · **C-metric:** `nfft_forward_direct_1d[*]`
+- **Current change:** `artifacts/change.diff`
+
+## The idea (discovered here)
+
+The 1d inner loop evaluates `e^{-i·omega_k}` with `omega_k = 2π(k − N/2)·x[j]` from scratch each
+iteration — two transcendentals per term. `omega_k` advances by a constant `Δ = 2π·x[j]`, so the
+kernel is a geometric sequence `w_{k+1} = w_k · e^{-iΔ}`: evaluate the two trig calls once per
+node, carry the phase by one complex multiply. Pattern: **phase recurrence / strength reduction**.
+Risk: rounding drift over `N` steps — guarded by the B-net tolerance, **checked in every precision**.
+
+## Iterations
+
+<!-- Iteration journal (canonical format). net = green in all three precisions. -->
+| iter | change | net | metric median (ns) before→after |
+|------|--------|-----|----------------------------------|
+| 1 | phase recurrence: hoist `COS/SIN` per node, carry `w *= dw` in the 1d loop | green d/f/l (d 1854/0, f 1843/0, l 1854/0) | see per-precision table below |
+
+### Per-precision speedup at iter 1 (forward_direct_1d median, baseline → after)
+
+| prec | [32/100] | [128/400] | [512/1600] | speedup range |
+|------|----------|-----------|------------|---------------|
+| d (double)      | 7694 → 5276       | 116439 → 92213      | 1862450 → 1463150     | **1.26–1.46×** |
+| f (float)       | 7779 → 4483       | 133304 → 86394      | 2222930 → 1417260     | **1.54–1.74×** |
+| l (long double) | 1895590 → 517441  | 32886100 → 8698350  | 528143000 → 132877000 | **3.66–3.97×** |
+
+**The win is precision-dependent** — and largest exactly where the baseline is worst: long-double
+`COSL`/`SINL` are ~250× the double cost, so removing them per-iteration is a ~4× win, vs ~1.3× in
+double. A double-only loop would have reported only the ~1.3× and missed this entirely. The drift
+risk did **not** materialise: the net stays green at every size in all three precisions.
+
+## Exit state
+
+- B-net green at latest kept state, **all precisions**: **yes** (d 1854/0, f 1843/0, l 1854/0; `checkall_threads` clean)
+- metric median dropped beyond noise: **yes** (d ~1.3×, f ~1.6×, l ~3.9×; stdev <1.5%)
+- `artifacts/change.diff` matches latest kept state: **yes**

--- a/docs/perfeng/0001-trafo-direct/phase-e-exit-gate.md
+++ b/docs/perfeng/0001-trafo-direct/phase-e-exit-gate.md
@@ -1,0 +1,94 @@
+# Phase E — exit gate
+
+- **Verdict:** ⚠ **partial / landed with caveat** — target improves in all three precisions and the net is green everywhere, but **one confirmed float regression** on an untouched control case. A reviewer must weigh ship-vs-fix-vs-revert.
+- **Target metric (forward_direct_1d):** double ~1.3× · float ~1.6× · **long double ~3.9×** faster
+- **Landed change:** `artifacts/change.diff` (kernel/nfft/nfft.c, the 1d phase recurrence)
+
+## Comparison (baseline → final, per precision)
+
+<!-- Comparison table (canonical format, prec column). Noise rule: regressed only if median
+     rises past max(3·stdev, 2% of base) AND survives a re-run. The 3 float flags were re-run:
+     only adjoint_1d[32/100] survived. long double = 1d family full + (2d/3d trimmed, see notes). -->
+| prec | case | base median_ns | final median_ns | Δ% | verdict |
+|------|------|----------------|-----------------|----|---------|
+| d | nfft_adjoint_direct_1d[128/400] | 124373 | 124247 | -0.1% | noise |
+| d | nfft_adjoint_direct_1d[256/800] | 502903 | 500677 | -0.4% | noise |
+| d | nfft_adjoint_direct_1d[32/100] | 8464 | 8491 | +0.3% | noise |
+| d | nfft_adjoint_direct_1d[512/1600] | 2006180 | 2003650 | -0.1% | noise |
+| d | nfft_adjoint_direct_1d[64/200] | 31395 | 31379 | -0.1% | noise |
+| d | nfft_adjoint_direct_2d[16/16/500] | 1260930 | 1251880 | -0.7% | noise |
+| d | nfft_adjoint_direct_2d[32/32/1000] | 9881200 | 9918570 | +0.4% | noise |
+| d | nfft_adjoint_direct_2d[64/64/2000] | 65500100 | 65184700 | -0.5% | noise |
+| d | nfft_adjoint_direct_3d[16/16/16/1000] | 40254800 | 40063600 | -0.5% | noise |
+| d | nfft_adjoint_direct_3d[4/4/4/250] | 98346 | 97820 | -0.5% | noise |
+| d | nfft_adjoint_direct_3d[8/8/8/500] | 3081320 | 3043050 | -1.2% | noise |
+| d | nfft_forward_direct_1d[128/400] | 116439 | 91781 | -21.2% | faster |
+| d | nfft_forward_direct_1d[256/800] | 465332 | 365396 | -21.5% | faster |
+| d | nfft_forward_direct_1d[32/100] | 7694 | 5204 | -32.4% | faster |
+| d | nfft_forward_direct_1d[512/1600] | 1862450 | 1468760 | -21.1% | faster |
+| d | nfft_forward_direct_1d[64/200] | 29324 | 22703 | -22.6% | faster |
+| d | nfft_forward_direct_2d[16/16/500] | 1312200 | 1274770 | -2.9% | noise |
+| d | nfft_forward_direct_2d[32/32/1000] | 10305100 | 9971300 | -3.2% | noise |
+| d | nfft_forward_direct_2d[64/64/2000] | 66904600 | 65103600 | -2.7% | faster |
+| d | nfft_forward_direct_3d[16/16/16/1000] | 42093800 | 40236200 | -4.4% | faster |
+| d | nfft_forward_direct_3d[4/4/4/250] | 96383 | 94932 | -1.5% | noise |
+| d | nfft_forward_direct_3d[8/8/8/500] | 3209680 | 3078380 | -4.1% | faster |
+| f | nfft_adjoint_direct_1d[128/400] | 134820 | 134708 | -0.1% | noise |
+| f | nfft_adjoint_direct_1d[256/800] | 547651 | 559795 | +2.2% | noise (re-run +0.2%, did not survive) |
+| f | nfft_adjoint_direct_1d[32/100] | 7849 | 8508 | +8.4% | ⚠ REGRESSED (confirmed: stable +8% vs reverted baseline; layout) |
+| f | nfft_adjoint_direct_1d[512/1600] | 2348450 | 2295190 | -2.3% | faster |
+| f | nfft_adjoint_direct_1d[64/200] | 33177 | 33214 | +0.1% | noise |
+| f | nfft_adjoint_direct_2d[16/16/500] | 436553 | 445324 | +2.0% | noise (re-run +0.5%, did not survive) |
+| f | nfft_adjoint_direct_2d[32/32/1000] | 3514870 | 3507950 | -0.2% | noise |
+| f | nfft_adjoint_direct_2d[64/64/2000] | 26436400 | 26338700 | -0.4% | noise |
+| f | nfft_adjoint_direct_3d[16/16/16/1000] | 13699100 | 13757100 | +0.4% | noise |
+| f | nfft_adjoint_direct_3d[4/4/4/250] | 61621 | 62228 | +1.0% | noise |
+| f | nfft_adjoint_direct_3d[8/8/8/500] | 952768 | 956795 | +0.4% | noise |
+| f | nfft_forward_direct_1d[128/400] | 133304 | 88442 | -33.7% | faster |
+| f | nfft_forward_direct_1d[256/800] | 541102 | 357644 | -33.9% | faster |
+| f | nfft_forward_direct_1d[32/100] | 7779 | 4604 | -40.8% | faster |
+| f | nfft_forward_direct_1d[512/1600] | 2222930 | 1439690 | -35.2% | faster |
+| f | nfft_forward_direct_1d[64/200] | 32829 | 20858 | -36.5% | faster |
+| f | nfft_forward_direct_2d[16/16/500] | 426308 | 422429 | -0.9% | noise |
+| f | nfft_forward_direct_2d[32/32/1000] | 3382850 | 3377610 | -0.2% | noise |
+| f | nfft_forward_direct_2d[64/64/2000] | 25346000 | 25269700 | -0.3% | noise |
+| f | nfft_forward_direct_3d[16/16/16/1000] | 13284100 | 13277100 | -0.1% | noise |
+| f | nfft_forward_direct_3d[4/4/4/250] | 61852 | 61705 | -0.2% | noise |
+| f | nfft_forward_direct_3d[8/8/8/500] | 936773 | 935945 | -0.1% | noise |
+| l | nfft_adjoint_direct_1d[128/400] | 32911800 | 31152400 | -5.3% | faster |
+| l | nfft_adjoint_direct_1d[256/800] | 131517000 | 124886000 | -5.0% | faster |
+| l | nfft_adjoint_direct_1d[32/100] | 1919880 | 1817470 | -5.3% | faster |
+| l | nfft_adjoint_direct_1d[512/1600] | 527667000 | 501199000 | -5.0% | faster |
+| l | nfft_adjoint_direct_1d[64/200] | 8150290 | 7602170 | -6.7% | faster |
+| l | nfft_forward_direct_1d[128/400] | 32886100 | 8716830 | -73.5% | faster |
+| l | nfft_forward_direct_1d[256/800] | 131978000 | 34083800 | -74.2% | faster |
+| l | nfft_forward_direct_1d[32/100] | 1895590 | 527033 | -72.2% | faster |
+| l | nfft_forward_direct_1d[512/1600] | 528143000 | 132684000 | -74.9% | faster |
+| l | nfft_forward_direct_1d[64/200] | 7985810 | 2192720 | -72.5% | faster |
+
+## Exit conditions (float · double · long double)
+
+1. **Full test suite passes as in Phase A, every precision:** ✅ PASS — `ctest` 100% in d/f/l (`checkall` + `checkall_threads`) — `artifacts/final-tests-{d,f,l}.log`
+2. **No benchmark regresses beyond noise, every case/precision:** ⚠ **QUALIFIED FAIL** — double 0/22 and long-double 0/10 clean; **float has 1 confirmed regression**: `adjoint_direct_1d[32/100]` +8% (untouched function; stable ~8480 ns vs stable reverted baseline ~7840 ns over 4+3 runs ⇒ a code-layout / i-cache effect of enlarging the sibling `trafo_direct`, not an algorithmic change). Two other float flags (`adjoint_1d[256/800]` +2.2%, `adjoint_2d[16/16/500]` +2.0%) were **noise** — they did not survive a re-run.
+3. **Deterministic cross-check (simulation):** N/A — no CodSpeed this session; walltime-only. CI's CodSpeed run is the final authority.
+4. **`git diff` is only the intended change:** ✅ PASS — kernel/nfft/nfft.c, the 1d recurrence only.
+
+## Notes / trims
+
+- **long double 2d/3d were not benchmarked** (each ~250× the double cost → tens of minutes). The
+  change is strictly in the 1d branch; the multivariate (2d/3d) path is untouched and is covered
+  at full fidelity in double and float (0 regressions there). long-double **tests** ran in full
+  (1854/1854). Disclosed per the skill's trim rule.
+- The float `adjoint_1d[32/100]` regression is **precision-specific**: in double the same case is
+  noise (±0%). Double-only validation would have shipped this blind — this is precisely the value
+  of the precision matrix.
+
+## Verdict
+
+The phase recurrence is a large, real win on the target in **every** precision — and a **~3.9×**
+win in long double, where `COSL`/`SINL` dominate — with the 116-case correctness net green in
+float, double, and long double. The exit gate does **not** pass clean: a reproducible ~8% float
+slowdown on the smallest *adjoint* (untouched) micro-benchmark, traced to code layout, trips
+condition 2. This is a judgment call for a human reviewer: ship (the regressed case is an 8µs
+operation; the target gains 1.3–3.9×), attempt a layout-neutral formulation, or revert. Recorded
+as **landed-with-caveat**, not a clean pass.

--- a/docs/perfeng/0001-trafo-direct/preflight.md
+++ b/docs/perfeng/0001-trafo-direct/preflight.md
@@ -1,0 +1,9 @@
+# Preflight — measurement track
+
+- **Track:** walltime
+- **Evidence** (the three CodSpeed checks, in order):
+  - MCP tools present this session: **no**
+  - `codspeed status` logged in: **no** (`codspeed` CLI not on PATH)
+  - repo onboarded with a base-branch run: **no**
+- **Decision:** first check failed ⇒ **walltime**; metric is `median_ns` under the noise rule.
+  Precision matrix is exercised in all three precisions (float·double·long-double).

--- a/docs/perfeng/0001-trafo-direct/summary.html
+++ b/docs/perfeng/0001-trafo-direct/summary.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Perf · X(trafo_direct) — optimization summary</title>
+<style>
+  :root{ --ink:#1a1a1a; --bg:#fffefb; --muted:#6b6256; --rule:#e4ddcf;
+         --brown:#9a6b2f; --blue:#26506e; --green:#5f8a59; --red:#b4412f;
+         --ok:#e7f1e3; --okline:#5f8a59; --fail:#f7e2dd; --failline:#b4412f;
+         --warn:#fbeecb; --warnline:#c79a3a;}
+  *{box-sizing:border-box}
+  body{ background:var(--bg); color:var(--ink); margin:0;
+        font-family:"Iowan Old Style","Palatino Linotype",Georgia,serif;
+        line-height:1.58; -webkit-font-smoothing:antialiased;}
+  .wrap{max-width:820px; margin:0 auto; padding:3rem 1.5rem 6rem;}
+  .kicker{font-size:.72rem; text-transform:uppercase; letter-spacing:.16em; color:var(--brown);}
+  h1{font-size:2rem; line-height:1.12; margin:.3rem 0 .4rem; letter-spacing:-.015em;}
+  .deck{font-size:1.12rem; color:var(--muted); font-style:italic; margin:0 0 1.4rem;}
+  .verdict{border-left:3px solid var(--brown); padding:.8rem 1.1rem; border-radius:0 4px 4px 0;
+           margin:1.4rem 0 2rem; font-size:1rem; background:#f6efe0;}
+  .verdict b{font-size:1.05rem}
+  body.ok      .verdict{background:var(--ok);   border-color:var(--okline)}
+  body.fail    .verdict{background:var(--fail); border-color:var(--failline)}
+  body.partial .verdict{background:var(--warn); border-color:var(--warnline)}
+  .meta{display:grid; grid-template-columns:auto 1fr; gap:.25rem 1rem; font-size:.9rem; color:var(--muted); margin:.6rem 0 0;}
+  .meta b{color:var(--ink); font-weight:600}
+  h2{font-size:1.32rem; margin:2.6rem 0 .7rem; letter-spacing:-.01em;}
+  p{margin:.8rem 0}
+  code{font-family:"SF Mono",Menlo,Consolas,monospace; font-size:.85em; background:#f3eede; padding:.05em .35em; border-radius:3px;}
+  pre{font-family:"SF Mono",Menlo,Consolas,monospace; font-size:.82rem; line-height:1.45; background:#f3eede; border:1px solid var(--rule); border-radius:6px; padding:.9rem 1.1rem; overflow:auto;}
+  pre code{background:none; padding:0; font-size:1em;}
+  .cap{font-size:.84rem; color:var(--muted); margin:.4rem 0 1.4rem;}
+  table{border-collapse:collapse; width:100%; font-size:.92rem; margin:1.1rem 0;}
+  th,td{border:1px solid var(--rule); padding:.4rem .6rem; text-align:left;}
+  th{background:#f6efe0; font-weight:600;}
+  td.num{text-align:right; font-family:"SF Mono",Menlo,Consolas,monospace;}
+  .good{color:var(--green); font-weight:600} .bad{color:var(--red); font-weight:600}
+  .cols{display:grid; grid-template-columns:1fr 1fr; gap:1.4rem; margin:1.1rem 0;}
+  .cols h3{font-size:1rem; margin:.2rem 0 .4rem; color:var(--blue)}
+  ul{margin:.5rem 0 .5rem 1.1rem; padding:0} li{margin:.3rem 0}
+  aside{font-size:.92rem; color:var(--muted); border-left:2px solid var(--rule); padding-left:1rem; margin:1.4rem 0;}
+  .carry{background:#f7f2e7; border:1px solid var(--rule); border-radius:8px; padding:1.1rem 1.3rem; margin:1.4rem 0;}
+  .carry h2{margin-top:.2rem}
+  a{color:var(--blue)}
+  footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); color:var(--muted); font-size:.82rem;}
+  footer a{margin-right:1rem;}
+</style>
+</head>
+<body class="partial">
+<div class="wrap">
+
+  <div class="kicker">Performance optimization · NFFT3</div>
+  <h1><code>X(trafo_direct)()</code> — phase recurrence in the 1d direct NDFT</h1>
+  <p class="deck">Replace two transcendentals per inner-loop iteration with one complex multiply. A large, precision-dependent win — up to ~3.9× in long double — but with one reproducible float side-effect the matrix caught.</p>
+
+  <div class="verdict">
+    <b>⚠ Landed with caveat</b> — the target speeds up in <b>every</b> precision
+    (<b>~1.3× double, ~1.6× float, ~3.9× long double</b>) with the 116-case correctness net green
+    in all three. But the exit gate is <b>not clean</b>: a reproducible <b>+8% slowdown</b> on the
+    untouched <code>adjoint_direct_1d[32/100]</code> micro-benchmark <em>in float only</em> — a
+    code-layout effect. A reviewer must decide: ship, attempt a layout-neutral form, or revert.
+    <div class="meta">
+      <b>Target</b><span><code>X(trafo_direct)()</code> — kernel/nfft/nfft.c:145 (1d branch)</span>
+      <b>Track</b><span>walltime</span>
+      <b>Precisions</b><span>float · double · long double — net green in all three (1843/1854/1854)</span>
+      <b>Baseline commit</b><span>a692216c</span>
+      <b>Date</b><span>2026-06-16</span>
+      <b>Tracker</b><span><a href="README.md">README.md</a></span>
+    </div>
+  </div>
+
+  <h2>1 · The target — what we optimized and why</h2>
+  <p><code>X(trafo_direct)</code> is the direct (<code>O(N·M)</code>) nonequispaced DFT; its 1d hot
+  loop evaluates <code>COS</code>/<code>SIN</code> on every inner iteration. It is precision-agnostic,
+  so it must be validated in float, double, <em>and</em> long double — where the per-call trig cost
+  differs by orders of magnitude.</p>
+  <pre><code>/* 1d branch, before */
+for (k_L = 0; k_L &lt; ths-&gt;N_total; k_L++) {
+  R omega = K2PI * ((R)(k_L - ths-&gt;N_total/2)) * ths-&gt;x[j];
+  v += f_hat[k_L] * (COS(omega) - II * SIN(omega));   /* 2 transcendentals / term */
+}</code></pre>
+
+  <h2>2 · The idea — what to change, and the reasoning</h2>
+  <p><code>omega_k</code> advances by a constant <code>Δ = 2π·x[j]</code> as <code>k</code> grows, so
+  the kernel <code>e<sup>−iω</sup></code> is a geometric sequence: evaluate the two trig calls once
+  per node, then carry the phase by one complex multiply per term (phase recurrence / strength
+  reduction).</p>
+  <pre><code>/* 1d branch, after */
+C w  = COS(omega0) - II * SIN(omega0);   /* start phase */
+C dw = COS(domega) - II * SIN(domega);   /* step factor */
+for (k_L = 0; k_L &lt; ths-&gt;N_total; k_L++) { v += f_hat[k_L] * w; w *= dw; }</code></pre>
+  <aside><b>Risk watched:</b> rounding drift over <code>N</code> steps — checked against the net
+  tolerance <em>in every precision</em>. It held (float included).</aside>
+
+  <h2>3 · The process — idea to verdict</h2>
+  <table>
+    <tr><th>Phase</th><th>What happened</th></tr>
+    <tr><td>A · baseline</td><td>Built all 3 precision trees (after clearing a stale in-source <code>config.h</code> that had broken non-double builds); full suite green d/f/l; 22 bench cases × 3. <b>Long double is ~250× slower than double</b> here (<code>COSL</code>/<code>SINL</code>).</td></tr>
+    <tr><td>B · correctness net</td><td>Imaginary-sign fault pins 116 <code>nfft</code> cases (1d <code>trafo_direct</code> + online).</td></tr>
+    <tr><td>C · performance metric</td><td>10× slowdown moves <code>forward_direct_1d[*]</code> ~10×; adjoint control flat → that is the metric.</td></tr>
+    <tr><td>D · inner loop</td><td>Recurrence applied (1 iteration). Net green d/f/l; metric drops ~1.3×/1.6×/3.9×.</td></tr>
+    <tr><td>E · exit gate</td><td>Full <code>ctest</code> green d/f/l. Benchmarks: double &amp; long-double clean; <b>float flags one real regression</b> on an untouched adjoint case (below).</td></tr>
+  </table>
+
+  <h2>4 · Results — the target, per precision</h2>
+  <table>
+    <tr><th>prec</th><th>case</th><th>before (ns)</th><th>after (ns)</th><th>Δ</th><th>note</th></tr>
+    <tr><td>d</td><td>forward_direct_1d[512/1600]</td><td class="num">1862450</td><td class="num">1468760</td><td class="good">−21%</td><td>~1.3×</td></tr>
+    <tr><td>f</td><td>forward_direct_1d[512/1600]</td><td class="num">2222930</td><td class="num">1439690</td><td class="good">−35%</td><td>~1.6×</td></tr>
+    <tr><td>l</td><td>forward_direct_1d[512/1600]</td><td class="num">528143000</td><td class="num">132684000</td><td class="good">−75%</td><td><b>~3.9×</b></td></tr>
+  </table>
+  <p>The win scales with the precision's trig cost: marginal-but-real in double, larger in float, and
+  <b>~3.9× in long double</b> where <code>COSL</code>/<code>SINL</code> dominate. (Full 22-case × 3-precision
+  table in <a href="phase-e-exit-gate.md">phase-e-exit-gate.md</a>; raw JSON in <code>artifacts/</code>.)</p>
+
+  <h2>5 · The caveat (why the gate is not clean)</h2>
+  <table>
+    <tr><th>case (float)</th><th>baseline</th><th>final</th><th>re-run</th><th>verdict</th></tr>
+    <tr><td>adjoint_direct_1d[32/100]</td><td class="num">7849</td><td class="num">8508</td><td class="num">~8480 (×4)</td><td class="bad">+8% — real (layout)</td></tr>
+    <tr><td>adjoint_direct_1d[256/800]</td><td class="num">547651</td><td class="num">559795</td><td class="num">+0.2%</td><td>noise (didn't survive)</td></tr>
+    <tr><td>adjoint_direct_2d[16/16/500]</td><td class="num">436553</td><td class="num">445324</td><td class="num">+0.5%</td><td>noise (didn't survive)</td></tr>
+  </table>
+  <ul>
+    <li><b>Known:</b> <code>adjoint_direct</code> is <em>not touched</em> by this change, yet float
+        <code>adjoint_1d[32/100]</code> is a stable ~8480 ns vs a stable reverted-baseline ~7840 ns
+        (confirmed by reverting + rebuilding + 4+3 independent runs). Cause: enlarging the sibling
+        <code>trafo_direct</code> shifts <code>adjoint_direct</code>'s code placement → i-cache/alignment
+        on the smallest case. <b>It is precision-specific</b> — in double the same case is noise.</li>
+    <li><b>Mechanism confirmed = alignment.</b> Rebuilding the float tree with
+        <code>-falign-functions=64 -falign-loops=32</code> (everything else equal) returns
+        <code>adjoint_1d[32/100]</code> to <b>~7840 ns</b> (regression gone) while the target
+        <code>forward_1d[32/100]</code> stays <b>~4470 ns (~1.7×)</b>. So it is alignment roulette,
+        not an algorithmic change to adjoint — deterministic alignment makes the neighbour insensitive
+        to <code>trafo_direct</code>'s size.</li>
+    <li><b>To resolve (recommended):</b> add <code>-falign-functions=64</code> as a <em>separate
+        build-policy change</em> — it removes this regression and damps the broader walltime layout
+        jitter, without touching the optimization diff. Alternatives: accept + document (the regressed
+        case is an 8 µs op on the slow reference path), or revert. <b>Deferred to a focused session</b>
+        — handoff at <code>/tmp/handoff-nfft-alignment-regression.md</code> (validate the flag across
+        the full matrix, weigh code-size, decide default-vs-opt-in).</li>
+  </ul>
+
+  <h2>6 · Patterns</h2>
+  <div class="cols">
+    <div><h3>Used</h3><ul>
+      <li>Phase recurrence — a constant-step phase is a geometric sequence; carry by multiplication.</li>
+      <li>Strength reduction — per-iteration transcendentals → one complex multiply.</li>
+    </ul></div>
+    <div><h3>Discovered</h3><ul>
+      <li><b>The win is precision-dependent</b> (1.3× / 1.6× / 3.9×) and largest where the baseline is
+          worst (long double). Double-only would report only the floor.</li>
+      <li><b>Code layout can regress an untouched sibling</b> — and only in one precision. The full
+          per-precision exit gate is what surfaced it; a scoped or double-only check would not.</li>
+    </ul></div>
+  </div>
+
+  <div class="carry">
+    <h2>7 · Carry-forward notes</h2>
+    <ul>
+      <li><b>Clear stale in-source <code>include/config.h</code> before configuring precision trees</b>
+          (a leftover Autotools double config silently breaks float/long-double linking). CI does this;
+          the skill now does too.</li>
+      <li><b>Long double trig is ~250× double</b> on this hardware — any cos/sin-heavy kernel is a prime
+          long-double optimization target, with outsized payoff there.</li>
+      <li><b>The same recurrence applies to <code>adjoint_direct</code> and the multivariate branches</b>
+          (untouched here) — obvious next targets, and doing adjoint too might offset the layout shift.</li>
+      <li><b>Re-run flagged walltime cases</b> — 2 of 3 float flags here were noise that vanished on re-run;
+          only the reverted-baseline comparison proved the third real.</li>
+    </ul>
+  </div>
+
+  <footer>
+    Deliverables: <a href="preflight.md">preflight</a> <a href="phase-a-baseline.md">A·baseline</a>
+    <a href="phase-b-correctness-net.md">B·net</a> <a href="phase-c-performance-metric.md">C·metric</a>
+    <a href="phase-d-inner-loop.md">D·inner</a> <a href="phase-e-exit-gate.md">E·exit</a>
+    · raw data in <code>artifacts/</code> · tracker <a href="README.md">README.md</a>
+  </footer>
+</div>
+</body>
+</html>

--- a/docs/perfeng/README.md
+++ b/docs/perfeng/README.md
@@ -1,0 +1,35 @@
+# Performance engineering log (`docs/perfeng/`)
+
+One directory per optimization, front-to-back — the way [`docs/adr/`](../adr/) keeps
+one file per decision. Each directory records a single scoped optimization (a
+function, a hot loop) as it moves through the test-pinned, benchmark-measured loop,
+with a concrete **deliverable** captured at every phase.
+
+These directories are **produced by the `optimize-nfft-performance` skill**
+(`.claude/skills/optimize-nfft-performance/`). Don't hand-author them; the skill
+creates the directory, the tracker, and the per-phase deliverables as it runs. The
+deliverable format and the exit-gate-per-phase rule live in the skill's
+[`details/deliverables.md`](../../.claude/skills/optimize-nfft-performance/details/deliverables.md).
+
+## Layout
+
+```
+docs/perfeng/
+  README.md                         # this file — convention + index
+  NNNN-<target-slug>/               # one optimization (e.g. 0001-trafo-direct)
+    README.md                       # the tracker: phase status, links, outcome
+    preflight.md  phase-a-baseline.md  phase-b-correctness-net.md
+    phase-c-performance-metric.md   phase-d-inner-loop.md  phase-e-exit-gate.md
+    summary.html                    # human-facing close-out report (any outcome)
+    artifacts/                      # raw logs, benchmark JSON, diffs
+```
+
+The tracker (`README.md`) is the agent-facing front page; `summary.html` is the
+**human report** — open it to read the run end-to-end (idea → process → results, plus
+failure analysis and reusable lessons) and approve the work.
+
+## Index
+
+| Task | Target | Track | Status | Outcome |
+|------|--------|-------|--------|---------|
+| [0001-trafo-direct](0001-trafo-direct/) | `X(trafo_direct)` (kernel/nfft/nfft.c:145) | walltime | complete (caveat) | recurrence: ~1.3×/1.6×/3.9× (d/f/l), net green all 3; one confirmed +8% float layout regression on an untouched control case → reviewer decides |

--- a/kernel/nfft/nfft.c
+++ b/kernel/nfft/nfft.c
@@ -157,10 +157,17 @@ void X(trafo_direct)(const X(plan) *ths)
     {
       C v = K(0.0);
       INT k_L;
+      /* The kernel e^{-i omega_k} with omega_k = 2pi (k - N/2) x[j] advances by a
+       * constant factor as k increments, so evaluate the two trigonometric calls
+       * once per node and carry the phase by complex multiplication. */
+      R omega0 = K2PI * ((R)(-ths->N_total/2)) * ths->x[j];
+      R domega = K2PI * ths->x[j];
+      C w = COS(omega0) - II * SIN(omega0);
+      C dw = COS(domega) - II * SIN(domega);
       for (k_L = 0; k_L < ths->N_total; k_L++)
       {
-        R omega = K2PI * ((R)(k_L - ths->N_total/2)) * ths->x[j];
-        v += f_hat[k_L] * (COS(omega) - II * SIN(omega));
+        v += f_hat[k_L] * w;
+        w *= dw;
       }
 
       f[j] = v;


### PR DESCRIPTION
This PR adds an optimization to the 1D direct NFFT algorithm that should result in performance improvements.

It's an example of a result obtained by using a coding agent with a harness to guide the code optimization process and ensure correctness. I'll leave it here for a bit before merging.

Unfortunately, the benchmarks suffer from noise from different GitHub runners and thus are not really comparable with `develop`; see https://codspeed.io/blog/why-glibc-faster-github-actions.

To fix this, we should switch to CodSpeeds Macro Runners. The drawback may be that we can easily hit the 500 minutes per month quota on the free tier. However, for open-source projects, they may be willing to increase the quota as per their website.

It would be best to merge this PR only when we have removed the noise from our CI.