### PR TITLE
Ensure CMake builds do not inadvertently pick up a stale Autotools config.h.

### DIFF
--- a/include/infft.h
+++ b/include/infft.h
@@ -22,7 +22,7 @@
 #ifndef __INFFT_H__
 #define __INFFT_H__
 
-#include "config.h"
+#include <config.h>
 
 #include <math.h>
 #include <float.h>

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -30,12 +30,16 @@ function(nfft_configure_library tgt outname)
     VERSION 4.0.3        # libtool -version-info 4:3:0 -> current.age.revision
     SOVERSION 0
     EXPORT_NAME "${outname}")
+  # The generated directory goes first: infft.h includes <config.h>, and the
+  # source include/ can hold a config.h left by an in-tree Autotools configure.
+  # Whichever directory comes first on the -I line wins, so this build's own
+  # header has to precede it.
+  target_include_directories(${tgt} BEFORE PRIVATE
+      ${NFFT_GENERATED_INCLUDE_DIR})   # build/: config.h + ticks.h
   target_include_directories(${tgt}
     PUBLIC
       $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-    PRIVATE
-      ${NFFT_GENERATED_INCLUDE_DIR})   # build/: config.h + ticks.h
+      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
   if(UNIX)
     target_link_libraries(${tgt} PUBLIC m)  # Add math library.
   endif()


### PR DESCRIPTION
This PR switches the inclusion of `config.h` to angle brackets so that the CMake build script can ensure the correct file is included by passing the correct path via `-I`. Otherwise, a stale `config.h` from `include/` could be included, instead of the correct version from the build directory.