### PR TITLE
Change to wallclock mode.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -63,10 +63,12 @@ USER vscode
 ENV EDITOR=nano
 ENV VISUAL=nano
 
-# Install Julia, uv, and Python.
+# Install Julia, uv, Python, zizmor.
+ENV PATH="/home/vscode/.local/bin:${PATH}"
 RUN curl -fsSL https://install.julialang.org | sh -s -- -y \
   && curl -fsSL https://astral.sh/uv/install.sh | sh \
-  && /home/vscode/.local/bin/uv python install --default 3.13
+  && /home/vscode/.local/bin/uv python install --default 3.13 \
+  && bin/uv tool install zizmor
 
 # Install RTK.
 RUN curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh

--- a/.github/workflows/bench-linux.yml
+++ b/.github/workflows/bench-linux.yml
@@ -56,10 +56,6 @@ jobs:
           build-essential
           cmake
           libfftw3-dev
-          libcunit1-dev 
-          doxygen 
-          doxygen-latex 
-          graphviz
           libomp-dev
           libatomic1
 
@@ -94,16 +90,13 @@ jobs:
           *) echo "Unknown PRECISION_OPT '${PRECISION_OPT}'" >&2; exit 1 ;;
         esac
         EXTRA=()
-        if [ "${WINDOW}" = "kaiserbessel" ] && [ "${COMPILER}" = "gcc" ]; then
-          AGNOSTIC_FLAGS="window:1"
-          AGNOSTIC_FLAGS="$AGNOSTIC_FLAGS,openmp:1"
-          [ "${PRECISION_OPT}" = "" ] && AGNOSTIC_FLAGS="$AGNOSTIC_FLAGS,precision:1" || AGNOSTIC_FLAGS="$AGNOSTIC_FLAGS,precision:0"
-          EXTRA+=( -DNFFT_ENABLE_BENCHMARKS=ON
-                   -DBENCHMARKS_PREFIX="${BUILD_CONFIG}/"
-                   -DNFFT_AGNOSTIC_BENCHMARKS="$AGNOSTIC_FLAGS"
-                   -DCODSPEED_MODE=walltime
-                   -DFETCHCONTENT_SOURCE_DIR_CODSPEED="$(pwd)/codspeed-cpp" )
-        fi
+        AGNOSTIC_FLAGS="window:1,openmp:1"
+        [ "${PRECISION_OPT}" = "" ] && AGNOSTIC_FLAGS="$AGNOSTIC_FLAGS,precision:1" || AGNOSTIC_FLAGS="$AGNOSTIC_FLAGS,precision:0"
+        EXTRA+=( -DNFFT_ENABLE_BENCHMARKS=ON
+                  -DBENCHMARKS_PREFIX="${BUILD_CONFIG}/"
+                  -DNFFT_AGNOSTIC_BENCHMARKS="$AGNOSTIC_FLAGS"
+                  -DCODSPEED_MODE=walltime
+                  -DFETCHCONTENT_SOURCE_DIR_CODSPEED="$(pwd)/codspeed-cpp" )
         # -falign-functions/-falign-loops: force deterministic code layout so an
         # unrelated function's hot loop can't shift to a worse alignment when a
         # nearby function changes size (avoids phantom instruction-count regressions).
@@ -118,7 +111,6 @@ jobs:
       run: cmake --build build-cmake -j
 
     - name: CMake — Benchmarks
-      if: matrix.window == 'kaiserbessel' && matrix.compiler == 'gcc'
       uses: CodSpeedHQ/action@3194d9a39c4d46684cb44bf7207fc56626aad8fd # v4
       with:
         # "walltime" measures real elapsed time instead of the deterministic

--- a/.github/workflows/bench-linux.yml
+++ b/.github/workflows/bench-linux.yml
@@ -1,6 +1,13 @@
 name: Bench Linux
 
 on:
+  # SECURITY INVARIANT: use `pull_request`, NEVER `pull_request_target`.
+  # `pull_request` runs fork code with a read-only token and no secrets;
+  # `pull_request_target` would expose a read-write token + secrets to
+  # untrusted PR code. Benchmarks on PRs are gated by the `benchmarks`
+  # environment approval below (see the job's `environment:`); pushes to the
+  # default branches run automatically to keep the CodSpeed baseline fresh.
+  # `workflow_dispatch` runs are also un-gated (ad-hoc manual runs).
   push:
     branches: [ main, develop, master ]
   pull_request:
@@ -11,14 +18,27 @@ permissions:
   contents: read
 
 concurrency:
-  group: bench-linux
-  cancel-in-progress: false
+  # Per-ref group: a new push to a PR supersedes that PR's older, not-yet-approved
+  # benchmark run (GitHub can't distinguish "waiting for approval" from "running",
+  # so cancel-in-progress cancels the stale waiting run too — desired, since the
+  # superseded commit's run is stale anyway). Per-ref (not global) so one PR never
+  # cancels another PR's or the default branch's run. The approval gate is now the
+  # throttle, so global serialization is no longer needed. For default-branch
+  # pushes, a rapid second push likewise supersedes the first; CodSpeed still
+  # records the latest commit as the baseline.
+  group: bench-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CODSPEED_VERSION: v2.3.0
 
 jobs:
   build:
+    # OPT-IN GATE: on pull_request, reference the protected `benchmarks`
+    # environment so a required reviewer must approve before any PR code runs.
+    # On push/workflow_dispatch the name is empty -> no environment -> no gate,
+    # so default-branch baseline runs stay automatic.
+    environment: ${{ github.event_name == 'pull_request' && 'benchmarks' || '' }}
     runs-on: ${{ matrix.os }}
     env:
       BUILD_CONFIG: "${{ matrix.os }}_${{ matrix.compiler }}_${{ matrix.window }}_${{ matrix.precision_opt == '' && 'double' || matrix.precision_opt == '--enable-float' && 'float' || matrix.precision_opt == '--enable-long-double' && 'long-double' || 'unknown' }}"

--- a/.github/workflows/bench-linux.yml
+++ b/.github/workflows/bench-linux.yml
@@ -1,4 +1,4 @@
-name: Build Linux
+name: Bench Linux
 
 on:
   push:
@@ -85,6 +85,7 @@ jobs:
       env:
         WINDOW: ${{ matrix.window }}
         PRECISION_OPT: ${{ matrix.precision_opt }}
+        COMPILER: ${{ matrix.compiler }}
       run: |
         case "${PRECISION_OPT}" in
           "")                     CMAKE_PREC="" ;;
@@ -109,6 +110,8 @@ jobs:
         cmake -S . -B build-cmake \
           -DCMAKE_C_FLAGS="-O3 -g -fomit-frame-pointer -fstrict-aliasing -ffast-math -falign-functions=64 -falign-loops=32" \
           -DNFFT_WINDOW="${WINDOW}" ${CMAKE_PREC} -DNFFT_ENABLE_OPENMP=ON \
+          -DNFFT_ENABLE_EXHAUSTIVE_UNIT_TESTS=OFF \
+          -DNFFT_ENABLE_EXAMPLES=OFF -DNFFT_ENABLE_APPLICATIONS=OFF \
           "${EXTRA[@]}"
 
     - name: CMake — Build

--- a/.github/workflows/bench-linux.yml
+++ b/.github/workflows/bench-linux.yml
@@ -25,7 +25,7 @@ jobs:
     name: "${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.window }}-${{ matrix.precision_opt == '' && 'double' || matrix.precision_opt == '--enable-float' && 'float' || matrix.precision_opt == '--enable-long-double' && 'long-double' || 'unknown' }}"
     strategy:
       matrix:
-        os: ["ubuntu-latest"]
+        os: ["codspeed-macro"]
         compiler: ["gcc"]
         window: ["kaiserbessel"]
         precision_opt: ["", "--enable-float", "--enable-long-double"]
