### PR TITLE
NDFT blocked recurrence

### DIFF
--- a/kernel/nfft/nfft.c
+++ b/kernel/nfft/nfft.c
@@ -142,6 +142,17 @@ static inline void sort(const X(plan) *ths)
  * for k in I_N^d
  *  f_hat[k] = sum_{j=0}^{M_total-1} f[j] * exp(-2(pi) k x[j])
  */
+/* Block size for the phase recurrence in the direct transforms */
+#define NFFT_DIRECT_RECURRENCE_BLOCK 32
+
+/* Accurate phase for exp(+-i 2pi k x): reduce k*x modulo 1 into ~[-1/2,1/2) so COS/SIN see a
+ * small argument, error does not grow with N. Requires FMA single-rounding semantics. */
+static inline R X(reduced_omega)(const R k, const R x)
+{
+  const R n = RINT(k * x);  // Nearest integer to k * x.
+  return K2PI * FFMA(k, x, -n);  // Calculate k * x - n witha single rounding, then multiply 2 * pi.
+}
+
 void X(trafo_direct)(const X(plan) *ths)
 {
   C *f_hat = (C*)ths->f_hat, *f = (C*)ths->f;
@@ -149,6 +160,7 @@ void X(trafo_direct)(const X(plan) *ths)
   if (ths->d == 1)
   {
     /* specialize for univariate case, rationale: faster */
+    const INT B = NFFT_DIRECT_RECURRENCE_BLOCK;
     INT j;
 #ifdef _OPENMP
     #pragma omp parallel for default(shared) private(j)
@@ -156,11 +168,21 @@ void X(trafo_direct)(const X(plan) *ths)
     for (j = 0; j < ths->M_total; j++)
     {
       C v = K(0.0);
-      INT k_L;
-      for (k_L = 0; k_L < ths->N_total; k_L++)
+      const R x = ths->x[j];
+      const R dphi = K2PI * x;                 /* |dphi| <= pi: accurate without reduction */
+      const C dw = COS(dphi) - II * SIN(dphi); /* per-step phase factor exp(-i 2pi x)      */
+      INT k_L = 0;
+      while (k_L < ths->N_total)
       {
-        R omega = K2PI * ((R)(k_L - ths->N_total/2)) * ths->x[j];
-        v += f_hat[k_L] * (COS(omega) - II * SIN(omega));
+        /* Accurate seed exp(-i 2pi (k_L - N/2) x), then recur within the block. */
+        const R omega = X(reduced_omega)((R)(k_L - ths->N_total/2), x);
+        C w = COS(omega) - II * SIN(omega);
+        INT kend = k_L + B; if (kend > ths->N_total) kend = ths->N_total;
+        for (; k_L < kend; k_L++)
+        {
+          v += f_hat[k_L] * w;
+          w *= dw;
+        }
       }
 
       f[j] = v;
@@ -217,7 +239,45 @@ void X(adjoint_direct)(const X(plan) *ths)
   if (ths->d == 1)
   {
     /* specialize for univariate case, rationale: faster */
+    const INT B = NFFT_DIRECT_RECURRENCE_BLOCK;
 #ifdef _OPENMP
+    if (ths->N_total > B)
+    {
+      /* Give each thread a disjoint, contiguous range of frequencies [klo,khi) (so the
+       * f_hat[k] writes are race-free) and run the phase recurrence within it, re-seeded
+       * every B steps. */
+      #pragma omp parallel default(shared)
+      {
+        const int nt = omp_get_num_threads();
+        const int tid = omp_get_thread_num();
+        const INT klo = (INT)(((long long)ths->N_total * tid) / nt);
+        const INT khi = (INT)(((long long)ths->N_total * (tid + 1)) / nt);
+        INT j;
+        for (j = 0; j < ths->M_total; j++)
+        {
+          const R x = ths->x[j];
+          const R dphi = K2PI * x;
+          const C dw = COS(dphi) + II * SIN(dphi);
+          INT k_L = klo;
+          while (k_L < khi)
+          {
+            const R omega = X(reduced_omega)((R)(k_L - ths->N_total/2), x);
+            C w = COS(omega) + II * SIN(omega);
+            INT kend = k_L + B; if (kend > khi) kend = khi;
+            for (; k_L < kend; k_L++)
+            {
+              f_hat[k_L] += f[j] * w;
+              w *= dw;
+            }
+          }
+        }
+      }
+    }
+    else
+    {
+      /* N <= B: the recurrence spans at most one block per thread-range, so its per-block
+       * seed/setup costs more than it saves once threaded. Use the plain per-k
+       * parallelisation. At these tiny N the per-entry phase error is in check. */
       INT k_L;
       #pragma omp parallel for default(shared) private(k_L)
       for (k_L = 0; k_L < ths->N_total; k_L++)
@@ -229,15 +289,25 @@ void X(adjoint_direct)(const X(plan) *ths)
           f_hat[k_L] += f[j] * (COS(omega) + II * SIN(omega));
         }
       }
+    }
 #else
       INT j;
       for (j = 0; j < ths->M_total; j++)
       {
-        INT k_L;
-        for (k_L = 0; k_L < ths->N_total; k_L++)
+        const R x = ths->x[j];
+        const R dphi = K2PI * x;
+        const C dw = COS(dphi) + II * SIN(dphi);
+        INT k_L = 0;
+        while (k_L < ths->N_total)
         {
-          R omega = K2PI * ((R)(k_L - ths->N_total / 2)) * ths->x[j];
-          f_hat[k_L] += f[j] * (COS(omega) + II * SIN(omega));
+          const R omega = X(reduced_omega)((R)(k_L - ths->N_total/2), x);
+          C w = COS(omega) + II * SIN(omega);
+          INT kend = k_L + B; if (kend > ths->N_total) kend = ths->N_total;
+          for (; k_L < kend; k_L++)
+          {
+            f_hat[k_L] += f[j] * w;
+            w *= dw;
+          }
         }
       }
 #endif

--- a/tests/accuracy/htmlreport.py
+++ b/tests/accuracy/htmlreport.py
@@ -129,7 +129,8 @@ def _cell_html(cell, change=None):
     if change is not None:
         arrow = "▲" if change.delta_digits > 0 else "▼"
         cls = ' class="chg"'
-        text = f"{text} {arrow}"
+        pr_head = "∞" if max_error == 0.0 else f"{digits:.1f}"
+        text = f"{change.base_digits:.1f} → {pr_head} ({bound_digits:.1f}) {arrow}"
         tip = (
             f"{change.base_digits:.2f} -> {change.pr_digits:.2f} digits "
             f"(delta {change.delta_digits:+.2f})"

--- a/tests/accuracy/tests/test_htmlreport.py
+++ b/tests/accuracy/tests/test_htmlreport.py
@@ -172,6 +172,12 @@ def test_pr_view_marks_changed_cell():
     doc = render_report(_tree(), _diff(), title="PR")
     assert 'class="chg"' in doc
     assert "▲" in doc
+    # Changed cell shows baseline → new (bound) using cell's own digits (13.7 from tree).
+    # In production change.pr_digits == cell digits; the mock has them mismatched on purpose
+    # so we test with the cell value that actually ends up in the HTML.
+    assert "13.0 → 13.7 (11.0) ▲" in doc
+    # Regression: base=14.0, cell digits=12.0 (bound=11.0)
+    assert "14.0 → 12.0 (11.0) ▼" in doc
 
 
 def test_changes_itemized_capped_at_10():


### PR DESCRIPTION
This PR seeks to improve the efficiency as well as the accuracy of the 1D direct NDFT forward/adjoint transforms for serial and threaded cases.

I was originally just trying to improve the performance but then noticed that the forward transform's error (max abs node-wise error divided by 1-norm of Fourier coefficients vector) grows like O(sqrt(N)) and that of the adjoint transform like O(N) while the error bound we use in our tests is just O(eps), independent of N.

After some rounding error analysis, the two sources of errors were 
1. the calculation of the argument to sin/cos, and
3. the final summation over the frequencies. 

1. can be reduced by using an FMA to reduce the argument to [-pi,pi] before feeding into sin/cos. This change has removed the N-dependency of the errors entirely.

After confirming the accuracy improvements, I applied another optimization that avoids the repeated costly sin/cos evaluations, by pulling out a constant factor added to the phase from one loop iteration to the next. This has to be done block-wise to not remove the accuracy improvements from the first set of changes again. There's now a tunable parameter B=32, the block size, that trades accuracy (B smaller) for speed (B larger).

I have attached a HTML write-up generated by my coding assistant that describes the changes and the rationale: 
[direct-1d-recurrence-optimization.html](https://github.com/user-attachments/files/29202858/direct-1d-recurrence-optimization.html)

This was tested on ARM64 (macOS) as well as in CI on x64 (Linux) architectures. If a platform does not support the single-rounding FMA semantics, the error bound could still be N-dependent again.