### PR TITLE
Ensure deterministic code alignment (for benchmarks).

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -290,8 +290,11 @@ jobs:
                    -DCODSPEED_MODE=simulation
                    -DFETCHCONTENT_SOURCE_DIR_CODSPEED="$(pwd)/codspeed-cpp" )
         fi
+        # -falign-functions/-falign-loops: force deterministic code layout so an
+        # unrelated function's hot loop can't shift to a worse alignment when a
+        # nearby function changes size (avoids phantom instruction-count regressions).
         cmake -S . -B build-cmake \
-          -DCMAKE_C_FLAGS="-O3 -g -fomit-frame-pointer -fstrict-aliasing -ffast-math" \
+          -DCMAKE_C_FLAGS="-O3 -g -fomit-frame-pointer -fstrict-aliasing -ffast-math -falign-functions=64 -falign-loops=32" \
           -DNFFT_WINDOW="${WINDOW}" ${CMAKE_PREC} ${CMAKE_OMP} ${CMAKE_JULIA} \
           -DNFFT_ENABLE_EXHAUSTIVE_UNIT_TESTS=ON \
           -DNFFT_ENABLE_EXAMPLES=ON -DNFFT_ENABLE_APPLICATIONS=ON \


### PR DESCRIPTION
This fixes a potential issue regarding benchmark metrics while optimizing code. In certain environments, e.g. when running inside a devcontainer, it can happen that GCCs -O3 option may not pick the optimal code alignment parameters for the host machine. If code is then changed, then this may cause other untouched code to change its alignment in the output unfavorably, so that a benchmark regression from the affected code appears. To avoid this, we set fixed alignment parameters for functions and loops to reduce this noise.

Note: We set the fixed alignment parameters only in CI to safeguard for benchmark runs, not when a user actually builds the project.