@@ -34,11 +34,11 @@ jobs:
       with:
         persist-credentials: false
 
-    - name: Disable initramfs update
-      run: sudo sed -i 's/yes/no/g' /etc/initramfs-tools/update-initramfs.conf
+    # - name: Disable initramfs update
+    #   run: sudo sed -i 's/yes/no/g' /etc/initramfs-tools/update-initramfs.conf
 
-    - name: Disable man-db update
-      run: sudo rm -f /var/lib/man-db/auto-update        
+    # - name: Disable man-db update
+    #   run: sudo rm -f /var/lib/man-db/auto-update        
     
     - name: Install dependencies
       uses: dsx137/deb-cache@caf71786c0050ce140ac752de004d7c1343d4363 # main

--- a/.github/workflows/bench-linux.yml
+++ b/.github/workflows/bench-linux.yml
@@ -1,0 +1,131 @@
+name: Build Linux
+
+on:
+  push:
+    branches: [ main, develop, master ]
+  pull_request:
+    branches: [ main, develop, master ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bench-linux
+  cancel-in-progress: false
+
+env:
+  CODSPEED_VERSION: v2.3.0
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    env:
+      BUILD_CONFIG: "${{ matrix.os }}_${{ matrix.compiler }}_${{ matrix.window }}_${{ matrix.precision_opt == '' && 'double' || matrix.precision_opt == '--enable-float' && 'float' || matrix.precision_opt == '--enable-long-double' && 'long-double' || 'unknown' }}"
+    name: "${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.window }}-${{ matrix.precision_opt == '' && 'double' || matrix.precision_opt == '--enable-float' && 'float' || matrix.precision_opt == '--enable-long-double' && 'long-double' || 'unknown' }}"
+    strategy:
+      matrix:
+        os: ["ubuntu-latest"]
+        compiler: ["gcc"]
+        window: ["kaiserbessel"]
+        precision_opt: ["", "--enable-float", "--enable-long-double"]
+    steps:    
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
+
+    - name: Disable initramfs update
+      run: sudo sed -i 's/yes/no/g' /etc/initramfs-tools/update-initramfs.conf
+
+    - name: Disable man-db update
+      run: sudo rm -f /var/lib/man-db/auto-update        
+    
+    - name: Install dependencies
+      uses: dsx137/deb-cache@caf71786c0050ce140ac752de004d7c1343d4363 # main
+      with:
+        PACKAGES: |
+          software-properties-common
+
+    - name: Add universe repo
+      run: sudo add-apt-repository universe
+
+    - name: Install dependencies
+      uses: dsx137/deb-cache@caf71786c0050ce140ac752de004d7c1343d4363 # main
+      with:
+        PACKAGES: |
+          build-essential
+          cmake
+          libfftw3-dev
+          libcunit1-dev 
+          doxygen 
+          doxygen-latex 
+          graphviz
+          libomp-dev
+          libatomic1
+
+    - name: Cache CodSpeed integration library
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      id: cache-codspeed
+      with:
+        path: codspeed-cpp
+        key: codspeed-cpp-${{ matrix.os }}-${{ env.CODSPEED_VERSION }}
+
+    - name: Checkout CodSpeed integration library
+      if: steps.cache-codspeed.outputs.cache-hit != 'true'
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
+        repository: CodSpeedHQ/codspeed-cpp
+        ref: "${{ env.CODSPEED_VERSION }}"
+        path: codspeed-cpp
+        submodules: recursive
+
+    - name: CMake — Configure
+      shell: bash
+      env:
+        WINDOW: ${{ matrix.window }}
+        PRECISION_OPT: ${{ matrix.precision_opt }}
+      run: |
+        case "${PRECISION_OPT}" in
+          "")                     CMAKE_PREC="" ;;
+          "--enable-float")       CMAKE_PREC="-DNFFT_ENABLE_FLOAT=ON" ;;
+          "--enable-long-double") CMAKE_PREC="-DNFFT_ENABLE_LONG_DOUBLE=ON" ;;
+          *) echo "Unknown PRECISION_OPT '${PRECISION_OPT}'" >&2; exit 1 ;;
+        esac
+        EXTRA=()
+        if [ "${WINDOW}" = "kaiserbessel" ] && [ "${COMPILER}" = "gcc" ]; then
+          AGNOSTIC_FLAGS="window:1"
+          AGNOSTIC_FLAGS="$AGNOSTIC_FLAGS,openmp:1"
+          [ "${PRECISION_OPT}" = "" ] && AGNOSTIC_FLAGS="$AGNOSTIC_FLAGS,precision:1" || AGNOSTIC_FLAGS="$AGNOSTIC_FLAGS,precision:0"
+          EXTRA+=( -DNFFT_ENABLE_BENCHMARKS=ON
+                   -DBENCHMARKS_PREFIX="${BUILD_CONFIG}/"
+                   -DNFFT_AGNOSTIC_BENCHMARKS="$AGNOSTIC_FLAGS"
+                   -DCODSPEED_MODE=walltime
+                   -DFETCHCONTENT_SOURCE_DIR_CODSPEED="$(pwd)/codspeed-cpp" )
+        fi
+        # -falign-functions/-falign-loops: force deterministic code layout so an
+        # unrelated function's hot loop can't shift to a worse alignment when a
+        # nearby function changes size (avoids phantom instruction-count regressions).
+        cmake -S . -B build-cmake \
+          -DCMAKE_C_FLAGS="-O3 -g -fomit-frame-pointer -fstrict-aliasing -ffast-math -falign-functions=64 -falign-loops=32" \
+          -DNFFT_WINDOW="${WINDOW}" ${CMAKE_PREC} -DNFFT_ENABLE_OPENMP=ON \
+          "${EXTRA[@]}"
+
+    - name: CMake — Build
+      run: cmake --build build-cmake -j
+
+    - name: CMake — Benchmarks
+      if: matrix.window == 'kaiserbessel' && matrix.compiler == 'gcc'
+      uses: CodSpeedHQ/action@3194d9a39c4d46684cb44bf7207fc56626aad8fd # v4
+      with:
+        # "walltime" measures real elapsed time instead of the deterministic
+        # instruction-count "simulation" build. Must match -DCODSPEED_MODE=walltime
+        # in the configure step above. NOTE: walltime on shared GitHub-hosted
+        # runners is sensitive to neighbour noise; CodSpeed recommends their
+        # hosted macro runners for stable walltime data.
+        mode: walltime
+        run: |
+          ./build-cmake/benchmarks/bench_nfft_direct
+          if [ -x ./build-cmake/benchmarks/bench_nfft_direct_omp ]; then
+            ./build-cmake/benchmarks/bench_nfft_direct_omp
+          fi

--- a/.github/workflows/bench-linux.yml
+++ b/.github/workflows/bench-linux.yml
@@ -39,33 +39,20 @@ jobs:
 
     # - name: Disable man-db update
     #   run: sudo rm -f /var/lib/man-db/auto-update        
-    
-    - name: Install dependencies
-      uses: dsx137/deb-cache@caf71786c0050ce140ac752de004d7c1343d4363 # main
-      with:
-        PACKAGES: |
-          software-properties-common
-
-    - name: Add universe repo
-      run: sudo add-apt-repository universe
 
     - name: Install dependencies
-      uses: dsx137/deb-cache@caf71786c0050ce140ac752de004d7c1343d4363 # main
-      with:
-        PACKAGES: |
-          libc6-dbg
-          build-essential
-          cmake
-          libfftw3-dev
-          libomp-dev
-          libatomic1
+      run: |
+        sudo apt-get install -y software-properties-common
+        sudo add-apt-repository universe
+        sudo apt-get update
+        sudo apt-get install -y libc6-dbg build-essential cmake libfftw3-dev libomp-dev libatomic1
 
     - name: Cache CodSpeed integration library
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       id: cache-codspeed
       with:
         path: codspeed-cpp
