### PR TITLE
Cut benchmark minutes.

### DIFF
--- a/.github/workflows/bench-linux.yml
+++ b/.github/workflows/bench-linux.yml
@@ -10,8 +10,22 @@ on:
   # `workflow_dispatch` runs are also un-gated (ad-hoc manual runs).
   push:
     branches: [ main, develop, master ]
+    paths:
+      - 'kernel/**'
+      - 'include/**'
+      - 'benchmarks/**'
+      - 'cmake/**'
+      - 'CMakeLists.txt'
+      - '.github/workflows/bench-linux.yml'
   pull_request:
     branches: [ main, develop, master ]
+    paths:
+      - 'kernel/**'
+      - 'include/**'
+      - 'benchmarks/**'
+      - 'cmake/**'
+      - 'CMakeLists.txt'
+      - '.github/workflows/bench-linux.yml'
   workflow_dispatch:
 
 permissions:
@@ -65,7 +79,7 @@ jobs:
         sudo apt-get install -y software-properties-common
         sudo add-apt-repository universe
         sudo apt-get update
-        sudo apt-get install -y libc6-dbg build-essential cmake libfftw3-dev libomp-dev libatomic1
+        sudo apt-get install -y build-essential cmake libfftw3-dev libatomic1
 
     - name: Cache CodSpeed integration library
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -127,19 +141,10 @@ jobs:
         # hosted macro runners for stable walltime data.
         mode: walltime
         run: |
-          ./build-cmake/benchmarks/bench_nfft_direct
-          if [ -x ./build-cmake/benchmarks/bench_nfft_direct_omp ]; then
-            ./build-cmake/benchmarks/bench_nfft_direct_omp
-          fi
-          ./build-cmake/benchmarks/bench_nfft_fast
-          if [ -x ./build-cmake/benchmarks/bench_nfft_fast_omp ]; then
-            ./build-cmake/benchmarks/bench_nfft_fast_omp
-          fi
-          ./build-cmake/benchmarks/bench_nfct_direct
-          if [ -x ./build-cmake/benchmarks/bench_nfct_direct_omp ]; then
-            ./build-cmake/benchmarks/bench_nfct_direct_omp
-          fi
-          ./build-cmake/benchmarks/bench_nfst_direct
-          if [ -x ./build-cmake/benchmarks/bench_nfst_direct_omp ]; then
-            ./build-cmake/benchmarks/bench_nfst_direct_omp
-          fi
+          ARGS="--benchmark_min_time=0.1s"
+          for b in bench_nfft_direct bench_nfft_fast bench_nfct_direct bench_nfst_direct; do
+            ./build-cmake/benchmarks/$b $ARGS
+            if [ -x ./build-cmake/benchmarks/${b}_omp ]; then
+              ./build-cmake/benchmarks/${b}_omp $ARGS
+            fi
+          done

--- a/benchmarks/bench_nfct_direct.cpp
+++ b/benchmarks/bench_nfct_direct.cpp
@@ -70,7 +70,6 @@ static void nfct_forward_direct_1d(benchmark::State& state) {
     }
 
     NFCT(finalize)(&plan);
-    state.SetComplexityN(N * M);
 }
 
 // Benchmark for NFCT adjoint direct transform (adjoint_direct)
@@ -87,7 +86,6 @@ static void nfct_adjoint_direct_1d(benchmark::State& state) {
     }
 
     NFCT(finalize)(&plan);
-    state.SetComplexityN(N * M);
 }
 
 // Benchmark for 2D NFCT direct transform
@@ -105,7 +103,6 @@ static void nfct_forward_direct_2d(benchmark::State& state) {
     }
 
     NFCT(finalize)(&plan);
-    state.SetComplexityN(N1 * N2 * M);
 }
 
 // Benchmark for 2D NFCT adjoint direct transform
@@ -123,7 +120,6 @@ static void nfct_adjoint_direct_2d(benchmark::State& state) {
     }
 
     NFCT(finalize)(&plan);
-    state.SetComplexityN(N1 * N2 * M);
 }
 
 // Benchmark for 3D NFCT direct transform
