### PR TITLE
Scale the Kaiser-Bessel window to unit peak.

### DIFF
--- a/include/infft.h
+++ b/include/infft.h
@@ -255,20 +255,30 @@ typedef ptrdiff_t INT;
     #define WINDOW_HELP_ESTIMATE_m 11
   #endif
 #else /* Kaiser-Bessel is the default. */
-  #define PHI_HUT(n,k,d) (Y(bessel_i0)((R)(ths->m) * SQRT(ths->b[d] * ths->b[d] - (K(2.0) * KPI * (R)(k) / (R)(n)) * (K(2.0) * KPI * (R)(k) / (R)(n)))))
-  #define PHI(n,x,d) (  (((R)(ths->m) * (R)(ths->m) - (x) * (R)(n) * (x) * (R)(n)) > K(0.0)) \
-                      ?   SINH(ths->b[d] * SQRT((R)(ths->m) * (R)(ths->m) - (x) * (R)(n) * (x) * (R)(n))) \
-                        / (KPI * SQRT((R)(ths->m) * (R)(ths->m) - (x) * (R)(n) * (x) * (R)(n))) \
-                      :   ((((R)(ths->m) * (R)(ths->m) - (x) * (R)(n) * (x) * (R)(n)) < K(0.0)) \
-                        ?   SIN(ths->b[d] * SQRT((x) * (R)(n) * (x) * (R)(n) - (R)(ths->m) * (R)(ths->m))) \
-                          / (KPI * SQRT((x) * (R)(n) * (x) * (R)(n) - (R)(ths->m) * (R)(ths->m))) \
-                        : ths->b[d] / KPI))
+  /* PHI and PHI_HUT both carry the factor exp(-log I0(m b)) so that PHI_HUT(n,0,ax) 
+   * is normalized to 1. Deconvolution divides by PHI_HUT and convolution multiplies 
+   * by PHI, so the factor cancels and the transform is unchanged.
+   *
+   * ths->b holds 3 * ths->d reals: b per axis, log I0(m b), and log I0(m b) - m b. */
+  #define KB_B(ax) (ths->b[(ax)])
+  #define KB_LG_PEAK(ax) (ths->b[(ths->d) + (ax)])
+  #define KB_LG_TAIL(ax) (ths->b[2 * (ths->d) + (ax)])
+  #define PHI_HUT(n,k,ax) (Y(kb_phi_hut)(KB_B(ax), KB_LG_PEAK(ax), \
+                             KB_LG_TAIL(ax), (R)(ths->m), (R)(n), (R)(k)))
+  #define PHI(n,x,ax) (Y(kb_phi)(KB_B(ax), KB_LG_PEAK(ax), KB_LG_TAIL(ax), \
+                         (R)(ths->m), (R)(n), (R)(x)))
   #define WINDOW_HELP_INIT \
     { \
       int WINDOW_idx; \
-      ths->b = (R*) Y(malloc)((size_t)(ths->d) * sizeof(R)); \
+      ths->b = (R*) Y(malloc)((size_t)(3 * ths->d) * sizeof(R)); \
       for (WINDOW_idx = 0; WINDOW_idx < ths->d; WINDOW_idx++) \
-        ths->b[WINDOW_idx] = (KPI * (K(2.0) - K(1.0) / ths->sigma[WINDOW_idx])); \
+      { \
+        R WINDOW_b = (KPI * (K(2.0) - K(1.0) / ths->sigma[WINDOW_idx])); \
+        R WINDOW_xpk = ((R)(ths->m)) * WINDOW_b; \
+        ths->b[WINDOW_idx] = WINDOW_b; \
+        ths->b[ths->d + WINDOW_idx] = Y(bessel_i0_log)(WINDOW_xpk); \
+        ths->b[2 * ths->d + WINDOW_idx] = Y(bessel_i0_logtail)(WINDOW_xpk); \
+      } \
   }
   #define WINDOW_HELP_FINALIZE {Y(free)(ths->b);}
   #if MANT_DIG == 113
@@ -292,6 +302,11 @@ typedef ptrdiff_t INT;
 
 /* window.c */
 INT Y(m2K)(const INT m);