-        key: codspeed-cpp-${{ matrix.os }}-${{ env.CODSPEED_VERSION }}
+        key: codspeed-cpp-${{ runner.arch }}-${{ matrix.os }}-${{ env.CODSPEED_VERSION }}
 
     - name: Checkout CodSpeed integration library
       if: steps.cache-codspeed.outputs.cache-hit != 'true'

--- a/.github/workflows/bench-linux.yml
+++ b/.github/workflows/bench-linux.yml
@@ -53,6 +53,7 @@ jobs:
       uses: dsx137/deb-cache@caf71786c0050ce140ac752de004d7c1343d4363 # main
       with:
         PACKAGES: |
+          libc6-dbg
           build-essential
           cmake
           libfftw3-dev

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -301,16 +301,12 @@ jobs:
         if [ "${BUILD_JULIA}" = "1" ] && [ -z "${PRECISION_OPT}" ]; then
           CMAKE_JULIA="-DNFFT_ENABLE_JULIA=ON"
         fi
-        # CUnit test suite only where the tests actually run (gcc + kaiserbessel).
-        CMAKE_TESTS=""
-        if [ "${COMPILER}" = "gcc" ]; then
-          CMAKE_TESTS="-DNFFT_ENABLE_TESTS=ON"
-        fi
         cmake -S . -B build-cmake \
           -DCMAKE_C_FLAGS="-O3 -g -fomit-frame-pointer -fstrict-aliasing -ffast-math" \
-          -DNFFT_WINDOW="${WINDOW}" ${CMAKE_PREC} -DNFFT_ENABLE_OPENMP=ON ${CMAKE_JULIA} ${CMAKE_TESTS} \
+          -DNFFT_WINDOW="${WINDOW}" ${CMAKE_PREC} -DNFFT_ENABLE_OPENMP=ON ${CMAKE_JULIA} \
           -DNFFT_ENABLE_EXHAUSTIVE_UNIT_TESTS=ON \
-          -DNFFT_ENABLE_EXAMPLES=ON -DNFFT_ENABLE_APPLICATIONS=ON
+          -DNFFT_ENABLE_EXAMPLES=ON -DNFFT_ENABLE_APPLICATIONS=ON \
+          -DNFFT_ENABLE_TESTS=ON
 
     - name: CMake — Check config.h parity (Autotools vs. CMake)
       shell: bash
@@ -338,54 +334,54 @@ jobs:
         fi
         echo "example/application binaries present"
 
-    - name: CMake — Test
-      if: matrix.compiler == 'gcc'
-      shell: bash
-      run: |
-        set -o pipefail
-        ctest --test-dir build-cmake --output-on-failure 2>&1 | tee build-cmake/ctest.log
+    # - name: CMake — Test
+    #   if: matrix.compiler == 'gcc'
+    #   shell: bash
+    #   run: |
+    #     set -o pipefail
+    #     ctest --test-dir build-cmake --output-on-failure 2>&1 | tee build-cmake/ctest.log
 
-    - name: CMake — Convert test reports to JUnit
-      if: always()
-      shell: bash
-      run: |
-        conv() { uv run --with lxml python -c "import sys;from lxml import etree;d=etree.parse(sys.argv[1]);open(sys.argv[3],'wb').write(etree.tostring(etree.XSLT(etree.parse(sys.argv[2]))(d),pretty_print=True))" "$1" tests/cunit2junit.xsl "$2"; }
-        [ -f build-cmake/tests/CUnitAutomated-Results.xml ]         && conv build-cmake/tests/CUnitAutomated-Results.xml         build-cmake/tests/junit.xml         || true
-        [ -f build-cmake/tests/CUnitAutomated_threads-Results.xml ] && conv build-cmake/tests/CUnitAutomated_threads-Results.xml build-cmake/tests/junit_threads.xml || true
+    # - name: CMake — Convert test reports to JUnit
+    #   if: always()
+    #   shell: bash
+    #   run: |
+    #     conv() { uv run --with lxml python -c "import sys;from lxml import etree;d=etree.parse(sys.argv[1]);open(sys.argv[3],'wb').write(etree.tostring(etree.XSLT(etree.parse(sys.argv[2]))(d),pretty_print=True))" "$1" tests/cunit2junit.xsl "$2"; }
+    #     [ -f build-cmake/tests/CUnitAutomated-Results.xml ]         && conv build-cmake/tests/CUnitAutomated-Results.xml         build-cmake/tests/junit.xml         || true
+    #     [ -f build-cmake/tests/CUnitAutomated_threads-Results.xml ] && conv build-cmake/tests/CUnitAutomated_threads-Results.xml build-cmake/tests/junit_threads.xml || true
 
-    - name: CMake — Publish Test Report (serial)
-      if: ${{ always() && hashFiles('build-cmake/tests/junit.xml') != '' }}
-      uses: ctrf-io/github-test-reporter@0f299074936c32ccaab5be5230511f6b2b9080aa # v1
-      with:
-        report-path: './build-cmake/tests/junit.xml'
-        integrations-config: |
-          {
-            "junit-to-ctrf": {
-              "enabled": true, "action": "convert",
-              "options": {
-                "output": "./ctrf-reports/ctrf-cmake.json",
-                "toolname": "junit-to-ctrf", "useSuiteName": false,
-                "env": { "appName": "nfft-cmake" }
-              }
-            }
-          }
+    # - name: CMake — Publish Test Report (serial)
+    #   if: ${{ always() && hashFiles('build-cmake/tests/junit.xml') != '' }}
+    #   uses: ctrf-io/github-test-reporter@0f299074936c32ccaab5be5230511f6b2b9080aa # v1
+    #   with:
+    #     report-path: './build-cmake/tests/junit.xml'
+    #     integrations-config: |
+    #       {
+    #         "junit-to-ctrf": {
+    #           "enabled": true, "action": "convert",
+    #           "options": {
+    #             "output": "./ctrf-reports/ctrf-cmake.json",
+    #             "toolname": "junit-to-ctrf", "useSuiteName": false,
+    #             "env": { "appName": "nfft-cmake" }
+    #           }
+    #         }
+    #       }
 
-    - name: CMake — Publish Test Report (threads)
-      if: ${{ always() && hashFiles('build-cmake/tests/junit_threads.xml') != '' }}
-      uses: ctrf-io/github-test-reporter@0f299074936c32ccaab5be5230511f6b2b9080aa # v1
-      with:
-        report-path: './build-cmake/tests/junit_threads.xml'
-        integrations-config: |
-          {
-            "junit-to-ctrf": {
-              "enabled": true, "action": "convert",
-              "options": {
-                "output": "./ctrf-reports/ctrf-cmake-threads.json",
-                "toolname": "junit-to-ctrf", "useSuiteName": false,
-                "env": { "appName": "nfft-cmake-threads" }
-              }
-            }
-          }
+    # - name: CMake — Publish Test Report (threads)
+    #   if: ${{ always() && hashFiles('build-cmake/tests/junit_threads.xml') != '' }}
+    #   uses: ctrf-io/github-test-reporter@0f299074936c32ccaab5be5230511f6b2b9080aa # v1
+    #   with:
+    #     report-path: './build-cmake/tests/junit_threads.xml'
+    #     integrations-config: |
+    #       {
+    #         "junit-to-ctrf": {
+    #           "enabled": true, "action": "convert",
+    #           "options": {
+    #             "output": "./ctrf-reports/ctrf-cmake-threads.json",
+    #             "toolname": "junit-to-ctrf", "useSuiteName": false,
+    #             "env": { "appName": "nfft-cmake-threads" }
+    #           }
+    #         }
+    #       }
 
     - name: CMake — Install
       if: matrix.window == 'kaiserbessel'

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -334,55 +334,6 @@ jobs:
         fi
         echo "example/application binaries present"
 