@@ -142,7 +138,6 @@ static void nfct_forward_direct_3d(benchmark::State& state) {
     }
 
     NFCT(finalize)(&plan);
-    state.SetComplexityN(N1 * N2 * N3 * M);
 }
 
 // Benchmark for 3D NFCT adjoint direct transform
@@ -161,61 +156,40 @@ static void nfct_adjoint_direct_3d(benchmark::State& state) {
     }
 
     NFCT(finalize)(&plan);
-    state.SetComplexityN(N1 * N2 * N3 * M);
 }
 
 // Register benchmarks for direct transforms
 BENCH(nfct_forward_direct_1d, SUFFIX)
-    ->Args({32, 100})
-    ->Args({64, 200})
     ->Args({128, 400})
-    ->Args({256, 800})
     ->Args({512, 1600})
     ->Setup(DoSetup)
-    ->Teardown(DoTeardown)
-    ->Complexity();
+    ->Teardown(DoTeardown);
 
 BENCH(nfct_adjoint_direct_1d, SUFFIX)
-    ->Args({32, 100})
-    ->Args({64, 200})
     ->Args({128, 400})
-    ->Args({256, 800})
     ->Args({512, 1600})
     ->Setup(DoSetup)
-    ->Teardown(DoTeardown)
-    ->Complexity();
+    ->Teardown(DoTeardown);
 
 BENCH(nfct_forward_direct_2d, SUFFIX)
-    ->Args({16, 16, 500})
     ->Args({32, 32, 1000})
-    ->Args({64, 64, 2000})
     ->Setup(DoSetup)
-    ->Teardown(DoTeardown)
-    ->Complexity();
+    ->Teardown(DoTeardown);
 
 BENCH(nfct_adjoint_direct_2d, SUFFIX)
-    ->Args({16, 16, 500})
     ->Args({32, 32, 1000})
-    ->Args({64, 64, 2000})
     ->Setup(DoSetup)
-    ->Teardown(DoTeardown)
-    ->Complexity();
+    ->Teardown(DoTeardown);
 
 BENCH(nfct_forward_direct_3d, SUFFIX)
-    ->Args({4, 4, 4, 250})
     ->Args({8, 8, 8, 500})
-    ->Args({16, 16, 16, 1000})
     ->Setup(DoSetup)
-    ->Teardown(DoTeardown)
-    ->Complexity();
+    ->Teardown(DoTeardown);
 
 BENCH(nfct_adjoint_direct_3d, SUFFIX)
-    ->Args({4, 4, 4, 250})
     ->Args({8, 8, 8, 500})
-    ->Args({16, 16, 16, 1000})
     ->Setup(DoSetup)
-    ->Teardown(DoTeardown)
-    ->Complexity();
+    ->Teardown(DoTeardown);
 
 // Main function.
 BENCHMARK_MAIN();

--- a/benchmarks/bench_nfft_direct.cpp
+++ b/benchmarks/bench_nfft_direct.cpp
@@ -70,7 +70,6 @@ static void nfft_forward_direct_1d(benchmark::State& state) {
     }
     
     NFFT(finalize)(&plan);
-    state.SetComplexityN(N * M);
 }
 
 // Benchmark for NFFT adjoint direct transform (adjoint_direct)
@@ -87,7 +86,6 @@ static void nfft_adjoint_direct_1d(benchmark::State& state) {
     }
     
     NFFT(finalize)(&plan);
-    state.SetComplexityN(N * M);
 }
 
 // Benchmark for 2D NFFT direct transform
@@ -105,7 +103,6 @@ static void nfft_forward_direct_2d(benchmark::State& state) {
     }
     
     NFFT(finalize)(&plan);
-    state.SetComplexityN(N1 * N2 * M);
 }
 
 // Benchmark for 2D NFFT adjoint direct transform
@@ -123,7 +120,6 @@ static void nfft_adjoint_direct_2d(benchmark::State& state) {
     }
     
     NFFT(finalize)(&plan);
-    state.SetComplexityN(N1 * N2 * M);
 }
 
 // Benchmark for 3D NFFT direct transform
@@ -142,7 +138,6 @@ static void nfft_forward_direct_3d(benchmark::State& state) {
     }
     
     NFFT(finalize)(&plan);
