### PR TITLE
Cap OpenMP threads number to reduce jitter in benchmarks.

### DIFF
--- a/.github/workflows/bench-linux.yml
+++ b/.github/workflows/bench-linux.yml
@@ -141,6 +141,10 @@ jobs:
         # hosted macro runners for stable walltime data.
         mode: walltime
         run: |
+          # Binding and OMP_DYNAMIC are read when the OpenMP runtime starts.
+          export OMP_PROC_BIND=close
+          export OMP_PLACES=cores
+          export OMP_DYNAMIC=false
           ARGS="--benchmark_min_time=0.1s"
           for b in bench_nfft_direct bench_nfft_fast bench_nfct_direct bench_nfst_direct; do
             ./build-cmake/benchmarks/$b $ARGS

--- a/benchmarks/bench_nfct_direct.cpp
+++ b/benchmarks/bench_nfct_direct.cpp
@@ -34,6 +34,7 @@
 #endif
 
 static void DoSetup(const benchmark::State& state) {
+    nfft_bench_cap_threads();
     #ifdef _OPENMP
     #ifdef HAVE_FFTW_THREADS
     FFTW(init_threads)();

--- a/benchmarks/bench_nfft_direct.cpp
+++ b/benchmarks/bench_nfft_direct.cpp
@@ -34,6 +34,7 @@
 #endif
 
 static void DoSetup(const benchmark::State& state) {
+    nfft_bench_cap_threads();
     #ifdef _OPENMP
     #ifdef HAVE_FFTW_THREADS
     FFTW(init_threads)();

--- a/benchmarks/bench_nfft_fast.cpp
+++ b/benchmarks/bench_nfft_fast.cpp
@@ -128,6 +128,7 @@ static void warm_omp_team(void) {
 }
 
 static void DoSetup(const benchmark::State& state) {
+    nfft_bench_cap_threads();
     #ifdef _OPENMP
     #ifdef HAVE_FFTW_THREADS
     if (!fftw_threads_started) {

--- a/benchmarks/bench_nfst_direct.cpp
+++ b/benchmarks/bench_nfst_direct.cpp
@@ -34,6 +34,7 @@
 #endif
 
 static void DoSetup(const benchmark::State& state) {
+    nfft_bench_cap_threads();
     #ifdef _OPENMP
     #ifdef HAVE_FFTW_THREADS
     FFTW(init_threads)();

--- a/benchmarks/util.h
+++ b/benchmarks/util.h
@@ -21,7 +21,31 @@
 
 #include "config.h"
 
+#include <cstdlib>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
 // Macro to register benchmark with optional prefix.
 #define BENCH(function, suffix) BENCHMARK(function)->Name(BENCHMARKS_PREFIX #function suffix)
+
+// Caps the OpenMP team unless the caller asked for a size. A small fixed team 
+// is steadier and independent of the host.
+#define NFFT_BENCH_MAX_THREADS 2
+
+static inline void nfft_bench_cap_threads(void)
+{
+#ifdef _OPENMP
+    if (std::getenv("OMP_NUM_THREADS") != nullptr)
+        return;
+
+    {
+        const int max = omp_get_max_threads();
+        omp_set_num_threads(max < NFFT_BENCH_MAX_THREADS ? max
+                                                         : NFFT_BENCH_MAX_THREADS);
+    }
+#endif
+}
 
 #endif // NFFT_BENCHMARKS_UTIL_H


### PR DESCRIPTION
This PR should make the OpenMP-related benchmark figures more stable and thus avoid noise.