-    # - name: CMake — Test
-    #   if: matrix.compiler == 'gcc'
-    #   shell: bash
-    #   run: |
-    #     set -o pipefail
-    #     ctest --test-dir build-cmake --output-on-failure 2>&1 | tee build-cmake/ctest.log
-
-    # - name: CMake — Convert test reports to JUnit
-    #   if: always()
-    #   shell: bash
-    #   run: |
-    #     conv() { uv run --with lxml python -c "import sys;from lxml import etree;d=etree.parse(sys.argv[1]);open(sys.argv[3],'wb').write(etree.tostring(etree.XSLT(etree.parse(sys.argv[2]))(d),pretty_print=True))" "$1" tests/cunit2junit.xsl "$2"; }
-    #     [ -f build-cmake/tests/CUnitAutomated-Results.xml ]         && conv build-cmake/tests/CUnitAutomated-Results.xml         build-cmake/tests/junit.xml         || true
-    #     [ -f build-cmake/tests/CUnitAutomated_threads-Results.xml ] && conv build-cmake/tests/CUnitAutomated_threads-Results.xml build-cmake/tests/junit_threads.xml || true
-
-    # - name: CMake — Publish Test Report (serial)
-    #   if: ${{ always() && hashFiles('build-cmake/tests/junit.xml') != '' }}
-    #   uses: ctrf-io/github-test-reporter@0f299074936c32ccaab5be5230511f6b2b9080aa # v1
-    #   with:
-    #     report-path: './build-cmake/tests/junit.xml'
-    #     integrations-config: |
-    #       {
-    #         "junit-to-ctrf": {
-    #           "enabled": true, "action": "convert",
-    #           "options": {
-    #             "output": "./ctrf-reports/ctrf-cmake.json",
-    #             "toolname": "junit-to-ctrf", "useSuiteName": false,
-    #             "env": { "appName": "nfft-cmake" }
-    #           }
-    #         }
-    #       }
-
-    # - name: CMake — Publish Test Report (threads)
-    #   if: ${{ always() && hashFiles('build-cmake/tests/junit_threads.xml') != '' }}
-    #   uses: ctrf-io/github-test-reporter@0f299074936c32ccaab5be5230511f6b2b9080aa # v1
-    #   with:
-    #     report-path: './build-cmake/tests/junit_threads.xml'
-    #     integrations-config: |
-    #       {
-    #         "junit-to-ctrf": {
-    #           "enabled": true, "action": "convert",
-    #           "options": {
-    #             "output": "./ctrf-reports/ctrf-cmake-threads.json",
-    #             "toolname": "junit-to-ctrf", "useSuiteName": false,
-    #             "env": { "appName": "nfft-cmake-threads" }
-    #           }
-    #         }
-    #       }
-
     - name: CMake — Install
       if: matrix.window == 'kaiserbessel'
       shell: bash

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -14,9 +14,6 @@ concurrency:
   group: build-linux
   cancel-in-progress: false
 
-env:
-  CODSPEED_VERSION: v2.3.0
-
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -118,23 +115,6 @@ jobs:
 
     - name: Set up Python
       run: uv python install 3.13
-
-    - name: Cache CodSpeed integration library
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-      id: cache-codspeed
-      with:
-        path: codspeed-cpp
-        key: codspeed-cpp-${{ matrix.os }}-${{ env.CODSPEED_VERSION }}
-
-    - name: Checkout CodSpeed integration library
-      if: steps.cache-codspeed.outputs.cache-hit != 'true'
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      with:
-        persist-credentials: false
-        repository: CodSpeedHQ/codspeed-cpp
-        ref: "${{ env.CODSPEED_VERSION }}"
-        path: codspeed-cpp
-        submodules: recursive
 
     - name: Set up Octave
       if: matrix.build_octave == '1'
@@ -318,27 +298,11 @@ jobs:
         if [ "${BUILD_JULIA}" = "1" ] && [ -z "${PRECISION_OPT}" ]; then
           CMAKE_JULIA="-DNFFT_ENABLE_JULIA=ON"
         fi
-        # Benchmark flags ONLY in the benchmark-producing cells: plain gcc, kaiserbessel.
-        EXTRA=()
-        if [ "${WINDOW}" = "kaiserbessel" ] && [ "${COMPILER}" = "gcc" ]; then
-          AGNOSTIC_FLAGS="window:1"
-          AGNOSTIC_FLAGS="$AGNOSTIC_FLAGS,openmp:1"
-          [ "${PRECISION_OPT}" = "" ] && AGNOSTIC_FLAGS="$AGNOSTIC_FLAGS,precision:1" || AGNOSTIC_FLAGS="$AGNOSTIC_FLAGS,precision:0"
-          EXTRA+=( -DNFFT_ENABLE_BENCHMARKS=ON
-                   -DBENCHMARKS_PREFIX="${BUILD_CONFIG}/"
-                   -DNFFT_AGNOSTIC_BENCHMARKS="$AGNOSTIC_FLAGS"
-                   -DCODSPEED_MODE=walltime
-                   -DFETCHCONTENT_SOURCE_DIR_CODSPEED="$(pwd)/codspeed-cpp" )
-        fi
-        # -falign-functions/-falign-loops: force deterministic code layout so an
-        # unrelated function's hot loop can't shift to a worse alignment when a
-        # nearby function changes size (avoids phantom instruction-count regressions).
         cmake -S . -B build-cmake \
-          -DCMAKE_C_FLAGS="-O3 -g -fomit-frame-pointer -fstrict-aliasing -ffast-math -falign-functions=64 -falign-loops=32" \
+          -DCMAKE_C_FLAGS="-O3 -g -fomit-frame-pointer -fstrict-aliasing -ffast-math" \
           -DNFFT_WINDOW="${WINDOW}" ${CMAKE_PREC} -DNFFT_ENABLE_OPENMP=ON ${CMAKE_JULIA} \
           -DNFFT_ENABLE_EXHAUSTIVE_UNIT_TESTS=ON \
-          -DNFFT_ENABLE_EXAMPLES=ON -DNFFT_ENABLE_APPLICATIONS=ON \
-          "${EXTRA[@]}"
+          -DNFFT_ENABLE_EXAMPLES=ON -DNFFT_ENABLE_APPLICATIONS=ON"
 
     - name: CMake — Check config.h parity (Autotools vs. CMake)
       shell: bash
@@ -423,22 +387,6 @@ jobs:
         SUFFIX=$([ "${{ matrix.precision_opt }}" = "--enable-float" ] && echo f || \
                  { [ "${{ matrix.precision_opt }}" = "--enable-long-double" ] && echo l || echo ""; })
         ls "${{ github.workspace }}"/_install_cmake/lib*/cmake/nfft3${SUFFIX}/NFFT3${SUFFIX}Config.cmake