+
+/* Kaiser-Bessel window scaled by exp(-lg_peak), with lg_peak = log I0(m b) and
+ * lg_tail = lg_peak - m b, so that phi_hut(0) == 1. */
+R Y(kb_phi_hut)(R b, R lg_peak, R lg_tail, R m, R n, R k);
+R Y(kb_phi)(R b, R lg_peak, R lg_tail, R m, R n, R x);
 
 #if defined(NFFT_LDOUBLE)
 #if HAVE_DECL_COPYSIGNL == 0
@@ -1480,7 +1495,18 @@ R Y(lambda)(R z, R eps);
 R Y(lambda2)(R mu, R nu);
 
 /* bessel_i0.c: */
-R Y(bessel_i0)(R x);
+
+/* Argument above which I0 switches to its asymptotic exp(x)/sqrt(x) form. */
+#if MANT_DIG == 113
+#  define NFFT_I0_ASYMP_SPLIT K(25.0)
+#else
+#  define NFFT_I0_ASYMP_SPLIT K(15.0)
+#endif
+
+R Y(bessel_i0)(R x);                    /* I0(x) */
+R Y(bessel_i0_log)(R x);                /* log I0(x), overflow-free for large x */
+R Y(bessel_i0_scaled)(R x, R lg_peak);  /* I0(x) * exp(-lg_peak), never forms I0(x) */
+R Y(bessel_i0_logtail)(R x);            /* log I0(x) - x, cancellation-free */
 
 /* bspline.c: */
 R Y(bsplines)(const INT, const R x);

--- a/kernel/util/bessel_i0.c
+++ b/kernel/util/bessel_i0.c
@@ -18,6 +18,10 @@
 
 #include "infft.h"
 
+/* Modified Bessel function I0 and its logarithmic forms. Two ranges per
+ * precision: the Chebyshev ratio P1/Q1 for x <= NFFT_I0_ASYMP_SPLIT, and the
+ * asymptotic exp(x)/sqrt(x) times P2/Q2 above it. */
+
 #if MANT_DIG == 113
   // IEEE 754 quadruple precision, 128 bits.
   static const R P1[] =
@@ -356,7 +360,7 @@ R Y(bessel_i0)(R x)
     return K(1.0);
 
 #if MANT_DIG == 113
-  if (x <= K(25.0))
+  if (x <= NFFT_I0_ASYMP_SPLIT)
   {
     R y = (x / K(2.0));
     y = y * y;
@@ -368,7 +372,7 @@ R Y(bessel_i0)(R x)
     return (EXP(x) / SQRT(x)) * evaluate_polynomial(N2, P2, 1 / x);
   }
 #else
