### PR TITLE
Add understanding-fftw skill.

### DIFF
--- a/.claude/skills/understanding-fftw/SKILL.md
+++ b/.claude/skills/understanding-fftw/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: understanding-fftw
+description: Use when you need a precise FFTW3 C function signature, planner-flag/alignment/execute-function detail, license text, or exact reference-manual wording — instead of relying on memory or a live web fetch.
+---
+
+# Understanding FFTW
+
+## Overview
+
+Offline, local mirror of the upstream FFTW3 project: a shallow clone of its
+source (`github.com/FFTW/fftw3`) plus its reference manual (`fftw3.pdf`)
+converted to Markdown. Grep it for ground truth instead of guessing from
+training data or depending on network access.
+
+The mirror is cached **inside the current project**, at
+`<repo-root>/.fftw3-reference/`, not inside this skill directory —
+run the fetch scripts below the first time you need it in a given repo. The
+scripts also add that path to the repo's `.git/info/exclude` (never to a
+tracked `.gitignore`), so it's ignored locally without affecting anyone
+else's clone.
+
+## When to use
+
+- Confirming an exact FFTW3 public API signature, macro, or type
+- Checking FFTW's license text or source layout
+- Looking up reference-manual sections (planner flags, alignment rules,
+  new-array execute functions, guru interface, MPI/threads, ...)
+- Any FFTW-related question — e.g. while working on NFFT3, which depends on
+  and is influenced by FFTW — where source- or manual-level precision matters
+  more than a paraphrase
+
+## Contents
+
+Under `<repo-root>/.fftw3-reference/`:
+
+- `fftw3-src/` — depth-1 clone of `https://github.com/FFTW/fftw3.git`.
+  Public API lives in `api/fftw3.h`, generated via `X()`/`R`/`C` mangling
+  macros (precision-agnostic, one source per float/double/long-double —
+  analogous to NFFT3's own `Y()`/`X()` convention).
+- `fftw3-docs.md` — `fftw3.pdf` converted to Markdown (headings and code
+  blocks preserved; not pixel-perfect, see Common mistakes below).
+
+## How to use
+
+First time in a given repo (or to check it exists), fetch/update:
+
+```bash
+.claude/skills/understanding-fftw/scripts/update.sh          # both
+.claude/skills/understanding-fftw/scripts/fetch-source.sh    # source only
+.claude/skills/understanding-fftw/scripts/fetch-docs.sh      # docs only
+```
+
+Run these from anywhere inside the target project's working tree — they
+resolve the project root via `git rev-parse --show-toplevel`. Not being
+inside a git repo is an error (the script has nowhere sensible to cache to).
+
+Then grep, don't read whole files, from `<repo-root>/.fftw3-reference/`:
+
+```bash
+grep -n "plan_many_dft_r2c" fftw3-src/api/fftw3.h
+grep -n -i "new-array execute" fftw3-docs.md
+```
+
+The header uses unexpanded macros, so search for the name **without** the
+`fftw_` prefix (e.g. `plan_many_dft_r2c`, not `fftw_plan_many_dft_r2c`).
+
+## Quick reference
+
+| Need | Where |
+|---|---|
+| Exact function signature | `.fftw3-reference/fftw3-src/api/fftw3.h` |
+| License | `.fftw3-reference/fftw3-src/COPYING` |
+| Build/config options | `.fftw3-reference/fftw3-src/configure.ac` |
+| Manual section (planner flags, alignment, execute functions, ...) | `.fftw3-reference/fftw3-docs.md` |
+| Precision-mangling macros | `.fftw3-reference/fftw3-src/api/fftw3.h` (search `X(`, `R`, `C`) |
+
+## Refreshing
+
+Cached content is a point-in-time snapshot. Re-run the fetch scripts above
+(safe to re-run any time — they update in place) when you need the latest
+upstream state. `fetch-docs.sh` tries `pandoc` first, falls back to
+`uvx`+`pymupdf4llm`, then `pdftotext`.
+
+## Common mistakes
+
+- Grepping `api/fftw3.h` for `fftw_`-prefixed names — the header uses
+  unexpanded `X()` macros; search the unprefixed name.
+- Assuming the Markdown conversion is typographically perfect — pymupdf4llm
+  occasionally merges hyphenated words split across a line break (e.g.
+  "new-array" → "newarray"). If a grep misses, retry with a shorter
+  substring or without the hyphen.
+- Treating `fftw3-src` as having full history — it's a depth-1 shallow
+  clone (latest default-branch commit only). Use the upstream GitHub repo
+  directly for blame/history questions.
+- Looking for `.fftw3-reference/` inside this skill directory — it lives in
+  the *project* you're working in, not here. If it's missing, run the fetch
+  scripts first.
+- Committing it by hand (e.g. `git add -A`) — it's excluded via
+  `.git/info/exclude`, so normal `git add`/`git status` never see it; no
+  extra care needed, but don't force-add it either.

--- a/.claude/skills/understanding-fftw/scripts/_common.sh
+++ b/.claude/skills/understanding-fftw/scripts/_common.sh
@@ -1,0 +1,23 @@
+# Shared setup for fetch-source.sh / fetch-docs.sh.
+# Resolves the current project's root and reference-cache directory, and
+# makes sure that directory is excluded from git locally (via
+# .git/info/exclude) without ever touching a tracked .gitignore file.
+set -euo pipefail
+
+PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+  echo "Error: not inside a git repository. cd into the target project first." >&2
+  exit 1
+}
+
+REF_DIR="$PROJECT_ROOT/.fftw3-reference"
+EXCLUDE_FILE="$PROJECT_ROOT/.git/info/exclude"
+EXCLUDE_PATTERN="/.fftw3-reference/"
+
+mkdir -p "$REF_DIR"
+
+if [ -f "$EXCLUDE_FILE" ] && grep -qxF "$EXCLUDE_PATTERN" "$EXCLUDE_FILE"; then
+  : # already excluded
+else
+  echo "$EXCLUDE_PATTERN" >> "$EXCLUDE_FILE"
+  echo "Added '$EXCLUDE_PATTERN' to $EXCLUDE_FILE (local-only, not tracked)"
+fi