-
-    - name: CMake — Benchmarks
-      if: matrix.window == 'kaiserbessel' && matrix.compiler == 'gcc'
-      uses: CodSpeedHQ/action@3194d9a39c4d46684cb44bf7207fc56626aad8fd # v4
-      with:
-        # "walltime" measures real elapsed time instead of the deterministic
-        # instruction-count "simulation" build. Must match -DCODSPEED_MODE=walltime
-        # in the configure step above. NOTE: walltime on shared GitHub-hosted
-        # runners is sensitive to neighbour noise; CodSpeed recommends their
-        # hosted macro runners for stable walltime data.
-        mode: walltime
-        run: |
-          ./build-cmake/benchmarks/bench_nfft_direct
-          if [ -x ./build-cmake/benchmarks/bench_nfft_direct_omp ]; then
-            ./build-cmake/benchmarks/bench_nfft_direct_omp
-          fi
 
     - name: CMake — Test Julia
       if: matrix.build_julia == '1' && matrix.precision_opt == ''

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -21,13 +21,13 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     env:
-      BUILD_CONFIG: "${{ matrix.os }}_${{ matrix.compiler }}_${{ matrix.window }}_${{ matrix.precision_opt == '' && 'double' || matrix.precision_opt == '--enable-float' && 'float' || matrix.precision_opt == '--enable-long-double' && 'long-double' || 'unknown' }}_${{ matrix.openmp == 1 && 'openmp' || 'singlethread' }}"
-    name: "${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.window }}-${{ matrix.precision_opt == '' && 'double' || matrix.precision_opt == '--enable-float' && 'float' || matrix.precision_opt == '--enable-long-double' && 'long-double' || 'unknown' }}-${{ matrix.openmp == 1 && 'openmp' || 'singlethread' }}"
+      BUILD_CONFIG: "${{ matrix.os }}_${{ matrix.compiler }}_${{ matrix.window }}_${{ matrix.precision_opt == '' && 'double' || matrix.precision_opt == '--enable-float' && 'float' || matrix.precision_opt == '--enable-long-double' && 'long-double' || 'unknown' }}"
+    name: "${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.window }}-${{ matrix.precision_opt == '' && 'double' || matrix.precision_opt == '--enable-float' && 'float' || matrix.precision_opt == '--enable-long-double' && 'long-double' || 'unknown' }}"
     strategy:
       matrix:
-        os: ["ubuntu-latest"] # TODO: Add more Ubuntu versions, e.g. "ubuntu-20.04", "ubuntu-18.04".
+        os: ["ubuntu-latest"]
         compiler: ["gcc"]
-        window: ["kaiserbessel", "gaussian", "bspline", "sinc"] # TODO: Add dirac.
+        window: ["kaiserbessel", "gaussian", "bspline", "sinc"]
         precision_opt: ["", "--enable-float", "--enable-long-double"]
         openmp: [1]
         build_octave: [0] # TODO: Re-activate Octave build and tests.
@@ -75,14 +75,6 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         persist-credentials: false
-    - name: Enable core dumps
-      run: |
-        ulimit -c unlimited
-        sudo mkdir /cores
-        sudo chmod 777 /cores
-        # Core filenames will be of the form executable.pid.timestamp:
-        sudo bash -c 'echo "/cores/%e.%p.%t" > /proc/sys/kernel/core_pattern'
-        echo "Core dumps will be written to: /cores"
 
     - name: Disable initramfs update
       run: sudo sed -i 's/yes/no/g' /etc/initramfs-tools/update-initramfs.conf
@@ -179,31 +171,29 @@ jobs:
           exit 1
         fi
         
-    - name: Bootstrap
+    - name: Autotools - Bootstrap
       run: ./bootstrap.sh
     
-    - name: Configure
+    - name: Autotools - Configure
       shell: bash
       env:
         WINDOW: ${{ matrix.window }}
-        OPENMP: ${{ matrix.openmp }}
         PRECISION_OPT: ${{ matrix.precision_opt }}
         BUILD_OCTAVE: ${{ matrix.build_octave }}
         BUILD_JULIA: ${{ matrix.build_julia }}
       run: |
-        ./configure --with-window=${WINDOW} ${PRECISION_OPT} --enable-all --enable-exhaustive-unit-tests \
-        $(if [ "${OPENMP}" = "1" ]; then echo "--enable-openmp"; else echo ""; fi) \
+        ./configure --with-window=${WINDOW} ${PRECISION_OPT} --enable-all --enable-exhaustive-unit-tests --enable-openmp \
         $(if [ "${BUILD_OCTAVE}" = "1" ]; then echo "--with-octave=$OCTAVEDIR"; else echo ""; fi) \
         $(if [ "${BUILD_JULIA}" = "1" ] && [ "${PRECISION_OPT}" = "" ]; then echo "--enable-julia"; else echo ""; fi)
     
-    - name: Build
+    - name: Autotools - Build
       run: make -j
     
-    - name: Test
+    - name: Autotools - Test
       id: test
       run: make check
 
-    - name: Print checkall.log on test failure
+    - name: Autotools - Print checkall.log on test failure
       if: failure() && steps.test.conclusion == 'failure'
       shell: bash
       run: |
@@ -225,16 +215,14 @@ jobs:
           echo "checkall_threads.log not found"
         fi
 
-    - name: Run tests again to reproduce failure
+    - name: Autotools - Run tests again to reproduce failure
       if: failure() && steps.test.conclusion == 'failure'
       shell: bash
-      env:
-        OPENMP: ${{ matrix.openmp }}
       run: |
         tests/checkall > checkall.log
-        if [ "${OPENMP}" = "1" ]; then tests/checkall_threads > checkall_threads.log; fi
+        tests/checkall_threads > checkall_threads.log
 
-    - name: Upload test failure logs
+    - name: Autotools - Upload test failure logs
       if: failure() && steps.test.conclusion == 'failure'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
@@ -244,24 +232,83 @@ jobs:
           checkall_threads.log
         if-no-files-found: ignore
 
-    - name: Convert CUnit test reports to JUnit
+    - name: Autotools - Convert CUnit test reports to JUnit
       if: always()
       run: |
         conv() { uv run --with lxml python -c "import sys;from lxml import etree;d=etree.parse(sys.argv[1]);open(sys.argv[3],'wb').write(etree.tostring(etree.XSLT(etree.parse(sys.argv[2]))(d),pretty_print=True))" "$1" tests/cunit2junit.xsl "$2"; }
         [ -f tests/CUnitAutomated-Results.xml ]         && conv tests/CUnitAutomated-Results.xml         tests/junit.xml         || true
         [ -f tests/CUnitAutomated_threads-Results.xml ] && conv tests/CUnitAutomated_threads-Results.xml tests/junit_threads.xml || true
 
+    - name: Autotools - Publish Test Report (serial)
+      if: ${{ always() && hashFiles('tests/junit.xml') != '' }}
+      uses: ctrf-io/github-test-reporter@0f299074936c32ccaab5be5230511f6b2b9080aa # v1
+      with:
+        report-path: './tests/junit.xml'
+        integrations-config: |
+          {
+            "junit-to-ctrf": {
+              "enabled": true,
+              "action": "convert",
+              "options": {
+                "output": "./ctrf-reports/ctrf-report.json",
+                "toolname": "junit-to-ctrf",
+                "useSuiteName": false,
+                "env": {
+                  "appName": "nfft"
+                }
+              }
+            }
+          }
+
+    - name: Autotools - Publish Test Report (threads)
+      if: ${{ always() && hashFiles('tests/junit_threads.xml') != '' }}
+      uses: ctrf-io/github-test-reporter@0f299074936c32ccaab5be5230511f6b2b9080aa # v1
+      with:
+        report-path: './tests/junit_threads.xml'
+        integrations-config: |
+          {
+            "junit-to-ctrf": {
+              "enabled": true, "action": "convert",
+              "options": {
+                "output": "./ctrf-reports/ctrf-threads.json",
+                "toolname": "junit-to-ctrf", "useSuiteName": false,
+                "env": { "appName": "nfft-threads" }
+              }
+            }
+          }
+
+    - name: Autotools - Test Julia
+      if: matrix.build_julia == '1' && matrix.precision_opt == ''
+      run: |
+        for DIR in julia/nf*t julia/fastsum; do
+          cd $DIR
+          for NAME in simple_test*.jl; do
+            julia -q "$NAME"
+          done
+          cd ../..
+        done
+    
+    - name: Autotools - Test Octave
+      if: matrix.build_octave == '1'
+      run: |
+        for DIR in matlab/nf*t matlab/fastsum; do
+          cd $DIR
+          for NAME in simple_test*.m; do
+            $OCTAVE --eval="run('$NAME')"
+          done
+          cd ../..
+        done
+
     # CMake build starts here.