-  if (x <= K(15.0))
+  if (x <= NFFT_I0_ASYMP_SPLIT)
   {
     /* x in (0, 15] */
     const R y = x * x;
@@ -380,6 +384,103 @@ R Y(bessel_i0)(R x)
     const R y = (K(30.0) - x) / x;
     return (EXP(x) / SQRT(x)) * (evaluate_chebyshev(N2, P2, y) /
       evaluate_chebyshev(M2, Q2, y));
+  }
+#endif
+}
+
+R Y(bessel_i0_log)(R x)
+{
+  if (x < 0)
+    x = -x;
+
+  if (x == K(0.0))
+    return K(0.0);
+
+#if MANT_DIG == 113
+  if (x <= NFFT_I0_ASYMP_SPLIT)
+  {
+    R y = (x / K(2.0));
+    y = y * y;
+    return LOG(K(1.0) + y * evaluate_polynomial(N1, P1, y));
+  }
+  else
+    return x - K(0.5) * LOG(x) + LOG(evaluate_polynomial(N2, P2, K(1.0) / x));
+#else
+  if (x <= NFFT_I0_ASYMP_SPLIT)
+  {
+    const R y = x * x;
+    return LOG(evaluate_chebyshev(N1, P1, y) / evaluate_chebyshev(M1, Q1, y));
+  }
+  else
+  {
+    const R y = (K(30.0) - x) / x;
+    return x - K(0.5) * LOG(x)
+        + LOG(evaluate_chebyshev(N2, P2, y) / evaluate_chebyshev(M2, Q2, y));
+  }
+#endif
+}
+
+R Y(bessel_i0_scaled)(R x, R lg_peak)
+{
+  if (x < 0)
+    x = -x;
+
+  if (x == K(0.0))
+    return EXP(-lg_peak);
+
+#if MANT_DIG == 113
+  if (x <= NFFT_I0_ASYMP_SPLIT)
+  {
+    R y = (x / K(2.0));
+    y = y * y;
+    return (K(1.0) + y * evaluate_polynomial(N1, P1, y)) * EXP(-lg_peak);
+  }
+  else
+    return (EXP(x - lg_peak) / SQRT(x)) * evaluate_polynomial(N2, P2, K(1.0) / x);
+#else
+  if (x <= NFFT_I0_ASYMP_SPLIT)
+  {
+    const R y = x * x;
+    return (evaluate_chebyshev(N1, P1, y) / evaluate_chebyshev(M1, Q1, y))
+        * EXP(-lg_peak);
+  }
+  else
+  {
+    const R y = (K(30.0) - x) / x;
+    return (EXP(x - lg_peak) / SQRT(x))
+        * (evaluate_chebyshev(N2, P2, y) / evaluate_chebyshev(M2, Q2, y));
+  }
+#endif
+}
+
+R Y(bessel_i0_logtail)(R x)
+{
+  if (x < 0)
+    x = -x;
+
+  if (x == K(0.0))
+    return K(0.0);
+
+#if MANT_DIG == 113
+  if (x <= NFFT_I0_ASYMP_SPLIT)
+  {
+    R y = (x / K(2.0));
+    y = y * y;
+    return LOG(K(1.0) + y * evaluate_polynomial(N1, P1, y)) - x;
+  }
+  else
+    return -K(0.5) * LOG(x) + LOG(evaluate_polynomial(N2, P2, K(1.0) / x));
+#else
+  if (x <= NFFT_I0_ASYMP_SPLIT)
+  {
+    const R y = x * x;
+    return LOG(evaluate_chebyshev(N1, P1, y) / evaluate_chebyshev(M1, Q1, y)) - x;
+  }
+  else
+  {
+    const R y = (K(30.0) - x) / x;
+    return -K(0.5) * LOG(x)
+        + LOG(evaluate_chebyshev(N2, P2, y) / evaluate_chebyshev(M2, Q2, y));
   }
 #endif
 }

--- a/kernel/util/window.c
+++ b/kernel/util/window.c
@@ -52,3 +52,47 @@ const char *Y(get_window_name)()
 {
   return STRINGIZE(WINDOW_NAME);
 }
