### PR TITLE
Support benchmark mode choice.

### DIFF
--- a/.github/workflows/bench-linux.yml
+++ b/.github/workflows/bench-linux.yml
@@ -100,11 +100,10 @@ jobs:
         EXTRA=()
         AGNOSTIC_FLAGS="window:1,openmp:1"
         [ "${PRECISION_OPT}" = "" ] && AGNOSTIC_FLAGS="$AGNOSTIC_FLAGS,precision:1" || AGNOSTIC_FLAGS="$AGNOSTIC_FLAGS,precision:0"
-        EXTRA+=( -DNFFT_ENABLE_BENCHMARKS=ON
-                  -DBENCHMARKS_PREFIX="${BUILD_CONFIG}/"
-                  -DNFFT_AGNOSTIC_BENCHMARKS="$AGNOSTIC_FLAGS"
-                  -DCODSPEED_MODE=walltime
-                  -DFETCHCONTENT_SOURCE_DIR_CODSPEED="$(pwd)/codspeed-cpp" )
+        EXTRA+=( -DNFFT_BENCHMARK_MODE=walltime
+                 -DBENCHMARKS_PREFIX="${BUILD_CONFIG}/"
+                 -DNFFT_AGNOSTIC_BENCHMARKS="$AGNOSTIC_FLAGS"
+                 -DFETCHCONTENT_SOURCE_DIR_CODSPEED="$(pwd)/codspeed-cpp" )
         # -falign-functions/-falign-loops: force deterministic code layout so an
         # unrelated function's hot loop can't shift to a worse alignment when a
         # nearby function changes size (avoids phantom instruction-count regressions).

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -264,7 +264,7 @@ jobs:
           done
           cd ../..
         done
-    
+
     - name: Autotools - Test Octave
       if: matrix.build_octave == '1'
       run: |
@@ -417,7 +417,7 @@ jobs:
         run: |
           cmake -S . -B build-cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DNFFT_WITH_OCTAVE=ON \
-            -DNFFT_ENABLE_OPENMP=ON -DNFFT_ENABLE_BENCHMARKS=OFF \
+            -DNFFT_ENABLE_OPENMP=ON \
             -DNFFT_ENABLE_EXAMPLES=OFF -DNFFT_ENABLE_APPLICATIONS=OFF \
             -DNFFT_ENABLE_TESTS=ON
 

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -241,7 +241,7 @@ jobs:
         fi
         cmake -S . -B build-cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
           -DNFFT_WINDOW=kaiserbessel ${CMAKE_PREC} ${CMAKE_JULIA} \
-          -DNFFT_ENABLE_OPENMP=OFF -DNFFT_ENABLE_BENCHMARKS=OFF \
+          -DNFFT_ENABLE_OPENMP=OFF \
           -DNFFT_ENABLE_EXHAUSTIVE_UNIT_TESTS=ON \
           -DNFFT_ENABLE_EXAMPLES=ON -DNFFT_ENABLE_APPLICATIONS=ON \
           -DFFTW3_ROOT=/opt/homebrew

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -54,7 +54,6 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_SHARED_LIBS=ON \
             -DNFFT_ENABLE_OPENMP=OFF \
-            -DNFFT_ENABLE_BENCHMARKS=OFF \
             -DNFFT_ENABLE_EXAMPLES=OFF \
             -DNFFT_ENABLE_APPLICATIONS=OFF
 

--- a/.gitignore
+++ b/.gitignore
@@ -164,6 +164,7 @@ nfft-*
 
 # CMake build tree
 build/
+build-cmake*/
 
 # macOS
 .DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,9 +16,20 @@ option(BUILD_SHARED_LIBS "Build shared libraries (DLLs on Windows)" ON)
 option(NFFT_ENABLE_FLOAT       "Build single (float) precision"   OFF)
 option(NFFT_ENABLE_LONG_DOUBLE "Build long double precision"      OFF)
 option(NFFT_ENABLE_OPENMP      "Build the OpenMP (_omp) library"  ON)