-    - name: CMake — clear stale in-source config.h.
+    - name: CMake — Clear stale in-source config.h
       shell: bash
       run: |
         if [ -f include/config.h ]; then mv include/config.h include/config.h.autotools.bak; fi
 
-    - name: CMake — configure (all windows; benchmark only in gcc kaiserbessel)
+    - name: CMake — Configure (all windows; benchmark only in gcc kaiserbessel)
       shell: bash
       env:
         WINDOW: ${{ matrix.window }}
-        OPENMP: ${{ matrix.openmp }}
         PRECISION_OPT: ${{ matrix.precision_opt }}
         BUILD_JULIA: ${{ matrix.build_julia }}
         COMPILER: ${{ matrix.compiler }}
@@ -272,9 +319,7 @@ jobs:
           "--enable-long-double") CMAKE_PREC="-DNFFT_ENABLE_LONG_DOUBLE=ON" ;;
           *) echo "Unknown PRECISION_OPT '${PRECISION_OPT}'" >&2; exit 1 ;;
         esac
-        CMAKE_OMP=$([ "${OPENMP}" = "1" ] && echo "-DNFFT_ENABLE_OPENMP=ON" || echo "-DNFFT_ENABLE_OPENMP=OFF")
-        # Julia interface is double-only — mirror the Autotools --enable-julia gating.
-        # (Octave is NOT folded here; it stays in the standalone cmake-octave job.)
+        # Julia interface is double-only.
         CMAKE_JULIA=""
         if [ "${BUILD_JULIA}" = "1" ] && [ -z "${PRECISION_OPT}" ]; then
           CMAKE_JULIA="-DNFFT_ENABLE_JULIA=ON"
@@ -296,19 +341,19 @@ jobs:
         # nearby function changes size (avoids phantom instruction-count regressions).
         cmake -S . -B build-cmake \
           -DCMAKE_C_FLAGS="-O3 -g -fomit-frame-pointer -fstrict-aliasing -ffast-math -falign-functions=64 -falign-loops=32" \
-          -DNFFT_WINDOW="${WINDOW}" ${CMAKE_PREC} ${CMAKE_OMP} ${CMAKE_JULIA} \
+          -DNFFT_WINDOW="${WINDOW}" ${CMAKE_PREC} -DNFFT_ENABLE_OPENMP=ON ${CMAKE_JULIA} \
           -DNFFT_ENABLE_EXHAUSTIVE_UNIT_TESTS=ON \
           -DNFFT_ENABLE_EXAMPLES=ON -DNFFT_ENABLE_APPLICATIONS=ON \
           "${EXTRA[@]}"
 
-    - name: CMake — config.h parity (Autotools vs. CMake)
+    - name: CMake — Check config.h parity (Autotools vs. CMake)
       shell: bash
       run: bash cmake/config-parity-check.sh include/config.h.autotools.bak build-cmake/config.h include/config.h.in
 
-    - name: CMake — build (library + benchmark)
+    - name: CMake — Build
       run: cmake --build build-cmake -j
 
-    - name: CMake — assert example/application binaries built
+    - name: CMake — Assert example/application
       shell: bash
       run: |
         set -e
@@ -327,13 +372,13 @@ jobs:
         fi
         echo "example/application binaries present"
 
-    - name: CMake — ctest (CUnit suite, parity with make check)
+    - name: CMake — Test
       shell: bash
       run: |
         set -o pipefail
         ctest --test-dir build-cmake --output-on-failure 2>&1 | tee build-cmake/ctest.log
 
-    - name: CMake — convert CUnit reports to JUnit
+    - name: CMake — Convert test reports to JUnit
       if: always()
       shell: bash
       run: |
@@ -375,7 +420,7 @@ jobs:
             }
           }
 
-    - name: CMake — test install
+    - name: CMake — Install
       if: matrix.window == 'kaiserbessel'
       shell: bash
       run: |
@@ -385,7 +430,7 @@ jobs:
                  { [ "${{ matrix.precision_opt }}" = "--enable-long-double" ] && echo l || echo ""; })
         ls "${{ github.workspace }}"/_install_cmake/lib*/cmake/nfft3${SUFFIX}/NFFT3${SUFFIX}Config.cmake
 
-    - name: CMake — Benchmarks (CodSpeed upload — the sole reporter now)
+    - name: CMake — Benchmarks
       if: matrix.window == 'kaiserbessel' && matrix.compiler == 'gcc'
       uses: CodSpeedHQ/action@3194d9a39c4d46684cb44bf7207fc56626aad8fd # v4
       with:
@@ -401,7 +446,7 @@ jobs:
             ./build-cmake/benchmarks/bench_nfft_direct_omp
           fi
 
-    - name: CMake — run-verify Julia staged simple_tests
+    - name: CMake — Test Julia
       if: matrix.build_julia == '1' && matrix.precision_opt == ''
       shell: bash
       run: |
@@ -415,110 +460,6 @@ jobs:
             ( cd "$DIR" && julia "$(basename "$NAME")" )
           done
         done
-
-    - name: Test Julia
-      if: matrix.build_julia == '1' && matrix.precision_opt == ''
-      run: |
-        for DIR in julia/nf*t julia/fastsum; do
-          cd $DIR
-          for NAME in simple_test*.jl; do
-            julia -q "$NAME"
-          done
-          cd ../..
-        done
-    
-    - name: Test Octave
-      if: matrix.build_octave == '1'
-      run: |
-        for DIR in matlab/nf*t matlab/fastsum; do
-          cd $DIR
-          for NAME in simple_test*.m; do
-            $OCTAVE --eval="run('$NAME')"
-          done
-          cd ../..
-        done
-
-    - name: Collect core dumps and binaries
-      if: failure()
-      run: |
-        # Extract binary paths from core dumps and copy them
-        for corefile in /cores/*.*.*; do
-          if [ -f "$corefile" ]; then
-            echo "Processing $corefile"
-            
-            # Get the binary path from the core dump
-            binary=$(file "$corefile" | grep -oP "from '[^']*'" | cut -d"'" -f2)
-            
-            # Alternative method using gdb (more reliable)
-            if command -v gdb &> /dev/null; then
-              binary=$(gdb -quiet -batch -c "$corefile" 2>/dev/null | grep "Core was generated by" | sed "s/Core was generated by \`\(.*\)'.*/\1/" | awk '{print $1}')
-            fi
-            
-            echo "Binary: $binary"
-            
-            # Copy the binary if it exists
-            if [ -n "$binary" ] && [ -f "$binary" ]; then
-              cp "$binary" /cores/
-              echo "Copied binary: $binary"
-              
-              # Also copy any shared libraries if needed
-              ldd "$binary" 2>/dev/null | grep "=>" | awk '{print $3}' | while read lib; do
-                if [ -f "$lib" ]; then
-                  cp --parents "$lib" /cores/ 2>/dev/null || true
-                fi
-              done
-            fi
-          fi
-        done
-        
-        ls -lah /cores/
-
-    - name: Upload core dumps
-      if: failure()
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: coredumps-${{ github.run_id }}
-        path: /cores/
-        if-no-files-found: warn
-        retention-days: 7
-
-    - name: Publish Test Report
-      if: ${{ always() && hashFiles('tests/junit.xml') != '' }}
-      uses: ctrf-io/github-test-reporter@0f299074936c32ccaab5be5230511f6b2b9080aa # v1
-      with:
-        report-path: './tests/junit.xml'
-        integrations-config: |
-          {
-            "junit-to-ctrf": {
-              "enabled": true,
-              "action": "convert",
-              "options": {
-                "output": "./ctrf-reports/ctrf-report.json",
-                "toolname": "junit-to-ctrf",
-                "useSuiteName": false,
-                "env": {
-                  "appName": "nfft"
-                }
-              }
-            }
-          }
-
-    - name: Publish Test Report (threads)
-      if: ${{ always() && hashFiles('tests/junit_threads.xml') != '' }}
-      uses: ctrf-io/github-test-reporter@0f299074936c32ccaab5be5230511f6b2b9080aa # v1
-      with:
-        report-path: './tests/junit_threads.xml'
-        integrations-config: |
-          {
-            "junit-to-ctrf": {
-              "enabled": true, "action": "convert",
-              "options": {
-                "output": "./ctrf-reports/ctrf-threads.json",
-                "toolname": "junit-to-ctrf", "useSuiteName": false,
-                "env": { "appName": "nfft-threads" }
-              }
-            }
-          }
 
   distcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -165,6 +165,7 @@ jobs:
     
     - name: Autotools - Test
       id: test