-    state.SetComplexityN(N1 * N2 * N3 * M);
 }
 
 // Benchmark for 3D NFFT adjoint direct transform
@@ -161,61 +156,40 @@ static void nfft_adjoint_direct_3d(benchmark::State& state) {
     }
     
     NFFT(finalize)(&plan);
-    state.SetComplexityN(N1 * N2 * N3 * M);
 }
 
 // Register benchmarks for direct transforms
 BENCH(nfft_forward_direct_1d, SUFFIX)
-    ->Args({32, 100})
-    ->Args({64, 200})
     ->Args({128, 400})
-    ->Args({256, 800})
     ->Args({512, 1600})
     ->Setup(DoSetup)
-    ->Teardown(DoTeardown)
-    ->Complexity();
+    ->Teardown(DoTeardown);
 
 BENCH(nfft_adjoint_direct_1d, SUFFIX)
-    ->Args({32, 100})
-    ->Args({64, 200})
     ->Args({128, 400})
-    ->Args({256, 800})
     ->Args({512, 1600})
     ->Setup(DoSetup)
-    ->Teardown(DoTeardown)
-    ->Complexity();
+    ->Teardown(DoTeardown);
 
 BENCH(nfft_forward_direct_2d, SUFFIX)
-    ->Args({16, 16, 500})
     ->Args({32, 32, 1000})
-    ->Args({64, 64, 2000})
     ->Setup(DoSetup)
-    ->Teardown(DoTeardown)
-    ->Complexity();
+    ->Teardown(DoTeardown);
 
 BENCH(nfft_adjoint_direct_2d, SUFFIX)
-    ->Args({16, 16, 500})
     ->Args({32, 32, 1000})
-    ->Args({64, 64, 2000})
     ->Setup(DoSetup)
-    ->Teardown(DoTeardown)
-    ->Complexity();
+    ->Teardown(DoTeardown);
 
 BENCH(nfft_forward_direct_3d, SUFFIX)
-    ->Args({4, 4, 4, 250})
     ->Args({8, 8, 8, 500})
-    ->Args({16, 16, 16, 1000})
     ->Setup(DoSetup)
-    ->Teardown(DoTeardown)
-    ->Complexity();
+    ->Teardown(DoTeardown);
 
 BENCH(nfft_adjoint_direct_3d, SUFFIX)
-    ->Args({4, 4, 4, 250})
     ->Args({8, 8, 8, 500})
-    ->Args({16, 16, 16, 1000})
     ->Setup(DoSetup)
-    ->Teardown(DoTeardown)
-    ->Complexity();
+    ->Teardown(DoTeardown);
 
 // Main function.
 BENCHMARK_MAIN();

--- a/benchmarks/bench_nfft_fast.cpp
+++ b/benchmarks/bench_nfft_fast.cpp
@@ -69,9 +69,16 @@ static bool same_geometry(const Geometry& a, const Geometry& b) {
  * different geometry finalizes the previous one. Benchmarks are registered
  * grouped by geometry, so precomputation and both transforms for one geometry
  * share a single init. */
+
+/* Which benchmark last seeded f_hat and f. Neither transform modifies its own
+ * input so repeated entries into one benchmark need no reseeding. Moving between the
+ * two does. */
+enum DataRole { DATA_NONE, DATA_TRAFO, DATA_ADJOINT };
+
 struct PlanSlot {
     bool valid = false;
     bool psi_ready = false;
+    DataRole data_role = DATA_NONE;
     Geometry geom = {};
     NFFT(plan) plan = {};
 };
@@ -84,6 +91,7 @@ static void release_plan(void) {
         NFFT(finalize)(&slot.plan);
         slot.valid = false;
         slot.psi_ready = false;
+        slot.data_role = DATA_NONE;
     }
 }
 
@@ -103,6 +111,22 @@ struct SlotCleanup {
 };
 static SlotCleanup slot_cleanup;
 
