### PR TITLE
Add agent docs.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,199 @@
+# AGENTS.md
+
+Guidance for coding agents working in this repository.
+
+## 1. Project overview
+
+**NFFT3** is a C library for computing **nonequispaced fast Fourier transforms**
+and related transforms. It is a mature, research-grade numerical library.
+
+Transforms implemented (each is its own module under `kernel/` with a public
+API in `include/nfft3.h`):
+
+- **NFFT** — nonequispaced FFT (forward + adjoint), the core module (`kernel/nfft`)
+- **NNFFT** — nonequispaced in both time *and* frequency (`kernel/nnfft`)
+- **NFCT / NFST** — real-valued (co)sine transforms (`kernel/nfct`, `kernel/nfst`)
+- **NFSFT** — transform on the sphere S² (`kernel/nfsft`)
+- **NFSOFT** — transform on the rotation group SO(3) (`kernel/nfsoft`)
+- **NSFFT** — sparse/hyperbolic-cross FFT (`kernel/nsfft`)
+- **FPT** — fast polynomial transform (`kernel/fpt`)
+- **solver** — generalised inverse transforms via iterative methods (CGNR/CGNE)
+- shared helpers in `kernel/util`
+
+Application/example programs live in `applications/` (fastsum, fast Gauss
+transform, MRI, polar FFT, Radon, S² quadrature, …) and `examples/`.
+
+### Tech stack
+
+- **Language:** C (C99). Benchmarks are C++17.
+- **Build system:** GNU Autotools (autoconf/automake/libtool) + `make`.
+  Experimental CMake support.
+- **Hard dependency:** [FFTW3](https://fftw.org) (`libfftw3-dev`). Single,
+  double, and long-double FFTW variants are all used depending on precision.
+- **Tests:** [CUnit](http://cunit.sourceforge.net) (`libcunit1-dev`).
+- **Benchmarks:** [CodSpeed](https://codspeed.io) C++ integration built on
+  google_benchmark (CI-oriented; see §4).
+- **Interfaces:** Julia (`julia/`), Matlab/Octave (`matlab/`).
+- The dev container (`.devcontainer/`) is Ubuntu 24.04 with gcc-14, clang,
+  FFTW (all precisions), CUnit, Octave, Julia, autotools, and clang-format
+  preinstalled. Assume these are available on the local host.
+
+### Code conventions
+
+The library is **precision-agnostic**: the same C sources compile in float,
+double, or long-double precision. Read `CONVENTIONS.md` before editing C code.
+Key rules:
+
+- **Name mangling:** use `Y(foo)` for names exported library-wide (expands to
+  `nfftf_`/`nfft_`/`nfftl_` by precision), `X(foo)` for module-local names
+  (e.g. `nfct_foo` inside the NFCT module), and `FFTW(foo)` for FFTW names.
+  Never hard-code a `nfft_`/`nfftf_`/`nfftl_` prefix.
+- Use the type aliases `R` (real), `E` (real, possibly extended precision),
+  `C` (complex); `A(...)` for assert, `CK(...)` for check.
+- Indentation is 2 spaces, BSD brace style. A `.clang-format` is provided.
+- New code must keep the float/double/long-double build matrix working.
+
+## 2. Building (local host)
+
+This is a source checkout, so the configure script must be generated first.
+
+```bash
+# One-time (and after editing any Makefile.am / configure.ac):
+./bootstrap.sh  # runs libtoolize + autoreconf
+
+# Configure. Build ALL modules, tests, examples, and applications:
+./configure --enable-all --enable-openmp
+
+# Compile:
+make -j
+```
+
+Useful `./configure` flags:
+
+- `--enable-all` — build all transform modules (plus examples & applications).
+- `--enable-openmp` — multithreaded (OpenMP) build; also produces the
+  `*_omp` library and the `checkall_threads` test binary.
+- `--enable-float` / `--enable-long-double` — change precision (default is
+  double). These are mutually exclusive. Build each precision in a *separate*
+  configured tree.
+- `--with-window=ARG` — window function: `kaiserbessel` (default), `gaussian`,
+  `bspline`, `sinc`, `dirac`.
+- `--enable-exhaustive-unit-tests` — larger, slower test cases (CI uses this).
+- `--enable-julia` — build the Julia interface (double precision + shared libs only).
+- `--with-matlab=/path` / `--with-octave=/path` — build the MATLAB/Octave interface.
+- `--enable-tests` - build the CUnit test programs.
+- `--enable-benchmarks --with-codspeed=<path>` — Autotools benchmark
+  build; benchmarks are now built in CI with CMake, easier to integrate (see §4).
+- `./configure --help` lists everything.
+
+A representative "build everything" configure line matching CI:
+
+```bash
+./configure --with-window=kaiserbessel --enable-all \
+            --enable-exhaustive-unit-tests --enable-openmp --enable-julia
+make -j
+```
+
+The build produces `libnfft3<suffix>.la` (and `..._omp.la` with OpenMP) in the
+top directory, where `<suffix>` is empty for double, `f` for float, `l` for
+long-double.
+
+## 3. Running the tests
+
+Tests use **CUnit** and only build when the tests are enabled and CUnit is 
+detected at configure time.
+
+```bash
+make check  # builds + runs the test suite, prints PASS/FAIL summary
+```
+
+What this runs:
+
+- `tests/checkall` — the full single-threaded suite.
+- `tests/checkall_threads` — the same suite against the OpenMP library
+  (only when configured with `--enable-openmp`).
+
+Checking which tests pass/fail:
+
+- The `make check` console output gives the per-test and overall pass/fail
+  summary, and writes `tests/checkall.log` / `tests/checkall.trs` (automake
+  test logs).
+- CUnit also emits a detailed XML report at
+  `tests/CUnitAutomated-Results.xml` (and `..._threads-Results.xml`). This can
+  be converted to JUnit with the bundled stylesheet `tests/cunit2junit.xsl`.
+- To re-run a single binary directly and capture full output:
+
+  ```bash
+  tests/checkall  # or: tests/checkall_threads
+  ```
+
+The C tests (`tests/nfft.c`, `nfct.c`, `nfst.c`, `check_nfsft.c`, …) validate
+transforms against reference data in `tests/data/` and against the direct
+(slow) transforms. Use `--enable-exhaustive-unit-tests` for the thorough set.
+
+## 4. Running the benchmarks
+
+Benchmarks (`benchmarks/bench_nfft_direct.cpp`) use the **CodSpeed** C++ integration
+and run in CI for continuous regression tracking. Build them with the **CMake** build
+(self-contained: `FetchContent` fetches/builds codspeed-cpp, submodules and all). A
+single knob, `-DNFFT_BENCHMARK_MODE=`, both enables the benchmark build and picks the
+measurement mode — **baked in at build time**:
+
+- `off` (default) — benchmarks not built.
+- `simulation` — deterministic instruction count; the metric CI gates on. The binary
+  only measures under callgrind (`valgrind --tool=callgrind …`, read `I refs`); run
+  directly it is inert (*"unknown environment"*).
+- `walltime` — wall-clock timing; the binary writes a local stats JSON to
+  `$CODSPEED_PROFILE_FOLDER/results/<pid>.json` (offline, no valgrind/runner).
+
+```bash
+cmake -S . -B build-cmake -DNFFT_BENCHMARK_MODE=walltime -DNFFT_ENABLE_OPENMP=ON \
+      -DCMAKE_C_FLAGS="-O3 -g -fomit-frame-pointer -fstrict-aliasing -ffast-math"
+cmake --build build-cmake -j  # binaries in build-cmake/benchmarks/
+CODSPEED_PROFILE_FOLDER=/tmp/wt build-cmake/benchmarks/bench_nfft_direct
+```
+
+Switching mode = reconfigure the tree with a different `-DNFFT_BENCHMARK_MODE` (or use
+a second build dir). Other options: `-DBENCHMARKS_PREFIX=`, `-DNFFT_AGNOSTIC_BENCHMARKS=`
+(`"window:1,openmp:0,precision:1"`), `-DFETCHCONTENT_SOURCE_DIR_CODSPEED=<path>` (reuse
+a checkout / offline). CodSpeeds `valgrind` fork and the `codspeed` CLI are preinstalled
+in the dev container.
+
+Continuous tracking happens via CodSpeed in GitHub Actions (same CMake build,
+`.github/workflows/bench-linux.yml`).
+
+> **Legacy:** the Autotools benchmark path (`./configure
+> --enable-benchmarks --with-codspeed=<path>` + `make bench`) predates CodSpeed; it
+> needs a hand-built `codspeed-cpp` and prints no measurements. Use the CMake build.
+
+## Quick reference
+
+| Task | Command |
+|------|---------|
+| Regenerate build system | `./bootstrap.sh` |
+| Configure (everything) | `./configure --enable-all --enable-openmp` |
+| Build | `make -j` |
+| Run tests | `make check` |
+| Test results (detail) | `tests/checkall`, `tests/CUnitAutomated-Results.xml` |
+| Build benchmarks | `cmake -S . -B build-cmake -DNFFT_BENCHMARK_MODE=walltime && cmake --build build-cmake -j` (§4) |
+| Measure (walltime) | `CODSPEED_PROFILE_FOLDER=/tmp/wt build-cmake/benchmarks/bench_nfft_direct` → `/tmp/wt/results/*.json` |
+| Clean | `make clean` / full reset: `make distclean` |
+| Format C code | `clang-format -i <file>` (uses repo `.clang-format`) |
+
+CI mirrors these steps in `.github/workflows/build-linux.yml`, `bench-linux.yml`,
+`build-macos.yml`, and `build-windows.yml` across different window × precision × OpenMP 
+matrices — consult those files when reproducing a CI configuration exactly.
+
+## Agent skills
+
+### Issue tracker
+
+Issues and PRDs live as markdown files under `.scratch/<feature>/`. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Five canonical triage roles using their default strings (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,170 @@
+# NFFT3 — Context
+
+NFFT3 is a precision-agnostic C library for nonequispaced fast Fourier transforms.
+This glossary fixes the vocabulary to use inside the project.
+
+## Language
+
+### Build systems & precision
+
+**Coexistence**:
+The policy that the CMake build is added *alongside* Autotools, never replacing it.
+A change to one build system must not break the other; shared C sources,
+`configure.ac`, and `Makefile.am` are not edited to serve CMake.
+_Avoid_: migration, port (they imply replacement).
+
+**Precision suffix**:
+The single letter fixing a build tree's floating-point precision in the library
+name and mangling: `` (double, `nfft_`), `f` (float, `nfftf_`), `l` (long-double,
+`nfftl_`). One precision per build tree (the FFTW model).
+_Avoid_: precision flavor, variant.
+
+### Benchmarks & CodSpeed
+
+**Benchmark name**:
+The google_benchmark/CodSpeed identifier
+`benchmarks/bench_nfft_direct.cpp::<prefix><function>/<args>`. The leaf
+(`<prefix><function>`) comes from the `BENCH` macro in `benchmarks/util.h`; since
+codspeed-cpp v2.x the `benchmarks/bench_nfft_direct.cpp::` prefix is supplied by
+codspeed from `__FILE__` relative to `CODSPEED_ROOT_DIR` (pinned to the repo root
+in `benchmarks/CMakeLists.txt`). The unit CodSpeed tracks; Preserving benchmark 
+names for the same unit of work while making changes is important.
+_Avoid_: benchmark id, test name, label.
+
+**Benchmarks prefix** (`BENCHMARKS_PREFIX`):
+The per-cell `<BUILD_CONFIG>/` string embedded in every benchmark name, where
+`BUILD_CONFIG = <os>_<compiler>_<window>_<precision>_<openmp>`. The only
+per-matrix-cell-variable part of a benchmark name; both build systems receive it
+as an identical string.
+_Avoid_: benchmark prefix tag, name prefix.
+
+**CodSpeed profile**:
+The full set of benchmark names CodSpeed has on record over time. The cutover must
+leave it unchanged — no names added, none removed.
+_Avoid_: benchmark suite, CodSpeed dashboard, baseline.
+
+**Benchmark-producing cell**:
+A CI matrix cell that builds and runs the benchmark, currently exactly the `kaiserbessel`
+window cells. Gated by `BENCHMARK_AGNOSTIC_WINDOW`.
+_Avoid_: benchmark job, active cell.
+
+**Agnostic benchmark flags**:
+The `window` / `openmp` / `precision` : `0/1` selectors choosing which matrix
+cells build a given benchmark (Autotools `--with-agnostic-benchmarks`, CMake
+`NFFT_AGNOSTIC_BENCHMARKS`; same `param:flag` CSV format). Only `window` is used
+today.
+_Avoid_: benchmark filters, build flags.
+
+### The two parity guards (distinct — do not conflate)
+
+**Config-symbol parity guard**:
+`cmake/config-parity-check.sh` — diffs the macro symbol *set* in Autotools
+`include/config.h` against CMake `build/config.h`, failing on any symbol the CMake
+header omits. Guards against config drift between the two build systems. (As of
+Phase 4 it exists but is not yet wired into CI.)
+_Avoid_: the parity guard (ambiguous), config check.
+
+### Tests
+
+**ctest suite**:
+The CMake counterpart of the Autotools `make check`: the CUnit binaries `checkall`
+(serial) and `checkall_threads` (OpenMP) registered with `add_test` and run via
+`ctest`. Covers exactly the **util / nfft / nfct / nfst** suites — the same set the
+Autotools suite builds. In CI it runs in every matrix cell (full window × precision ×
+openmp × compiler parity), like `make check`. Distinct from an **interface test**:
+the term covers the CUnit core only, never the opt-in MATLAB/Octave runners.
+_Avoid_: unit tests (ambiguous with the per-assertion `CU_ASSERT` cases), test harness.
+
+**Interface test**:
+An opt-in `ctest` case that runs a MATLAB/Octave unit-test runner
+(`nfftUnitTestsRunAndExit` etc.) via the configured toolbox, mirroring the
+`check_*_octave.sh`/`check_*_matlab.sh` tests Autotools runs under `make check`.
+Registered only when a mex backend is configured (e.g. `NFFT_WITH_OCTAVE`); the
+Octave set is nfft + nfsft (`HAVE_NFSFT`) + nfsoft (`HAVE_NFSOFT`). Separate from
+the **ctest suite** (the CUnit core) — the two are never conflated.
+_Avoid_: ctest suite (that is the CUnit core), unit test (the per-assertion cases).
+
+**Orphaned test**:
+`tests/check_nfsft.c` — a test source present in the tree but compiled by **neither**
+build system. The CUnit suite has no tests for the six double-only modules (nnfft,
+nsfft, mri, fpt, nfsft, nfsoft); the tested modules nfct/nfst build in every precision,
+so "gate the six modules' tests to double precision" is a **no-op**.
+_Avoid_: disabled test, skipped test (those imply a wired-up test deliberately not run).
+
+**FindCUnit**:
+The vendored `cmake/FindCUnit.cmake` — locates CUnit (the `<CUnit/CUnit.h>` header and
+the `cunit` library) and provides the `CUnit::CUnit` imported target; the CMake
+counterpart of `m4/nfft_lib_cunit.m4`. Honors `CUnit_ROOT` / `CUnit_INCLUDEDIR` /
+`CUnit_LIBDIR`.
+_Avoid_: the CUnit finder (ambiguous with the Autotools macro).
+
+**Reference-data generator**:
+The Python + mpmath tool `tests/refgen/` that is the single source of truth for the
+file-based check data: it emits `tests/data/*.txt`, the generated C headers
+`tests/data/generated/<module>_testcases.h`, and the data `EXTRA_DIST` list. Not a
+build dependency. See ADR-0002.
+_Avoid_: data scripts, Mathematica notebooks (removed).
+
+**File-based check / Online check**:
+The two CUnit test classes. A **file-based check** reads a high-precision reference
+from `tests/data/*.txt` and validates both the direct and fast transform against it.
+An **online check** generates random input, builds the reference with the direct
+transform, and validates the fast transform against it. See
+`docs/agents/test-methodology.md`.
+_Avoid_: reference test / accuracy test (ambiguous — name the class).
+
+### Language interfaces
+
+**Interface kernel**:
+The `kernel/*.c` sources recompiled into a PIC static library (`nfft3_iface`, plus
+`nfft3_iface_omp` under OpenMP) that links **no FFTW of its own** — the FFTW flavour
+(system vs MATLAB-bundled) is chosen at the *final* shared-object link. One pair
+serves every interface backend, collapsing Autotools' separate
+`libnfft3${s}_julia.la` / `libnfft3${s}_matlab.la` convenience libs (libtool bakes
+FFTW into each; CMake static libs defer linking).
+_Avoid_: julia/matlab kernel variant (there is only one), kernel object lib.
+
+**Mex backend**:
+The toolbox a mex module is built against: **octave** (`NFFT_WITH_OCTAVE`, via the
+vendored `FindOctave.cmake` with system FFTW or **matlab** (`find_package(Matlab)` 
++ bundled `libmwfftw3`. The two are mutually exclusive in one build tree (they produce 
+the same `<mod>mex` files). The loadable produced is named exactly `<mod>mex.<ext>` 
+(`.mex` for Octave), what the `.m` wrapper calls.
+_Avoid_: mex flavor, octave/matlab variant (use "backend").
+
+**Stub-MATLAB fixture**:
+A fake MATLAB tree (`cmake/test-fixtures/fake-matlab/`: stub `extern/include` headers,
+stub `bin/<arch>` libs, `libmwfftw3` = a copy of the real system FFTW, the
+`mexFunction.map` version script) used to verify the MATLAB backend's **CMake wiring**
+with no MATLAB present — that `find_package(Matlab)` + `matlab_add_mex` + the
+`libmwfftw3` finder resolve and produce a `<mod>mex.<ext>` exporting only
+`mexFunction`. It verifies **wiring only**, not that the C matches real MATLAB headers
+(self-authored stub) and not runtime/numerical correctness.
+_Avoid_: mock MATLAB (implies behavioural emulation — it emulates nothing).
+
+**Provisional backend**:
+A backend whose CMake wiring is verified (e.g. MATLAB via the **stub-MATLAB fixture**)
+but which has not yet been built+run against the real toolbox. It stays provisional
+until its runtime exit criterion passes (the MATLAB-host smoke test). Distinct from the
+**Octave** backend, which is run-verified locally.
+_Avoid_: working backend, supported backend (until the runtime test passes).
+
+### Examples & applications
+
+**Program target**:
+An example (`examples/`) or application (`applications/`) executable. In Autotools
+these are `noinst_PROGRAMS` — built by `make`, **never installed**, and **never run**
+by `make check` (several block on `getc(stdin)`). CMake parity bar is therefore
+that every such binary **builds**, not that it runs; no `ctest` cases are added for
+them. The double-only ones are gated on the kernel `HAVE_*` variables, so they vanish
+in float/long-double exactly as `m4/ax_nfft_module.m4` arranges.
+_Avoid_: test program (implies it is run), installed binary.
+
+**Orphaned application**:
+`applications/iterS2` — present in the tree but built by **neither** build system
+(commented out in `configure.ac`, no `Makefile.in`, `DIR_ITERS2` hard-wired empty).
+Kept in the repo for possible later re-integration; the CMake build omits it to stay
+at parity with Autotools (building it would break coexistence symmetry). The same
+class as the orphaned test `tests/check_nfsft.c`. (`examples/mri/Makefile.am` is a
+separate case — present but **empty**, so it builds nothing in either system.)
+_Avoid_: disabled app, removed app (the source is retained, just unbuilt).

--- a/docs/adr/0001-adopt-cmake-alongside-autotools.md
+++ b/docs/adr/0001-adopt-cmake-alongside-autotools.md
@@ -1,0 +1,47 @@
+# Adopt a CMake build alongside Autotools
+
+**Status:** accepted
+
+We will add a CMake build system that **coexists** with the existing Autotools
+build rather than replacing it, because Autotools cannot easily deliver four
+things we need: stable CodSpeed benchmark CI, Windows/MSVC builds,
+`find_package()` consumption, and good IDE integration. The precipitating pain is
+**intermittent CodSpeed CI failures**: CodSpeed's `codspeed-cpp` (a google_benchmark
+fork) is built by its own CMake, and our Autotools build currently reaches into
+that build tree with hardcoded include/library paths and hand-set instrumentation
+defines (`m4/nfft_lib_codspeed.m4`). That cross-build-system mismatch is the
+potentially part of the flakiness, and CodSpeed only documents a CMake (`FetchContent`)
+integration path.
+
+## Key decisions
+
+- **Coexistence, not replacement.** Autotools remains the supported build,
+  including for legacy/HPC toolchains. This lets the CMake floor be modern
+  (`cmake_minimum_required(VERSION 3.20)`) without locking anyone out.
+- **One precision per build tree** (the FFTW model). Precision is fixed at
+  configure time via `NFFT_SINGLE`/`NFFT_LDOUBLE`; an `ENABLE_FLOAT`/
+  `ENABLE_LONG_DOUBLE` → `PREC_SUFFIX` scheme drives the library name. The public
+  header `nfft3.h` is precision-agnostic and installed once; only the compiled
+  library and its `NFFT3{,f,l}Config.cmake` are per-precision.
+- **Benchmarks-first sequencing.** The first CMake milestone is the core library
+  plus the CodSpeed benchmark (double precision only, with the precision
+  scaffolding in place), obtaining `codspeed-cpp` via `FetchContent` (pinned tag,
+  with a cache/override variable). This delivers the actual driver — stable
+  benchmark CI — in the smallest slice. Tests, examples/applications, install/
+  export, and the MATLAB/Julia interfaces follow.
+- **Explicit source lists, hybrid layout.** Sources are listed explicitly (only
+  ~33 stable `kernel/*.c` files; transform modules are single-file), not globbed.
+  A root `CMakeLists.txt` plus `add_subdirectory` per top-level area co-locates
+  each list with its `Makefile.am`.
+- **Vendored `cmake/FindFFTW3.cmake`.** Handles the per-precision base/`_omp`/
+  `_threads` FFTW triplet that off-the-shelf modules don't model.
+
+## Consequences
+
+- **Dual maintenance.** Build logic exists twice. The source of truth for config
+  symbols is the `AC_DEFINE` set in `configure.ac` (`config.h.in` itself is
+  `autoheader`-generated and not checked in); `cmake.config.h.in` must mirror it.
+  A **CI parity guard** diffs the macro symbol sets between the two and fails on
+  divergence to prevent silent drift.
+- CMake CI starts as a single lane (double, all modules, OpenMP) and expands to
+  the full window × precision × OpenMP matrix only in the final phase.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,36 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+This is a single-context repo: one `CONTEXT.md` and one `docs/adr/` at the repo root.
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-precision-agnostic-sources.md
+│   └── 0002-fftw-as-hard-dependency.md
+├── include/
+└── kernel/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (window-function selection) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,19 @@
+# Issue tracker: Local Markdown
+
+Issues and PRDs for this repo live as markdown files in `.scratch/`.
+
+## Conventions
+
+- One feature per directory: `.scratch/<feature-slug>/`
+- The PRD is `.scratch/<feature-slug>/PRD.md`
+- Implementation issues are `.scratch/<feature-slug>/issues/<NN>-<slug>.md`, numbered from `01`
+- Triage state is recorded as a `Status:` line near the top of each issue file (see `triage-labels.md` for the role strings)
+- Comments and conversation history append to the bottom of the file under a `## Comments` heading
+
+## When a skill says "publish to the issue tracker"
+
+Create a new file under `.scratch/<feature-slug>/` (creating the directory if needed).
+
+## When a skill says "fetch the relevant ticket"
+
+Read the file at the referenced path. The user will normally pass the path or the issue number directly.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,17 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+With the local-markdown tracker, the label string is written as the `Status:` line near the top of each issue file (see `issue-tracker.md`).
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
This PR adds supporting documents that provide orientation for coding agents. Follows the [/setup-matt-pocock-skills](https://github.com/mattpocock/skills/blob/main/skills/engineering/setup-matt-pocock-skills/SKILL.md) skill:
- `AGENTS.md`/`CLAUDE.md`: general instructions re working with the project.
- `CONTEXT.md`: Glossary of important terms to foster consistent wording.
- `docs/agents/domain.md`: Domain doc consumer rules + layout.
- `docs/agents/issue-tracker.md`: How to track issues. Use local .md files for now. May change later to use actual GH issues.
- `docs/agents/triage-labels.md`: Default set of labels, not really used so far.
- `docs/adr/0001-adopt-cmake-alongside-autotools.md`: An architectural design record (ADR) to explain the rationale behind CMake adoption. Use ADRs to log important architectural decisions.