+      if: matrix.compiler == 'gcc' && matrix.window == 'kaiserbessel'
       run: make check
 
     - name: Autotools - Print checkall.log on test failure
@@ -302,7 +303,7 @@ jobs:
           -DCMAKE_C_FLAGS="-O3 -g -fomit-frame-pointer -fstrict-aliasing -ffast-math" \
           -DNFFT_WINDOW="${WINDOW}" ${CMAKE_PREC} -DNFFT_ENABLE_OPENMP=ON ${CMAKE_JULIA} \
           -DNFFT_ENABLE_EXHAUSTIVE_UNIT_TESTS=ON \
-          -DNFFT_ENABLE_EXAMPLES=ON -DNFFT_ENABLE_APPLICATIONS=ON"
+          -DNFFT_ENABLE_EXAMPLES=ON -DNFFT_ENABLE_APPLICATIONS=ON
 
     - name: CMake — Check config.h parity (Autotools vs. CMake)
       shell: bash
@@ -331,6 +332,7 @@ jobs:
         echo "example/application binaries present"
 
     - name: CMake — Test
+      if: matrix.compiler == 'gcc' && matrix.window == 'kaiserbessel'
       shell: bash
       run: |
         set -o pipefail

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -29,7 +29,6 @@ jobs:
         compiler: ["gcc"]
         window: ["kaiserbessel", "gaussian", "bspline", "sinc"]
         precision_opt: ["", "--enable-float", "--enable-long-double"]
-        openmp: [1]
         build_octave: [0] # TODO: Re-activate Octave build and tests.
         build_julia: [1]
         include:
@@ -38,21 +37,18 @@ jobs:
             compiler: "clang"
             window: "kaiserbessel"
             precision_opt: ""
-            openmp: 1
             build_octave: 0
             build_julia: 1
           - os: "ubuntu-latest"
             compiler: "clang"
             window: "kaiserbessel"
             precision_opt: "--enable-float"
-            openmp: 1
             build_octave: 0
             build_julia: 1
           - os: "ubuntu-latest"
             compiler: "clang"
             window: "kaiserbessel"
             precision_opt: "--enable-long-double"
-            openmp: 1
             build_octave: 0
             build_julia: 1
           # GCC 14
@@ -60,7 +56,6 @@ jobs:
             compiler: "gcc-14"
             window: "kaiserbessel"
             precision_opt: ""
-            openmp: 1
             build_octave: 0
             build_julia: 1
           # GCC Snapshot
@@ -68,7 +63,6 @@ jobs:
             compiler: "gcc-snapshot"
             window: "kaiserbessel"
             precision_opt: ""
-            openmp: 1
             build_octave: 0
             build_julia: 1
     steps:    
@@ -328,7 +322,7 @@ jobs:
         EXTRA=()
         if [ "${WINDOW}" = "kaiserbessel" ] && [ "${COMPILER}" = "gcc" ]; then
           AGNOSTIC_FLAGS="window:1"