-option(NFFT_ENABLE_BENCHMARKS  "Build CodSpeed benchmarks"        OFF)
 option(NFFT_ENABLE_MAXOPT      "Use aggressive compiler flags"    ON)
 option(NFFT_ENABLE_TESTS       "Build the CUnit test suite"       OFF)
+
+# Benchmarks: a single knob that both selects the CodSpeed measurement mode and
+# (when not "off") enables the benchmark build. The mode is baked in at build time
+# and forwarded to codspeed-cpp's CODSPEED_MODE.
+#   off        - benchmarks not built (default).
+#   simulation - deterministic instruction count via callgrind (needs valgrind to
+#                measure); the mode CI gates on.
+#   walltime   - wall-clock timing; the binary writes a local JSON of per-benchmark
+#                stats to $CODSPEED_PROFILE_FOLDER (offline, no runner/upload).
+set(NFFT_BENCHMARK_MODE "off" CACHE STRING
+    "Benchmark build + CodSpeed mode: off|simulation|walltime")
+set_property(CACHE NFFT_BENCHMARK_MODE PROPERTY STRINGS off simulation walltime)
 
 # If tests are enabled, allow opt-in to set of more exhaustive tests.
 include(CMakeDependentOption)
@@ -203,8 +214,8 @@ include(nfft_programs)  # nfft_add_serial_program / nfft_add_omp_program helpers
 # Kernel always built.
 add_subdirectory(kernel)
 
-# Optional benchmarks.
-if(NFFT_ENABLE_BENCHMARKS)
+# Optional benchmarks (built unless NFFT_BENCHMARK_MODE is "off").
+if(NOT NFFT_BENCHMARK_MODE STREQUAL "off")
   include(nfft_benchmarks) # parse NFFT_AGNOSTIC_BENCHMARKS into gating vars
   add_subdirectory(benchmarks)
 endif()

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -16,6 +16,11 @@ include(FetchContent)
 # Codspeed version.
 set(CODSPEED_VERSION "v2.3.0" CACHE STRING "codspeed-cpp tag")
 
+# Forward onto codspeed-cpp's own CODSPEED_MODE cache var. FORCE so that reconfiguring 
+# a tree with a different -DNFFT_BENCHMARK_MODE takes effect.
+set(CODSPEED_MODE "${NFFT_BENCHMARK_MODE}" CACHE STRING "Build mode for Codspeed" FORCE)
+message(STATUS "NFFT benchmark mode: ${NFFT_BENCHMARK_MODE}")
+
 # Build the CodSpeed google_benchmark fork with our toolchain.
 set(BENCHMARK_DOWNLOAD_DEPENDENCIES ON CACHE BOOL "" FORCE)
 set(BENCHMARK_ENABLE_TESTING        OFF CACHE BOOL "" FORCE)

--- a/cmake/consumer-tests/fetchcontent/CMakeLists.txt
+++ b/cmake/consumer-tests/fetchcontent/CMakeLists.txt
@@ -4,10 +4,10 @@ project(nfft3_consumer_fc LANGUAGES C)
 include(FetchContent)
 
 # Point at the in-repo source tree (passed via -DNFFT3_SOURCE_DIR=...).
-# Turn off benchmarks so the sub-build doesn't FetchContent codspeed-cpp,
-# and off OpenMP to keep the smoke test minimal.
-set(NFFT_ENABLE_BENCHMARKS OFF CACHE BOOL "" FORCE)
-set(NFFT_ENABLE_OPENMP     OFF CACHE BOOL "" FORCE)
+# Keep benchmarks off (the default) so the sub-build doesn't FetchContent
+# codspeed-cpp, and off OpenMP to keep the smoke test minimal.
+set(NFFT_BENCHMARK_MODE off CACHE STRING "" FORCE)
+set(NFFT_ENABLE_OPENMP  OFF CACHE BOOL   "" FORCE)
 
 FetchContent_Declare(nfft3 SOURCE_DIR "${NFFT3_SOURCE_DIR}")
 FetchContent_MakeAvailable(nfft3)


### PR DESCRIPTION
Allows to chose the CodSpeed benchmark mode (simulation/walltime/off) at configure time.