+
+/* Kaiser-Bessel window. lg_peak = log I0(m b), lg_tail = lg_peak - m b. */
+
+R Y(kb_phi_hut)(R b, R lg_peak, R lg_tail, R m, R n, R k)
+{
+  const R xpk = m * b;
+  const R t = K(2.0) * KPI * k / n;
+  const R rs = SQRT(b * b - t * t);
+  const R a = m * rs;
+
+  if (a > NFFT_I0_ASYMP_SPLIT && xpk > NFFT_I0_ASYMP_SPLIT)
+  {
+    /* I0(a)/I0(xpk) with a - xpk rationalized, so small t does not cancel */
+    const R da = -m * t * t / (rs + b);
+    return EXP(da + Y(bessel_i0_logtail)(a) - lg_tail);
+  }
+
+  return Y(bessel_i0_scaled)(a, lg_peak);
+}
+
+R Y(kb_phi)(R b, R lg_peak, R lg_tail, R m, R n, R x)
+{
+  const R nx = n * x;
+  const R a = m * m - nx * nx;
+
+  if (a > K(0.0))
+  {
+    const R ra = SQRT(a);
+    const R u = b * ra;
+    /* sinh(u) exp(-lg_peak) as exp(u - m b - lg_tail) (1 - exp(-2u)) / 2, with
+     * u - m b rationalized: no overflow for large u, none of the cancellation
+     * a difference of exponentials has for small u */
+    const R du = -b * nx * nx / (ra + m);
+    return K(-0.5) * EXP(du - lg_tail) * EXPM1(K(-2.0) * u) / (KPI * ra);
+  }
+
+  if (a < K(0.0))
+  {
+    const R rma = SQRT(-a);
+    return SIN(b * rma) * EXP(-lg_peak) / (KPI * rma);
+  }
+
+  return (b / KPI) * EXP(-lg_peak);
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ set(NFFT_TEST_SOURCES
   reflect.c reflect.h
   bspline.c bspline.h
   bessel.c  bessel.h
+  window.c  window.h
   nfft.c    nfft.h
   nfct.c    nfct.h
   nfst.c    nfst.h)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -34,7 +34,7 @@ else
   NFST_SOURCES=
 endif
 
-checkall_SOURCES = check.c util.c util.h accuracy_log.c accuracy_log.h reflect.c reflect.h bspline.c bspline.h bessel.c bessel.h nfft.c nfft.h $(NFCT_SOURCES) $(NFST_SOURCES)
+checkall_SOURCES = check.c util.c util.h accuracy_log.c accuracy_log.h reflect.c reflect.h bspline.c bspline.h bessel.c bessel.h window.c window.h nfft.c nfft.h $(NFCT_SOURCES) $(NFST_SOURCES)
 checkall_LDFLAGS = @fftw3_LDFLAGS@ @cunit_LDFLAGS@
 checkall_LDADD = $(top_builddir)/libnfft3@PREC_SUFFIX@.la @fftw3_LIBS@ @cunit_LIBS@
 

--- a/tests/check.c
+++ b/tests/check.c
@@ -26,6 +26,7 @@
 #include "util.h"
 #include "bspline.h"
 #include "bessel.h"
+#include "window.h"
 #include "nfft.h"
 #include "nfct.h"
 #include "nfst.h"
@@ -44,6 +45,10 @@ int main(void)
   util = CU_add_suite("util", 0, 0);
   CU_add_test(util, "bspline", X(check_bspline));
   CU_add_test(util, "bessel_i0", X(check_bessel_i0));
+  CU_add_test(util, "bessel_i0_scaling", X(check_bessel_i0_scaling));
+  CU_add_test(util, "kaiser_bessel_peak", X(check_kaiser_bessel_peak));
+  CU_add_test(util, "kaiser_bessel_reference", X(check_kaiser_bessel_reference));
+  CU_add_test(util, "kaiser_bessel_nfft", X(check_kaiser_bessel_nfft));
   CU_add_test(util, "version", X(check_get_version));
   CU_add_test(util, "window_name", X(check_get_window_name));
   CU_add_test(util, "log2i", X(check_log2i));

--- a/tests/window.c
+++ b/tests/window.c
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) 2002, 2017 Jens Keiner, Stefan Kunis, Daniel Potts
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+/* Standard headers. */
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <complex.h>
+#include <CUnit/CUnit.h>
+
+#include "nfft3.h"
+#include "infft.h"
+#include "window.h"
+
+/* The window macros in infft.h fall through to Kaiser-Bessel. */
+#if !defined(DIRAC_DELTA) && !defined(GAUSSIAN) && !defined(B_SPLINE) \
+    && !defined(SINC_POWER)
+#define WINDOW_IS_KAISER_BESSEL 1
+#endif
+
+#define ERR(x,y) IF(ABS(y) == K(0.0), ABS((x) - (y)), ABS((x) - (y)) / ABS(y))
+
+/* The test build carries -ffast-math, which rules out isnan and isinf, so bound
+ * the magnitude instead. Every peak-normalized window value is at most one. */
+#define FINITE(v) (ABS(v) < K(1.0E30))
+
+static R bound(void)
+{
+  return K(64.0) * Y(float_property)(NFFT_EPSILON);
+}
+
+/* Arguments straddling NFFT_I0_ASYMP_SPLIT in every precision, up to a peak
+ * far beyond what I0 itself can represent. */
+static const R i0_args[] =
+{
+  K(0.0), K(0.5), K(1.0), K(3.0), K(7.0), K(14.5), K(15.0), K(15.5),
+  K(24.0), K(25.5), K(40.0), K(80.0), K(200.0)
+};
+
+/* Largest argument for which I0 is representable in single precision. */
+#define I0_REPRESENTABLE K(80.0)
+
+void X(check_bessel_i0_scaling)(void)
+{
+  const R b = bound();
+  unsigned int j;
+
+  printf("BESSEL I0 SCALING\n-----------------\n");
+
+  for (j = 0; j < sizeof(i0_args) / sizeof(i0_args[0]); j++)
+  {
+    const R x = i0_args[j];
+    const R lg = Y(bessel_i0_log)(x);
+    const R lt = Y(bessel_i0_logtail)(x);
+    const R sc = Y(bessel_i0_scaled)(x, lg);
+    /* x - lg is formed inside bessel_i0_scaled, so its rounding grows with x */
+    const R tol = b * (K(1.0) + x);
+    R err;
+    int ok;
+
+    /* I0(x) exp(-log I0(x)) is one whatever x, and never forms I0(x) */
+    err = ERR(sc, K(1.0));
+    ok = IF(err < tol && FINITE(sc), 1, 0);
+    printf("i0_scaled[" __FE__ "] = " __FE__ " err_rel = " __FE__ " %-2s " __FE__
+      " -> %-4s\n", x, sc, err, IF(ok == 0, ">=", "<"), tol,
+      IF(ok == 0, "FAIL", "OK"));
+    CU_ASSERT(ok == 1);
+
+    /* the tail agrees with the cancelling difference it replaces */
+    err = ABS(lt - (lg - x));
+    ok = IF(err < tol && FINITE(lt), 1, 0);
+    printf("i0_logtail[" __FE__ "] = " __FE__ " err_abs = " __FE__ " %-2s " __FE__
+      " -> %-4s\n", x, lt, err, IF(ok == 0, ">=", "<"), tol,
+      IF(ok == 0, "FAIL", "OK"));
+    CU_ASSERT(ok == 1);
+
+    if (x <= I0_REPRESENTABLE)
+    {
+      const R i0 = Y(bessel_i0)(x);
+
+      err = ERR(Y(bessel_i0_scaled)(x, K(0.0)), i0);
+      ok = IF(err < b, 1, 0);
+      CU_ASSERT(ok == 1);
+
+      err = ERR(EXP(lg), i0);
+      ok = IF(err < tol, 1, 0);
+      printf("i0_log[" __FE__ "] = " __FE__ " err_rel = " __FE__ " %-2s " __FE__
+        " -> %-4s\n", x, lg, err, IF(ok == 0, ">=", "<"), tol,
+        IF(ok == 0, "FAIL", "OK"));
+      CU_ASSERT(ok == 1);
+    }
+  }
+}
+
+/* Oversampling factors and cut-offs. The large cut-offs put I0(m b) far above
+ * the overflow threshold of every precision. */
+static const R kb_sigma[] = {K(1.25), K(1.5), K(2.0)};
+static const int kb_m[] = {2, 4, 6, 8, 12, 16, 20, 24};
+
+void X(check_kaiser_bessel_peak)(void)
+{
+  const R b = bound();
+  const INT N = 64;
+  unsigned int s, i;
+
+  printf("KAISER-BESSEL PEAK\n------------------\n");
+
+  for (s = 0; s < sizeof(kb_sigma) / sizeof(kb_sigma[0]); s++)
+  {
+    for (i = 0; i < sizeof(kb_m) / sizeof(kb_m[0]); i++)
+    {
+      const int m = kb_m[i];
+      const INT n = 2 * (INT)(kb_sigma[s] * (R)N / K(2.0));
+      const R sh = KPI * (K(2.0) - (R)N / (R)n);
+      const R lg = Y(bessel_i0_log)((R)m * sh);
+      const R lt = Y(bessel_i0_logtail)((R)m * sh);
+      const R peak = Y(kb_phi_hut)(sh, lg, lt, (R)m, (R)n, K(0.0));
+      const R err = ERR(peak, K(1.0));
+      const int ok = IF(err < b, 1, 0);
+      R prev = peak;
+      INT k;
+      int l;
+
+      printf("phi_hut[sigma=" __FE__ ", m=%2d, k=0] = " __FE__ " err_rel = "
+        __FE__ " %-2s " __FE__ " -> %-4s\n", (R)n / (R)N, m, peak, err,
+        IF(ok == 0, ">=", "<"), b, IF(ok == 0, "FAIL", "OK"));
+      CU_ASSERT(ok == 1);
+
+      /* phi_hut decays from the peak across the band and stays finite */
+      for (k = 1; k <= N / 2; k++)
+      {
+        const R v = Y(kb_phi_hut)(sh, lg, lt, (R)m, (R)n, (R)k);
+        const int okk = IF(FINITE(v) && v > K(0.0)
+            && v <= prev * (K(1.0) + b), 1, 0);
+        if (okk == 0)
+          printf("phi_hut[sigma=" __FE__ ", m=%2d, k=" __D__ "] = " __FE__
+            " -> FAIL\n", (R)n / (R)N, m, k, v);
+        CU_ASSERT(okk == 1);
+        prev = v;
+      }
+
+      /* phi peaks at the node and decays to zero across its support; at the
+       * far edge the peak-normalized value is below the smallest number the
+       * precision can hold, so it may be zero */
+      prev = Y(kb_phi)(sh, lg, lt, (R)m, (R)n, K(0.0));
+      CU_ASSERT(FINITE(prev) && prev > K(0.0));
+      for (l = 1; l <= m; l++)
+      {
+        const R v = Y(kb_phi)(sh, lg, lt, (R)m, (R)n, (R)l / (R)n);
+        const int okl = IF(FINITE(v) && v >= K(0.0)
+            && v <= prev * (K(1.0) + b), 1, 0);
+        if (okl == 0)
+          printf("phi[sigma=" __FE__ ", m=%2d, l=%d] = " __FE__ " -> FAIL\n",
+            (R)n / (R)N, m, l, v);
+        CU_ASSERT(okl == 1);
+        prev = v;
+      }
+    }
+  }
+}
+
+void X(check_kaiser_bessel_reference)(void)
+{
+  /* m b stays well inside the range of I0 and sinh in single precision, so the
+   * textbook forms below are usable as a reference. */
+  const int m = 6;
+  const INT N = 64, n = 128;
+  const R sh = KPI * (K(2.0) - (R)N / (R)n);
+  const R lg = Y(bessel_i0_log)((R)m * sh);
+  const R lt = Y(bessel_i0_logtail)((R)m * sh);
+  const R peak = Y(bessel_i0)((R)m * sh);
+  const R b = K(4.0) * bound();
+  INT k;
+  int l;
+
+  printf("KAISER-BESSEL REFERENCE\n-----------------------\n");
+
+  for (k = 0; k <= N / 2; k++)
+  {
+    const R t = K(2.0) * KPI * (R)k / (R)n;
+    const R a = (R)m * SQRT(sh * sh - t * t);
+    const R ref = Y(bessel_i0)(a) / peak;
+    const R v = Y(kb_phi_hut)(sh, lg, lt, (R)m, (R)n, (R)k);
+    const R err = ERR(v, ref);
+    const int ok = IF(err < b, 1, 0);
+    printf("phi_hut[k=" __D__ "] = " __FE__ " err_rel = " __FE__ " %-2s " __FE__
+      " -> %-4s\n", k, v, err, IF(ok == 0, ">=", "<"), b,
+      IF(ok == 0, "FAIL", "OK"));
+    CU_ASSERT(ok == 1);
+  }
+
+  for (l = 0; l <= m; l++)
+  {
+    const R x = (R)l / (R)n;
+    const R s = (R)m * (R)m - ((R)n * x) * ((R)n * x);
+    const R ref = IF(s > K(0.0),
+        SINH(sh * SQRT(ABS(s))) / (KPI * SQRT(ABS(s))) / peak,
+        (sh / KPI) / peak);
+    const R v = Y(kb_phi)(sh, lg, lt, (R)m, (R)n, x);
+    const R err = ERR(v, ref);
+    const int ok = IF(err < b, 1, 0);
+    printf("phi[l=%d] = " __FE__ " err_rel = " __FE__ " %-2s " __FE__
+      " -> %-4s\n", l, v, err, IF(ok == 0, ">=", "<"), b,
+      IF(ok == 0, "FAIL", "OK"));
+    CU_ASSERT(ok == 1);
+  }
+}
+
+void X(check_kaiser_bessel_nfft)(void)
+{
+#if defined(WINDOW_IS_KAISER_BESSEL)
+  /* Cut-offs for which the unnormalized I0(m b) raised to the power d leaves
+   * the range of single precision. */
+  static const int cut_off[] = {6, 8, 10, 12, 14};
+  const int d = 3, M = 24;
+  int N[3] = {16, 16, 16}, n[3] = {32, 32, 32};
+  unsigned int i;
+
+  printf("KAISER-BESSEL NFFT\n------------------\n");
+
+  for (i = 0; i < sizeof(cut_off) / sizeof(cut_off[0]); i++)
+  {
+    const R sigma = (R)n[0] / (R)N[0];
+    /* roundoff plus the truncation error of the window itself */
+    const R b = K(1000.0) * Y(float_property)(NFFT_EPSILON)
+        + K(4.0) * EXP(K(-2.0) * KPI * (R)cut_off[i]
+            * SQRT(K(1.0) - K(1.0) / sigma));
+    Y(plan) p;
+    C *ref;
+    R err;
+    int j, ok;
+
+    Y(init_guru)(&p, d, N, M, n, cut_off[i],
+        PRE_PHI_HUT | PRE_PSI | MALLOC_X | MALLOC_F_HAT | MALLOC_F | FFTW_INIT,
+        FFTW_ESTIMATE | FFTW_DESTROY_INPUT);
+
+    Y(vrand_shifted_unit_double)(p.x, p.d * p.M_total);
+    Y(vrand_unit_complex)((C*)p.f_hat, p.N_total);
+    Y(precompute_one_psi)(&p);
+
+    ref = (C*)Y(malloc)((size_t)p.M_total * sizeof(C));
+    Y(trafo_direct)(&p);
+    for (j = 0; j < p.M_total; j++)
+      ref[j] = ((C*)p.f)[j];
+
+    Y(trafo)(&p);
+    err = Y(error_l_infty_1_complex)(ref, (C*)p.f, p.M_total, (C*)p.f_hat,
+        p.N_total);
+    ok = IF(FINITE(err) && err < b, 1, 0);
+    printf("nfft_3d[m=%2d] err = " __FE__ " %-2s " __FE__ " -> %-4s\n",
+      cut_off[i], err, IF(ok == 0, ">=", "<"), b, IF(ok == 0, "FAIL", "OK"));
+    CU_ASSERT(ok == 1);
+
+    Y(free)(ref);
+    Y(finalize)(&p);
+  }
+#else
+  printf("KAISER-BESSEL NFFT\n------------------\nskipped: %s window\n",
+    Y(get_window_name)());
+#endif
+}