--- a/.claude/skills/understanding-fftw/scripts/fetch-docs.sh
+++ b/.claude/skills/understanding-fftw/scripts/fetch-docs.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Downloads the FFTW3 reference manual PDF and converts it to
+# <project-root>/.fftw3-reference/fftw3-docs.md so it can be
+# grepped/read offline. Must be run from inside the target project's git repo.
+set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_common.sh"
+
+PDF="$REF_DIR/fftw3.pdf"
+OUT="$REF_DIR/fftw3-docs.md"
+PDF_URL="https://fftw.org/fftw3.pdf"
+
+echo "Downloading $PDF_URL"
+curl -fsSL -o "$PDF" "$PDF_URL"
+
+echo "Converting to Markdown ($OUT)"
+if command -v pandoc >/dev/null 2>&1; then
+  pandoc "$PDF" -f pdf -t gfm -o "$OUT"
+elif command -v uvx >/dev/null 2>&1; then
+  # pymupdf4llm produces clean, well-structured Markdown (headings, code
+  # blocks) from the manual; this is the preferred fallback when pandoc
+  # is unavailable, as it is on the devcontainer.
+  uvx --from pymupdf4llm python3 - "$PDF" "$OUT" <<'PYEOF'
+import sys, pathlib, pymupdf4llm
+pdf_path, out_path = sys.argv[1], sys.argv[2]
+md = pymupdf4llm.to_markdown(pdf_path)
+pathlib.Path(out_path).write_text(md)
+print(f"wrote {len(md)} chars")
+PYEOF
+elif command -v pdftotext >/dev/null 2>&1; then
+  echo "Warning: pandoc/uvx unavailable; falling back to pdftotext (plain text, no headings/tables)" >&2
+  pdftotext -layout "$PDF" "$OUT"
+else
+  echo "Error: no PDF-to-text/markdown converter available." >&2
+  echo "Install one of: pandoc, uv (https://docs.astral.sh/uv/), pdftotext (poppler-utils)." >&2
+  rm -f "$PDF"
+  exit 1
+fi
+
+rm -f "$PDF"
+echo "fftw3-docs.md: $(wc -l < "$OUT") lines"

--- a/.claude/skills/understanding-fftw/scripts/fetch-source.sh
+++ b/.claude/skills/understanding-fftw/scripts/fetch-source.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Shallow-clones (or updates) the upstream FFTW3 source tree into
+# <project-root>/.fftw3-reference/fftw3-src so it can be browsed
+# offline. Must be run from inside the target project's git repo.
+set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_common.sh"
+
+SRC_DIR="$REF_DIR/fftw3-src"
+REPO_URL="https://github.com/FFTW/fftw3.git"
+
+if [ -d "$SRC_DIR/.git" ]; then
+  echo "Updating existing clone at $SRC_DIR"
+  git -C "$SRC_DIR" fetch --depth 1 origin
+  git -C "$SRC_DIR" reset --hard FETCH_HEAD
+else
+  echo "Cloning $REPO_URL (shallow, depth=1) into $SRC_DIR"
+  git clone --depth 1 "$REPO_URL" "$SRC_DIR"
+fi
+
+commit="$(git -C "$SRC_DIR" rev-parse --short HEAD)"
+date="$(git -C "$SRC_DIR" log -1 --format=%cd --date=short)"
+echo "fftw3-src is now at commit $commit ($date)"

--- a/.claude/skills/understanding-fftw/scripts/update.sh
+++ b/.claude/skills/understanding-fftw/scripts/update.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Refreshes both the local FFTW3 source mirror and the converted manual.
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$DIR/fetch-source.sh"
+"$DIR/fetch-docs.sh"


### PR DESCRIPTION
Adds a repository-local `understanding-fftw` skill. This skill allows an agent to pull in an offline copy of the latest FFTW GitHub repo as well as a Markdown version of the documentation from the `fftw.org` website. When an agent needs to check FFTW's sources or the API docs, using the offline copy avoids unnecessary HTTP calls to retrieve the assets. The skill offers scripts with deterministic output layout.