-          [ "${OPENMP}" = "0" ] && AGNOSTIC_FLAGS="$AGNOSTIC_FLAGS,openmp:1" || AGNOSTIC_FLAGS="$AGNOSTIC_FLAGS,openmp:0"
+          AGNOSTIC_FLAGS="$AGNOSTIC_FLAGS,openmp:1"
           [ "${PRECISION_OPT}" = "" ] && AGNOSTIC_FLAGS="$AGNOSTIC_FLAGS,precision:1" || AGNOSTIC_FLAGS="$AGNOSTIC_FLAGS,precision:0"
           EXTRA+=( -DNFFT_ENABLE_BENCHMARKS=ON
                    -DBENCHMARKS_PREFIX="${BUILD_CONFIG}/"

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -155,8 +155,10 @@ jobs:
         PRECISION_OPT: ${{ matrix.precision_opt }}
         BUILD_OCTAVE: ${{ matrix.build_octave }}
         BUILD_JULIA: ${{ matrix.build_julia }}
+        COMPILER: ${{ matrix.compiler }}
       run: |
-        ./configure --with-window=${WINDOW} ${PRECISION_OPT} --enable-all --enable-exhaustive-unit-tests --enable-openmp \
+        ./configure --with-window=${WINDOW} ${PRECISION_OPT} --enable-all --enable-openmp \
+        $(if [ "${COMPILER}" = "gcc" ]; then echo "--enable-tests  --enable-exhaustive-unit-tests"; fi) \
         $(if [ "${BUILD_OCTAVE}" = "1" ]; then echo "--with-octave=$OCTAVEDIR"; else echo ""; fi) \
         $(if [ "${BUILD_JULIA}" = "1" ] && [ "${PRECISION_OPT}" = "" ]; then echo "--enable-julia"; else echo ""; fi)
     
@@ -299,9 +301,14 @@ jobs:
         if [ "${BUILD_JULIA}" = "1" ] && [ -z "${PRECISION_OPT}" ]; then
           CMAKE_JULIA="-DNFFT_ENABLE_JULIA=ON"
         fi
+        # CUnit test suite only where the tests actually run (gcc + kaiserbessel).
+        CMAKE_TESTS=""
+        if [ "${COMPILER}" = "gcc" ]; then
+          CMAKE_TESTS="-DNFFT_ENABLE_TESTS=ON"
+        fi
         cmake -S . -B build-cmake \
           -DCMAKE_C_FLAGS="-O3 -g -fomit-frame-pointer -fstrict-aliasing -ffast-math" \
-          -DNFFT_WINDOW="${WINDOW}" ${CMAKE_PREC} -DNFFT_ENABLE_OPENMP=ON ${CMAKE_JULIA} \
+          -DNFFT_WINDOW="${WINDOW}" ${CMAKE_PREC} -DNFFT_ENABLE_OPENMP=ON ${CMAKE_JULIA} ${CMAKE_TESTS} \
           -DNFFT_ENABLE_EXHAUSTIVE_UNIT_TESTS=ON \
           -DNFFT_ENABLE_EXAMPLES=ON -DNFFT_ENABLE_APPLICATIONS=ON
 

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -288,7 +288,7 @@ jobs:
           EXTRA+=( -DNFFT_ENABLE_BENCHMARKS=ON
                    -DBENCHMARKS_PREFIX="${BUILD_CONFIG}/"
                    -DNFFT_AGNOSTIC_BENCHMARKS="$AGNOSTIC_FLAGS"
-                   -DCODSPEED_MODE=simulation
+                   -DCODSPEED_MODE=walltime
                    -DFETCHCONTENT_SOURCE_DIR_CODSPEED="$(pwd)/codspeed-cpp" )
         fi
         # -falign-functions/-falign-loops: force deterministic code layout so an
@@ -389,11 +389,12 @@ jobs:
       if: matrix.window == 'kaiserbessel' && matrix.compiler == 'gcc'
       uses: CodSpeedHQ/action@3194d9a39c4d46684cb44bf7207fc56626aad8fd # v4
       with:
-        # "simulation" is the current name for what v3/codspeed-cpp called
-        # "instrumentation" (now a deprecated alias). codspeed-cpp v2.3.0 maps
-        # instrumentation/simulation/memory to the same CODSPEED_ANALYSIS build,
-        # so this is behavior- and benchmark-name-identical to the old value.
-        mode: simulation
+        # "walltime" measures real elapsed time instead of the deterministic
+        # instruction-count "simulation" build. Must match -DCODSPEED_MODE=walltime
+        # in the configure step above. NOTE: walltime on shared GitHub-hosted
+        # runners is sensitive to neighbour noise; CodSpeed recommends their
+        # hosted macro runners for stable walltime data.
+        mode: walltime
         run: |
           ./build-cmake/benchmarks/bench_nfft_direct
           if [ -x ./build-cmake/benchmarks/bench_nfft_direct_omp ]; then

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -165,7 +165,7 @@ jobs:
     
     - name: Autotools - Test
       id: test
-      if: matrix.compiler == 'gcc' && matrix.window == 'kaiserbessel'
+      if: matrix.compiler == 'gcc'
       run: make check
 
     - name: Autotools - Print checkall.log on test failure
@@ -332,7 +332,7 @@ jobs:
         echo "example/application binaries present"
 
     - name: CMake — Test
-      if: matrix.compiler == 'gcc' && matrix.window == 'kaiserbessel'
+      if: matrix.compiler == 'gcc'
       shell: bash
       run: |
         set -o pipefail

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ option(NFFT_ENABLE_LONG_DOUBLE "Build long double precision"      OFF)
 option(NFFT_ENABLE_OPENMP      "Build the OpenMP (_omp) library"  ON)
 option(NFFT_ENABLE_BENCHMARKS  "Build CodSpeed benchmarks"        OFF)
 option(NFFT_ENABLE_MAXOPT      "Use aggressive compiler flags"    ON)
-option(NFFT_ENABLE_TESTS       "Build the CUnit test suite"       ON)
+option(NFFT_ENABLE_TESTS       "Build the CUnit test suite"       OFF)
 
 # If tests are enabled, allow opt-in to set of more exhaustive tests.
 include(CMakeDependentOption)

--- a/configure.ac
+++ b/configure.ac
@@ -653,10 +653,19 @@ AC_CHECK_DECLS([copysignf, nextafterf, nanf, ceilf, floorf, nearbyintf, rintf, r
 #include <complex.h>])
 fi
 
-# CUnit
-NFFT_LIB_CUNIT
+# option for the CUnit test suite (requires CUnit, disabled by default)
+AC_ARG_ENABLE(tests, [AS_HELP_STRING([--enable-tests],[enable the CUnit test suite])], enable_tests=$enableval, enable_tests=no)
 
-AM_CONDITIONAL(HAVE_CUNIT, test "x$cunit_have_lib" = "xyes" )
+# CUnit
+cunit_have_lib="no"
+if test "x$enable_tests" = "xyes"; then
+  NFFT_LIB_CUNIT
+  if test "x$cunit_have_lib" != "xyes"; then
+    AC_MSG_ERROR([You have enabled the test suite (--enable-tests), but the CUnit library was not found.])
+  fi
+fi
+
+AM_CONDITIONAL(HAVE_CUNIT, test "x$enable_tests" = "xyes" -a "x$cunit_have_lib" = "xyes" )
 AC_SUBST(cunit_CPPFLAGS)
 AC_SUBST(cunit_LDFLAGS)
 AC_SUBST(cunit_LIBS)

--- a/docs/ci/benchmarks.md
+++ b/docs/ci/benchmarks.md
@@ -1,0 +1,48 @@
+# Running benchmarks in CI
+
+CodSpeed benchmarks (`.github/workflows/bench-linux.yml`) run on expensive
+macro runners with a limited monthly allowance, so on pull requests they are
+**opt-in behind a maintainer approval**.
+
+## When benchmarks run automatically
+
+- On every push to `main`, `develop`, or `master`. These keep CodSpeed's
+  comparison **baseline** current and need **no** approval. They happen on
+  merge, so they are infrequent.
+
+## How to run benchmarks on a pull request
+
+1. Every PR push creates a benchmark run that immediately enters a **"Waiting"**
+   state. It consumes **no** runner minutes while waiting.
+2. A listed reviewer opens the run (Checks / Actions tab) and clicks
+   **"Review deployments" → `benchmarks` → "Approve and deploy."**
+3. The benchmark runs against the PR's merge commit, and the **CodSpeed** check
+   (regressions/improvements vs. the base-branch baseline) posts automatically.
+
+Only the maintainers listed as **required reviewers** on the `benchmarks`
+environment can approve — see *Settings → Environments → benchmarks*.
+
+## What happens to older, un-approved runs
+
+Each new push **supersedes** the PR's previous not-yet-approved run (per-ref
+concurrency with `cancel-in-progress`), so there is always exactly **one** run
+to approve: the latest commit's. You don't need to clean up stale waiting runs.
+
+## Benchmarks are not a merge gate
+
+Benchmarks are advisory. If no one approves, the run never executes and there is
+no benchmark status on the PR, so it never blocks merging. Maintainers decide
+per PR whether to run benchmarks and whether to merge regardless of the result.
+
+## Security notes
+
+- The workflow uses `pull_request` (never `pull_request_target`): fork PR code
+  runs with a **read-only token and no secrets**. The approval gate means a
+  named maintainer explicitly authorizes each fork-code execution.
+- The workflow holds **`contents: read`** only — no write token.
+- No `CODSPEED_TOKEN` secret is used (tokenless CodSpeed upload on this public repo).
+
+## Manual / off-PR runs
+
+Use **Actions → Bench Linux → Run workflow** (`workflow_dispatch`) to benchmark
+any branch without a PR; these are not gated.


### PR DESCRIPTION
This PR refactors the CI workflows to improve how and when we run benchmarks:
- Benchmark runs are moved to a separate workflow.
- This allows benchmarks to run on separate runners (e.g. CodSpeed Macro Runners) while builds et cetera use vanilla GitHub runners.
- Benchmarks use a reduced matrix and only run on Linux for gcc, Kaiserbessel, and all three precisions. In most cases, this should be enough. Window-specific changes, for example, would need separate ad-hoc benchmarks to verify improvements and potential regressions as not covered in the standard set.
- Benchmarks now use CodSpeed Macro Runners. These offer more reliable runtime environments to make benchmarks actually comparable. Before, even in simulation mode, benchmarks were showing regressions and improvements on untouched code owing to different CPUs on the GH-provided runners.
- Changed the benchmark mode to walltime.
- Since CodSpeed has a cap on how many minutes you can use their runners on the free tier, benchmarks are now gated by a new `benchmarks` environment. So they only run automatically on `develop` and `master`/`main`. On PRs, the jobs get scheduled, but an explicit approval by a reviewer is needed for them to start.
- Benchmarks are not a hard gate for merging a PR. It's up to a reviewer to decide if benchmarks are a requirement.
- Also added zizmor (GitHub Actions YAML linter) to the devcontainer image.
- Benchmarks handling is described in `docs/ci/benchmarks.md`.
- tests now also run only in the Autotools build tree. The second run in the CMake build tree was effectively redundant. Also, tests only run on a matrix of gcc, all windows, and all precisions. There's no point in running correctness checks on more exotic platforms and compilers at all times. If it makes sense, we can expand the test coverage e.g. for release branches, as a final gate before cutting a release.