--- a/tests/window.h
+++ b/tests/window.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2002, 2017 Jens Keiner, Stefan Kunis, Daniel Potts
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "infft.h"
+
+void X(check_bessel_i0_scaling)(void);
+void X(check_kaiser_bessel_peak)(void);
+void X(check_kaiser_bessel_reference)(void);
+void X(check_kaiser_bessel_nfft)(void);


### PR DESCRIPTION
This PR is to improve the numerical properties of Kaiser-Bessel window function evaluations.

In contrast to other windows, the peak of the Kaiser-Bessel window function as used in the code grows with `m`. For example, in frequency space `PHI_HUT(n,k,d)` is `I0(m·b)` for `k = 0`, where `b = π(2 − 1/σ)` and `σ` is the oversampling factor, typically somewhere between 2 and 4. This grows quickly with `m` and applies per dimension. The time domain `PHI(n,x,d)` has similar properties where `x = 0`. For `d = 3` and `m >= 8`, this overflows in single precision, making the transform unusable.

Since the NFFT algorithm decomposes into CONV ∘ FFT ∘ DECONV, where the DECONV step divides by `PHI_HUT` and CONV multiplies by `PHI`, a scaling by `1 / I0(m·b)` of both `PHI_HUT` and `PHI` keeps the result identical, but removes the undesired scaling.

It is important to never evaluate `I0(m·b)` directly, but to use the representation `exp(−L)` with `L = log I0(m·b)`. The exponent `-L` can then be directly integrated into the existing calculations that use exponentials already.

The scaling approach itself adds to another issue since the calculation relies on taking the difference of exponents of nearly equal magnitude in three different places. Done naively, this destroys accuracy. Cancellations are avoided by rewriting the respective results into a form without the problematic subtractions.

For a more detailed explanation, see [kaiser-bessel-window-numerics.html](https://github.com/user-attachments/files/31454773/kaiser-bessel-window-numerics.html).