+/* Flag to indicate if OpenMP thread team has been created. It's a one-off cost 
+ * of the first parallel region in the process so it should be done once outside
+ * a timing loop. */
+static bool omp_team_started = false;
+
+static void warm_omp_team(void) {
+    #ifdef _OPENMP
+    int sink = 0;
+    #pragma omp parallel reduction(+:sink)
+    {
+        sink += 1;
+    }
+    benchmark::DoNotOptimize(sink);
+    #endif
+}
+
 static void DoSetup(const benchmark::State& state) {
     #ifdef _OPENMP
     #ifdef HAVE_FFTW_THREADS
@@ -111,6 +135,10 @@ static void DoSetup(const benchmark::State& state) {
         fftw_threads_started = true;
     }
     #endif
+    if (!omp_team_started) {
+        warm_omp_team();
+        omp_team_started = true;
+    }
     #endif
 }
 
@@ -140,6 +168,7 @@ static NFFT(plan)* acquire_plan(const Geometry& geom, bool fresh = false) {
 
     slot.valid = true;
     slot.psi_ready = false;
+    slot.data_role = DATA_NONE;
     slot.geom = geom;
     return &slot.plan;
 }
@@ -149,6 +178,14 @@ static void reseed_data(NFFT(plan)* plan) {
     NFFT(srand48)(BENCH_SEED);
     NFFT(vrand_unit_complex)(plan->f_hat, plan->N_total);
     NFFT(vrand_unit_complex)(plan->f, plan->M_total);
+}
+
+/* Seeds only when the data on the plan belongs to another benchmark. */
+static void ensure_data(NFFT(plan)* plan, DataRole role) {
+    if (slot.data_role == role)
+        return;
+    reseed_data(plan);
+    slot.data_role = role;
 }
 
 static void ensure_psi(NFFT(plan)* plan) {
@@ -177,13 +214,8 @@ static void prefault_psi(NFFT(plan)* plan) {
     memset(plan->psi, 0, len * sizeof(R));
 }
 
-/* Times one nfft_precompute_one_psi on a plan whose psi table has never been
- * filled. Nothing in the API promises that a second call on the same plan
- * redoes the work, so every measured call gets its own plan; Iterations(1) at
- * the registration keeps that true, and repetitions, which re-enter this
- * function, supply the statistics. Building the plan here rather than inside
- * the loop keeps init and allocation out of the measurement in both walltime
- * and simulation mode. */
+/* Times nfft_precompute_one_psi on a plan built here, so init and allocation
+ * stay out of the measurement. */
 static void run_precompute(benchmark::State& state, int d) {
     NFFT(plan)* plan = acquire_plan(geometry_from(state, d), /*fresh=*/true);
     prefault_psi(plan);
@@ -199,7 +231,7 @@ static void run_precompute(benchmark::State& state, int d) {
 static void run_trafo(benchmark::State& state, int d) {
     NFFT(plan)* plan = acquire_plan(geometry_from(state, d));
     ensure_psi(plan);
-    reseed_data(plan);
+    ensure_data(plan, DATA_TRAFO);
 
     for (auto _ : state) {
         NFFT(trafo)(plan);
@@ -210,7 +242,7 @@ static void run_trafo(benchmark::State& state, int d) {
 static void run_adjoint(benchmark::State& state, int d) {
     NFFT(plan)* plan = acquire_plan(geometry_from(state, d));
     ensure_psi(plan);
-    reseed_data(plan);
+    ensure_data(plan, DATA_ADJOINT);
 
     for (auto _ : state) {
         NFFT(adjoint)(plan);
@@ -237,7 +269,7 @@ DEFINE_DIM(4d, 4)
 /* Args are N[0..d-1], M, m. */
 #define REGISTER_CASE(tag, ...) \
     BENCH(nfft_fast_precompute_psi_##tag, SUFFIX) \
-        ->Args({__VA_ARGS__})->Iterations(1)->Setup(DoSetup); \
+        ->Args({__VA_ARGS__})->Iterations(3)->Setup(DoSetup); \
     BENCH(nfft_fast_trafo_##tag, SUFFIX) \
         ->Args({__VA_ARGS__})->Setup(DoSetup); \
     BENCH(nfft_fast_adjoint_##tag, SUFFIX) \

--- a/benchmarks/bench_nfst_direct.cpp
+++ b/benchmarks/bench_nfst_direct.cpp
@@ -70,7 +70,6 @@ static void nfst_forward_direct_1d(benchmark::State& state) {
     }
 
     NFST(finalize)(&plan);
-    state.SetComplexityN(N * M);
 }
 
 // Benchmark for NFST adjoint direct transform (adjoint_direct)
@@ -87,7 +86,6 @@ static void nfst_adjoint_direct_1d(benchmark::State& state) {
     }
 
     NFST(finalize)(&plan);
-    state.SetComplexityN(N * M);
 }
 
 // Benchmark for 2D NFST direct transform
@@ -105,7 +103,6 @@ static void nfst_forward_direct_2d(benchmark::State& state) {
     }
 
     NFST(finalize)(&plan);
-    state.SetComplexityN(N1 * N2 * M);
 }
 
 // Benchmark for 2D NFST adjoint direct transform
@@ -123,7 +120,6 @@ static void nfst_adjoint_direct_2d(benchmark::State& state) {
     }
 
     NFST(finalize)(&plan);
-    state.SetComplexityN(N1 * N2 * M);
 }
 
 // Benchmark for 3D NFST direct transform
@@ -142,7 +138,6 @@ static void nfst_forward_direct_3d(benchmark::State& state) {
     }
 
     NFST(finalize)(&plan);
-    state.SetComplexityN(N1 * N2 * N3 * M);
 }
 
 // Benchmark for 3D NFST adjoint direct transform
@@ -161,61 +156,40 @@ static void nfst_adjoint_direct_3d(benchmark::State& state) {
     }
 
     NFST(finalize)(&plan);
-    state.SetComplexityN(N1 * N2 * N3 * M);
 }
 
 // Register benchmarks for direct transforms
 BENCH(nfst_forward_direct_1d, SUFFIX)
-    ->Args({32, 100})
-    ->Args({64, 200})
     ->Args({128, 400})
-    ->Args({256, 800})
     ->Args({512, 1600})
     ->Setup(DoSetup)
-    ->Teardown(DoTeardown)
-    ->Complexity();
+    ->Teardown(DoTeardown);
 
 BENCH(nfst_adjoint_direct_1d, SUFFIX)
-    ->Args({32, 100})
-    ->Args({64, 200})
     ->Args({128, 400})
-    ->Args({256, 800})
     ->Args({512, 1600})
     ->Setup(DoSetup)
-    ->Teardown(DoTeardown)
-    ->Complexity();
+    ->Teardown(DoTeardown);
 
 BENCH(nfst_forward_direct_2d, SUFFIX)
-    ->Args({16, 16, 500})
     ->Args({32, 32, 1000})
-    ->Args({64, 64, 2000})
     ->Setup(DoSetup)
-    ->Teardown(DoTeardown)
-    ->Complexity();
+    ->Teardown(DoTeardown);
 
 BENCH(nfst_adjoint_direct_2d, SUFFIX)
-    ->Args({16, 16, 500})
     ->Args({32, 32, 1000})
-    ->Args({64, 64, 2000})
     ->Setup(DoSetup)
-    ->Teardown(DoTeardown)
-    ->Complexity();
+    ->Teardown(DoTeardown);
 
 BENCH(nfst_forward_direct_3d, SUFFIX)
-    ->Args({4, 4, 4, 250})
     ->Args({8, 8, 8, 500})
-    ->Args({16, 16, 16, 1000})
     ->Setup(DoSetup)
-    ->Teardown(DoTeardown)
-    ->Complexity();
+    ->Teardown(DoTeardown);
 
 BENCH(nfst_adjoint_direct_3d, SUFFIX)
-    ->Args({4, 4, 4, 250})
     ->Args({8, 8, 8, 500})
-    ->Args({16, 16, 16, 1000})
     ->Setup(DoSetup)
-    ->Teardown(DoTeardown)
-    ->Complexity();
+    ->Teardown(DoTeardown);
 
 // Main function.
 BENCHMARK_MAIN();


### PR DESCRIPTION
The current set of benchmarks spends too many minutes on the CodSpeed macro runners. This will not be sustainable as new benchmarks are added in the future. Therefore, cutting down the number of cases we test while keeping the set representative of actual performance.