### PR TITLE
Add more tests for Gaussian window sweeping different m values.

### DIFF
--- a/tests/accuracy/htmlreport.py
+++ b/tests/accuracy/htmlreport.py
@@ -12,6 +12,8 @@ import html
 # Window functions whose token may appear in a testbed name
 # (`<os>_<compiler>_<window>_<precision>`). Used to split the window axis out.
 KNOWN_WINDOWS = ("kaiserbessel", "gaussian", "bspline", "sinc", "dirac")
+# Precision tokens of a testbed name, in mantissa order; columns sort by it.
+PRECISIONS = ("float", "double", "long-double")
 
 # Margin color bands. Hex equals round(255*c) of the old matplotlib RGBA floats.
 RED = "#d63026"  # margin < 0      (error exceeds bound -- should never happen)
@@ -44,6 +46,15 @@ def parse_window(testbed):
             rest = tokens[:i] + tokens[i + 1 :]
             return tok, "_".join(rest)
     return "other", testbed
+
+
+def precision_rank(label):
+    """Position of the label's precision token in PRECISIONS; unknown last."""
+    tokens = label.split("_")
+    for i, p in enumerate(PRECISIONS):
+        if p in tokens:
+            return i
+    return len(PRECISIONS)
 
 
 def metric_module(name):
@@ -254,7 +265,7 @@ def render_report(tree, diff_result=None, *, title):
     order = [w for w in (list(KNOWN_WINDOWS) + ["other"]) if w in windows]
     inputs, panels = [], []
     for idx, win in enumerate(order):
-        testbeds = sorted(windows[win], key=lambda x: x[1])
+        testbeds = sorted(windows[win], key=lambda x: (precision_rank(x[1]), x[1]))
         checked = " checked" if idx == 0 else ""
         inputs.append(
             f'<input type="radio" name="wintab" id="tab-{win}"{checked}>'

--- a/tests/accuracy/report.py
+++ b/tests/accuracy/report.py
@@ -13,13 +13,34 @@ MARKER = "<!-- nfft-accuracy-report -->"
 CAP = 10
 
 
-def check_summary(result):
+def _counts(result):
     y, z = len(result.improvements), len(result.regressions)
+    na, nr = len(result.added), len(result.removed)
+    line = f"{result.unchanged_count} unchanged · {y} improved · {z} regressed"
+    if na or nr:
+        line += f" · {na} added · {nr} removed"
+    return y, z, na, nr, line
+
+
+# A renamed or regrouped metric shows up as one added plus one removed name, and
+# the max-merged neighbours it left change too, so those counts are not accuracy.
+def _regroup_note(na, nr):
+    if not (na or nr):
+        return ""
+    return (
+        f"The metric set changed ({na} added, {nr} removed), so improved and "
+        "regressed counts may reflect regrouping rather than accuracy changes."
+    )
+
+
+def check_summary(result):
+    y, z, na, nr, summary = _counts(result)
     if y == 0 and z == 0:
         title = "accuracy unchanged"
     else:
         title = f"{z} regressed, {y} improved"
-    summary = f"{result.unchanged_count} unchanged · {y} improved · {z} regressed"
+    if na or nr:
+        title += f", {na} added, {nr} removed"
     return "neutral", title, summary
 
 
@@ -41,19 +62,18 @@ def _module_table(result):
 
 
 def comment_body(result, report_url):
-    y, z = len(result.improvements), len(result.regressions)
+    y, z, na, nr, summary = _counts(result)
+    note = _regroup_note(na, nr)
     if y == 0 and z == 0:
         body = f"{MARKER}\nAccuracy: {result.unchanged_count} cases unchanged."
+        if note:
+            body += f" {na} metrics added, {nr} removed."
         link = _report_link(report_url)
         return (body + (f"\n\n{link}" if link else "")).rstrip() + "\n"
-    lines = [
-        MARKER,
-        "## Accuracy report",
-        f"{result.unchanged_count} unchanged · {y} improved · {z} regressed",
-        "",
-        _module_table(result),
-        "",
-    ]
+    lines = [MARKER, "## Accuracy report", summary, ""]
+    if note:
+        lines += [note, ""]
+    lines += [_module_table(result), ""]
     link = _report_link(report_url)
     if link:
         lines.append(link)

--- a/tests/accuracy/tests/test_htmlreport.py
+++ b/tests/accuracy/tests/test_htmlreport.py
@@ -194,3 +194,13 @@ def test_changes_itemized_capped_at_10():
     )
     doc = render_report(_tree(), big, title="PR")
     assert "+3 more" in doc
+
+
+def test_render_orders_precision_columns_by_mantissa():
+    tree = {
+        f"ci_gcc_kaiserbessel_{p}": {"nfft/serial/file/fast/forward/1d/a": _cell(6.0, 5.0)}
+        for p in ("long-double", "double", "float")
+    }
+    doc = render_report(tree, title="T")
+    head = re.findall(r"<th>(ci_gcc_[a-z-]+)</th>", doc)
+    assert head == ["ci_gcc_float", "ci_gcc_double", "ci_gcc_long-double"]

--- a/tests/accuracy/tests/test_report.py
+++ b/tests/accuracy/tests/test_report.py
@@ -8,7 +8,7 @@ from tests.accuracy.report import (
 )
 
 
-def _result(impr=0, regr=0, unchanged=5):
+def _result(impr=0, regr=0, unchanged=5, added=0, removed=0):
     imps = [
         Change("t1", f"nfft/i{k}", 13.0, 14.0 + k, 1.0 + k, 7.0) for k in range(impr)
     ]
@@ -16,7 +16,14 @@ def _result(impr=0, regr=0, unchanged=5):
         Change("t1", f"nfct/r{k}", 14.0, 13.0 - k, -(1.0 + k), -7.0)
         for k in range(regr)
     ]
-    return DiffResult(imps, regs, unchanged, by_testbed={})
+    return DiffResult(
+        imps,
+        regs,
+        unchanged,
+        added=[f"t1::nfft/a{k}" for k in range(added)],
+        removed=[f"t1::nfft/d{k}" for k in range(removed)],
+        by_testbed={},
+    )
 
 
 def test_check_never_fails():
@@ -58,3 +65,25 @@ def test_no_baseline_comment_links_and_notes():
 def test_no_baseline_check_is_neutral_and_pending():
     conclusion, title, _ = check_summary_no_baseline()
     assert conclusion == "neutral" and "pending" in title
+
+
+def test_added_removed_absent_when_metric_set_is_stable():
+    _, title, summary = check_summary(_result(impr=2, regr=1))
+    assert "added" not in title and "added" not in summary
+    assert "regrouping" not in comment_body(_result(impr=2, regr=1), "u")
+
+
+def test_added_removed_counts_in_check_and_comment():
+    r = _result(impr=2, regr=1, added=3, removed=4)
+    _, title, summary = check_summary(r)
+    assert title == "1 regressed, 2 improved, 3 added, 4 removed"
+    assert summary.endswith("· 3 added · 4 removed")
+    body = comment_body(r, "u")
+    assert "5 unchanged · 2 improved · 1 regressed · 3 added · 4 removed" in body
+    assert "metric set changed (3 added, 4 removed)" in body
+    assert "regrouping" in body
+
+
+def test_flat_comment_mentions_added_removed():
+    body = comment_body(_result(added=3, removed=4), "u")
+    assert "5 cases unchanged. 3 metrics added, 4 removed." in body

--- a/tests/check.c
+++ b/tests/check.c
@@ -87,6 +87,16 @@ int main(void)
   CU_add_test(nfft, "nfft_3d_fast_file", X(check_3d_fast_file));
   CU_add_test(nfft, "nfft_adjoint_3d_direct_file", X(check_adjoint_3d_direct_file));
   CU_add_test(nfft, "nfft_adjoint_3d_fast_file", X(check_adjoint_3d_fast_file));
+#if defined(GAUSSIAN)
+  CU_add_test(nfft, "nfft_1d_online_gaussian_m", X(check_1d_online_gaussian_m));
+  CU_add_test(nfft, "nfft_adjoint_1d_online_gaussian_m", X(check_adjoint_1d_online_gaussian_m));
+  CU_add_test(nfft, "nfft_2d_online_gaussian_m", X(check_2d_online_gaussian_m));
+  CU_add_test(nfft, "nfft_adjoint_2d_online_gaussian_m", X(check_adjoint_2d_online_gaussian_m));
+#ifdef NFFT_EXHAUSTIVE_UNIT_TESTS
+  CU_add_test(nfft, "nfft_3d_online_gaussian_m", X(check_3d_online_gaussian_m));
+  CU_add_test(nfft, "nfft_adjoint_3d_online_gaussian_m", X(check_adjoint_3d_online_gaussian_m));
+#endif
+#endif
 #ifdef NFFT_EXHAUSTIVE_UNIT_TESTS
   CU_add_test(nfft, "nfft_3d_online", X(check_3d_online));
   CU_add_test(nfft, "nfft_adjoint_3d_online", X(check_adjoint_3d_online));
@@ -117,6 +127,16 @@ int main(void)
   CU_add_test(nfct, "nfct_3d_fast_file", X(check_3d_fast_file));
   CU_add_test(nfct, "nfct_adjoint_3d_direct_file", X(check_adjoint_3d_direct_file));
   CU_add_test(nfct, "nfct_adjoint_3d_fast_file", X(check_adjoint_3d_fast_file));
+#if defined(GAUSSIAN)
+  CU_add_test(nfct, "nfct_1d_online_gaussian_m", X(check_1d_online_gaussian_m));
+  CU_add_test(nfct, "nfct_adjoint_1d_online_gaussian_m", X(check_adjoint_1d_online_gaussian_m));
+  CU_add_test(nfct, "nfct_2d_online_gaussian_m", X(check_2d_online_gaussian_m));
+  CU_add_test(nfct, "nfct_adjoint_2d_online_gaussian_m", X(check_adjoint_2d_online_gaussian_m));
+#ifdef NFFT_EXHAUSTIVE_UNIT_TESTS
+  CU_add_test(nfct, "nfct_3d_online_gaussian_m", X(check_3d_online_gaussian_m));
+  CU_add_test(nfct, "nfct_adjoint_3d_online_gaussian_m", X(check_adjoint_3d_online_gaussian_m));
+#endif
+#endif
 #ifdef NFFT_EXHAUSTIVE_UNIT_TESTS
   CU_add_test(nfct, "nfct_3d_online", X(check_3d_online));
   CU_add_test(nfct, "nfct_adjoint_3d_online", X(check_adjoint_3d_online));
@@ -149,6 +169,16 @@ int main(void)
   CU_add_test(nfst, "nfst_3d_fast_file", X(check_3d_fast_file));
   CU_add_test(nfst, "nfst_adjoint_3d_direct_file", X(check_adjoint_3d_direct_file));
   CU_add_test(nfst, "nfst_adjoint_3d_fast_file", X(check_adjoint_3d_fast_file));
+#if defined(GAUSSIAN)
+  CU_add_test(nfst, "nfst_1d_online_gaussian_m", X(check_1d_online_gaussian_m));
+  CU_add_test(nfst, "nfst_adjoint_1d_online_gaussian_m", X(check_adjoint_1d_online_gaussian_m));
+  CU_add_test(nfst, "nfst_2d_online_gaussian_m", X(check_2d_online_gaussian_m));
+  CU_add_test(nfst, "nfst_adjoint_2d_online_gaussian_m", X(check_adjoint_2d_online_gaussian_m));
+#ifdef NFFT_EXHAUSTIVE_UNIT_TESTS
+  CU_add_test(nfst, "nfst_3d_online_gaussian_m", X(check_3d_online_gaussian_m));
+  CU_add_test(nfst, "nfst_adjoint_3d_online_gaussian_m", X(check_adjoint_3d_online_gaussian_m));
+#endif
+#endif
 #ifdef NFFT_EXHAUSTIVE_UNIT_TESTS
   CU_add_test(nfst, "nfst_3d_online", X(check_3d_online));
   CU_add_test(nfst, "nfst_adjoint_3d_online", X(check_adjoint_3d_online));

--- a/tests/nfct.c
+++ b/tests/nfct.c
@@ -66,6 +66,7 @@ typedef struct testcase_delegate_online_s
 } testcase_delegate_online_t;
 
 static void setup_online(const testcase_delegate_t *ego_, int *d, int **N, int *NN, int *M, R **x, R **f_hat, R **f);
+static void setup_adjoint_online(const testcase_delegate_t *ego_, int *d, int **N, int *NN, int *M, R **x, R **f_hat, R **f);
 static void destroy_online(const testcase_delegate_t *ego_, int *N, R *x, R *f_hat, R *f);
 
 /* Initialization delegate. */
@@ -395,7 +396,7 @@ static int check_single(const testcase_delegate_t *testcase,
     ok = IF(err < bound, 1, 0);
     printf(" -> %-4s " __FE__ " (" __FE__ ")\n", IF(ok == 0, "FAIL", "OK"), err, bound);
     accuracy_log_append("nfct",
-      testcase->setup == setup_online ? "online" : "file",
+      testcase->setup == setup_online || testcase->setup == setup_adjoint_online ? "online" : "file",
       d, N, M, init_delegate->name, trafo_delegate->name,
       (long double)err, (long double)bound, ok);
   }
@@ -733,8 +734,7 @@ static init_delegate_t init_advanced_pre_lin_psi = {"init_guru (PRE LIN PSI)", i
 static init_delegate_t init_advanced_pre_fg_psi = {"init_guru (PRE FG PSI)", init_advanced_pre_psi_, WINDOW_HELP_ESTIMATE_m, PRE_PHI_HUT | FG_PSI | PRE_FG_PSI | DEFAULT_NFFT_FLAGS, DEFAULT_FFTW_FLAGS};
 
 /* Gaussian at fixed m below the round-off floor, where the window's
- * truncation error shows. The default m reaches that floor, so each list
- * stops one below WINDOW_HELP_ESTIMATE_m (infft.h). The bound is the
+ * truncation error shows. The default m reaches that floor. The bound is the
  * theoretical 4 exp(-m pi (1 - 1/(2 sigma - 1))) at sigma 2; err_trafo's
  * prefactor is fitted to the default m only. */
 static R err_trafo_gaussian_m(X(plan) *p)

--- a/tests/nfct.c
+++ b/tests/nfct.c
@@ -731,6 +731,47 @@ static init_delegate_t init_advanced_pre_full_psi = {"init_guru (PRE FULL PSI)",
 static init_delegate_t init_advanced_pre_lin_psi = {"init_guru (PRE LIN PSI)", init_advanced_pre_psi_, WINDOW_HELP_ESTIMATE_m, PRE_PHI_HUT | PRE_LIN_PSI | DEFAULT_NFFT_FLAGS, DEFAULT_FFTW_FLAGS};
 #if defined(GAUSSIAN)
 static init_delegate_t init_advanced_pre_fg_psi = {"init_guru (PRE FG PSI)", init_advanced_pre_psi_, WINDOW_HELP_ESTIMATE_m, PRE_PHI_HUT | FG_PSI | PRE_FG_PSI | DEFAULT_NFFT_FLAGS, DEFAULT_FFTW_FLAGS};
+
+/* Gaussian at fixed m below the round-off floor, where the window's
+ * truncation error shows. The default m reaches that floor, so each list
+ * stops one below WINDOW_HELP_ESTIMATE_m (infft.h). The bound is the
+ * theoretical 4 exp(-m pi (1 - 1/(2 sigma - 1))) at sigma 2; err_trafo's
+ * prefactor is fitted to the default m only. */
+static R err_trafo_gaussian_m(X(plan) *p)
+{
+  return FMAX(K(4.0) * EXP(-((R)p->m) * KPI * (K(1.0) - K(1.0) / K(3.0))), err_trafo(p));
+}
+static trafo_delegate_t trafo_gaussian_m = {"trafo", X(trafo), X(check), 0, err_trafo_gaussian_m};
+static trafo_delegate_t adjoint_gaussian_m = {"adjoint", X(adjoint), X(check), 0, err_trafo_gaussian_m};
+static const trafo_delegate_t* trafos_gaussian_m[] = {&trafo_gaussian_m};
+static const trafo_delegate_t* trafos_adjoint_gaussian_m[] = {&adjoint_gaussian_m};
+#define GAUSSIAN_M_DELEGATE(mm) \
+  static init_delegate_t init_gaussian_m##mm = {"init_guru (PRE PSI, m=" #mm ")", init_advanced_pre_psi_, mm, PRE_PHI_HUT | PRE_PSI | DEFAULT_NFFT_FLAGS, DEFAULT_FFTW_FLAGS};
+#if MANT_DIG == 24
+  // IEEE 754 single precision, 32 bits.
+GAUSSIAN_M_DELEGATE(2)
+GAUSSIAN_M_DELEGATE(3)
+GAUSSIAN_M_DELEGATE(4)
+static const init_delegate_t* initializers_gaussian_m[] = {&init_gaussian_m2, &init_gaussian_m3, &init_gaussian_m4};
+#elif MANT_DIG == 64 || MANT_DIG == 113
+  // Intel double extended, 80 bits, and IEEE 754 quadruple precision, 128 bits.
+GAUSSIAN_M_DELEGATE(2)
+GAUSSIAN_M_DELEGATE(4)
+GAUSSIAN_M_DELEGATE(8)
+GAUSSIAN_M_DELEGATE(12)
+GAUSSIAN_M_DELEGATE(16)
+static const init_delegate_t* initializers_gaussian_m[] = {&init_gaussian_m2, &init_gaussian_m4, &init_gaussian_m8, &init_gaussian_m12, &init_gaussian_m16};
+#else
+  // IEEE 754 double precision, 64 bits; assumed for unknown types.
+GAUSSIAN_M_DELEGATE(2)
+GAUSSIAN_M_DELEGATE(4)
+GAUSSIAN_M_DELEGATE(6)
+GAUSSIAN_M_DELEGATE(8)
+GAUSSIAN_M_DELEGATE(10)
+GAUSSIAN_M_DELEGATE(12)
+static const init_delegate_t* initializers_gaussian_m[] = {&init_gaussian_m2, &init_gaussian_m4, &init_gaussian_m6, &init_gaussian_m8, &init_gaussian_m10, &init_gaussian_m12};
+#endif
+#undef GAUSSIAN_M_DELEGATE
 #endif
 
 /* Check routines. */
@@ -912,6 +953,15 @@ void X(check_1d_online)(void)
     testcases_1d_online_, initializers_1d, &check_trafo, trafos_1d_online);
 }
 
+#if defined(GAUSSIAN)
+void X(check_1d_online_gaussian_m)(void)
+{
+  printf("check_1d_online_gaussian_m:\n");
+  check_many(SIZE(testcases_1d_online), SIZE(initializers_gaussian_m), SIZE(trafos_gaussian_m),
+    testcases_1d_online_, initializers_gaussian_m, &check_trafo, trafos_gaussian_m);
+}
+#endif
+
 static const testcase_delegate_online_t nfct_adjoint_online_1d_50_50 = {setup_adjoint_online, destroy_online, 1, 50 ,50};
 static const testcase_delegate_online_t nfct_adjoint_online_1d_100_50 = {setup_adjoint_online, destroy_online, 1, 100 ,50};
 static const testcase_delegate_online_t nfct_adjoint_online_1d_200_50 = {setup_adjoint_online, destroy_online, 1, 200 ,50};
@@ -944,6 +994,15 @@ void X(check_adjoint_1d_online)(void)
   check_many(SIZE(testcases_adjoint_1d_online), SIZE(initializers_1d), SIZE(trafos_adjoint_1d_online),
     testcases_adjoint_1d_online_, initializers_1d, &check_adjoint, trafos_adjoint_1d_online);
 }
+
+#if defined(GAUSSIAN)
+void X(check_adjoint_1d_online_gaussian_m)(void)
+{
+  printf("check_adjoint_1d_online_gaussian_m:\n");
+  check_many(SIZE(testcases_adjoint_1d_online), SIZE(initializers_gaussian_m), SIZE(trafos_adjoint_gaussian_m),
+    testcases_adjoint_1d_online_, initializers_gaussian_m, &check_adjoint, trafos_adjoint_gaussian_m);
+}
+#endif
 
 /* 2D */
 
@@ -1023,6 +1082,15 @@ void X(check_2d_online)(void)
     testcases_2d_online_, initializers_2d, &check_trafo, trafos_2d_online);
 }
 
+#if defined(GAUSSIAN)
+void X(check_2d_online_gaussian_m)(void)
+{
+  printf("check_2d_online_gaussian_m:\n");
+  check_many(SIZE(testcases_2d_online), SIZE(initializers_gaussian_m), SIZE(trafos_gaussian_m),
+    testcases_2d_online_, initializers_gaussian_m, &check_trafo, trafos_gaussian_m);
+}
+#endif
+
 static const testcase_delegate_online_t nfct_adjoint_online_2d_50_50 = {setup_adjoint_online, destroy_online, 2, 50 ,50};
 static const testcase_delegate_online_t nfct_adjoint_online_2d_100_50 = {setup_adjoint_online, destroy_online, 2, 100 ,50};
 static const testcase_delegate_online_t nfct_adjoint_online_2d_200_50 = {setup_adjoint_online, destroy_online, 2, 200 ,50};
@@ -1049,6 +1117,15 @@ void X(check_adjoint_2d_online)(void)
   check_many(SIZE(testcases_adjoint_2d_online), SIZE(initializers_2d), SIZE(trafos_adjoint_2d_online),
     testcases_adjoint_2d_online_, initializers_2d, &check_adjoint, trafos_adjoint_2d_online);
 }
+
+#if defined(GAUSSIAN)
+void X(check_adjoint_2d_online_gaussian_m)(void)
+{
+  printf("check_adjoint_2d_online_gaussian_m:\n");
+  check_many(SIZE(testcases_adjoint_2d_online), SIZE(initializers_gaussian_m), SIZE(trafos_adjoint_gaussian_m),
+    testcases_adjoint_2d_online_, initializers_gaussian_m, &check_adjoint, trafos_adjoint_gaussian_m);
+}
+#endif
 
 /* 3D */
 
@@ -1119,6 +1196,15 @@ void X(check_3d_online)(void)
     testcases_3d_online_, initializers_3d, &check_trafo, trafos_3d_online);
 }
 
+#if defined(GAUSSIAN)
+void X(check_3d_online_gaussian_m)(void)
+{
+  printf("check_3d_online_gaussian_m:\n");
+  check_many(SIZE(testcases_3d_online), SIZE(initializers_gaussian_m), SIZE(trafos_gaussian_m),
+    testcases_3d_online_, initializers_gaussian_m, &check_trafo, trafos_gaussian_m);
+}
+#endif
+
 static const testcase_delegate_online_t nfct_adjoint_online_3d_50_50 = {setup_adjoint_online, destroy_online, 3, 50 ,50};
 
 static const testcase_delegate_online_t *testcases_adjoint_3d_online[] =
@@ -1135,6 +1221,15 @@ void X(check_adjoint_3d_online)(void)
   check_many(SIZE(testcases_adjoint_3d_online), SIZE(initializers_3d), SIZE(trafos_adjoint_3d_online),
     testcases_adjoint_3d_online_, initializers_3d, &check_adjoint, trafos_adjoint_3d_online);
 }
+
+#if defined(GAUSSIAN)
+void X(check_adjoint_3d_online_gaussian_m)(void)
+{
+  printf("check_adjoint_3d_online_gaussian_m:\n");
+  check_many(SIZE(testcases_adjoint_3d_online), SIZE(initializers_gaussian_m), SIZE(trafos_adjoint_gaussian_m),
+    testcases_adjoint_3d_online_, initializers_gaussian_m, &check_adjoint, trafos_adjoint_gaussian_m);
+}
+#endif
 #endif
 
 /* 4D. */

--- a/tests/nfct.h
+++ b/tests/nfct.h
@@ -42,3 +42,12 @@ void X(check_adjoint_3d_direct_file)(void);
 void X(check_adjoint_3d_fast_file)(void);
 void X(check_adjoint_3d_online)(void);
 void X(check_adjoint_4d_online)(void);
+
+#if defined(GAUSSIAN)
+void X(check_1d_online_gaussian_m)(void);
+void X(check_2d_online_gaussian_m)(void);
+void X(check_3d_online_gaussian_m)(void);
+void X(check_adjoint_1d_online_gaussian_m)(void);
+void X(check_adjoint_2d_online_gaussian_m)(void);
+void X(check_adjoint_3d_online_gaussian_m)(void);
+#endif

--- a/tests/nfft.c
+++ b/tests/nfft.c
@@ -66,6 +66,7 @@ typedef struct testcase_delegate_online_s
 } testcase_delegate_online_t;
 
 static void setup_online(const testcase_delegate_t *ego_, int *d, int **N, int *NN, int *M, R **x, C **f_hat, C **f);
+static void setup_adjoint_online(const testcase_delegate_t *ego_, int *d, int **N, int *NN, int *M, R **x, C **f_hat, C **f);
 static void destroy_online(const testcase_delegate_t *ego_, int *N, R *x, C *f_hat, C *f);
 
 /* Initialization delegate. */
@@ -397,7 +398,7 @@ static int check_single(const testcase_delegate_t *testcase,
     ok = IF(err < bound, 1, 0);
     printf(" -> %-4s " __FE__ " (" __FE__ ")\n", IF(ok == 0, "FAIL", "OK"), err, bound);
     accuracy_log_append("nfft",
-      testcase->setup == setup_online ? "online" : "file",
+      testcase->setup == setup_online || testcase->setup == setup_adjoint_online ? "online" : "file",
       d, N, M, init_delegate->name, trafo_delegate->name,
       (long double)err, (long double)bound, ok);
   }

--- a/tests/nfft.c
+++ b/tests/nfft.c
@@ -236,7 +236,7 @@ static R err_trafo(X(plan) *p)
     b = K(50.0);
   #elif MANT_DIG == 64
     // Intel double extended, 80 bits.
-    a = K(0.95);
+    a = K(1.5);
     b = K(50.0);
   #elif MANT_DIG == 53
     // IEEE 754 double precision, 64 bits.

--- a/tests/nfft.c
+++ b/tests/nfft.c
@@ -765,6 +765,47 @@ static init_delegate_t init_advanced_no_pre = {"init_guru (no PRE_PHI_HUT, no PR
 //static init_delegate_t init_advanced_pre_lin_psi_06 = {"init_guru (PRE LIN PSI) 06", init_advanced_pre_lin_psi_, WINDOW_HELP_ESTIMATE_m, PRE_PHI_HUT | PRE_LIN_PSI | DEFAULT_NFFT_FLAGS, DEFAULT_FFTW_FLAGS, (1U << 29)};
 #if defined(GAUSSIAN)
 static init_delegate_t init_advanced_pre_fg_psi = {"init_guru (PRE FG PSI)", init_advanced_pre_psi_, WINDOW_HELP_ESTIMATE_m, PRE_PHI_HUT | FG_PSI | PRE_FG_PSI | DEFAULT_NFFT_FLAGS, DEFAULT_FFTW_FLAGS};
+
+/* Gaussian at fixed m below the round-off floor, where the window's
+ * truncation error shows. The default m reaches that floor, so each list
+ * stops one below WINDOW_HELP_ESTIMATE_m (infft.h). The bound is the
+ * theoretical 4 exp(-m pi (1 - 1/(2 sigma - 1))) at sigma 2; err_trafo's
+ * prefactor is fitted to the default m only. */
+static R err_trafo_gaussian_m(X(plan) *p)
+{
+  return FMAX(K(4.0) * EXP(-((R)p->m) * KPI * (K(1.0) - K(1.0) / K(3.0))), err_trafo(p));
+}
+static trafo_delegate_t trafo_gaussian_m = {"trafo", X(trafo), X(check), 0, err_trafo_gaussian_m};
+static trafo_delegate_t adjoint_gaussian_m = {"adjoint", X(adjoint), X(check), 0, err_trafo_gaussian_m};
+static const trafo_delegate_t* trafos_gaussian_m[] = {&trafo_gaussian_m};
+static const trafo_delegate_t* trafos_adjoint_gaussian_m[] = {&adjoint_gaussian_m};
+#define GAUSSIAN_M_DELEGATE(mm) \
+  static init_delegate_t init_gaussian_m##mm = {"init_guru (PRE PSI, m=" #mm ")", init_advanced_pre_psi_, mm, PRE_PHI_HUT | PRE_PSI | DEFAULT_NFFT_FLAGS, DEFAULT_FFTW_FLAGS};
+#if MANT_DIG == 24
+  // IEEE 754 single precision, 32 bits.
+GAUSSIAN_M_DELEGATE(2)
+GAUSSIAN_M_DELEGATE(3)
+GAUSSIAN_M_DELEGATE(4)
+static const init_delegate_t* initializers_gaussian_m[] = {&init_gaussian_m2, &init_gaussian_m3, &init_gaussian_m4};
+#elif MANT_DIG == 64 || MANT_DIG == 113
+  // Intel double extended, 80 bits, and IEEE 754 quadruple precision, 128 bits.
+GAUSSIAN_M_DELEGATE(2)
+GAUSSIAN_M_DELEGATE(4)
+GAUSSIAN_M_DELEGATE(8)
+GAUSSIAN_M_DELEGATE(12)
+GAUSSIAN_M_DELEGATE(16)
+static const init_delegate_t* initializers_gaussian_m[] = {&init_gaussian_m2, &init_gaussian_m4, &init_gaussian_m8, &init_gaussian_m12, &init_gaussian_m16};
+#else
+  // IEEE 754 double precision, 64 bits; assumed for unknown types.
+GAUSSIAN_M_DELEGATE(2)
+GAUSSIAN_M_DELEGATE(4)
+GAUSSIAN_M_DELEGATE(6)
+GAUSSIAN_M_DELEGATE(8)
+GAUSSIAN_M_DELEGATE(10)
+GAUSSIAN_M_DELEGATE(12)
+static const init_delegate_t* initializers_gaussian_m[] = {&init_gaussian_m2, &init_gaussian_m4, &init_gaussian_m6, &init_gaussian_m8, &init_gaussian_m10, &init_gaussian_m12};
+#endif
+#undef GAUSSIAN_M_DELEGATE
 #endif
 
 /* Check routines. */
@@ -955,6 +996,15 @@ void X(check_1d_online)(void)
     testcases_1d_online_, initializers_1d, &check_trafo, trafos_1d_online);
 }
 
+#if defined(GAUSSIAN)
+void X(check_1d_online_gaussian_m)(void)
+{
+  printf("check_1d_online_gaussian_m:\n");
+  check_many(SIZE(testcases_1d_online), SIZE(initializers_gaussian_m), SIZE(trafos_gaussian_m),
+    testcases_1d_online_, initializers_gaussian_m, &check_trafo, trafos_gaussian_m);
+}
+#endif
+
 static const testcase_delegate_online_t nfft_adjoint_online_1d_50_50 = {setup_adjoint_online, destroy_online, 1, 50 ,50};
 static const testcase_delegate_online_t nfft_adjoint_online_1d_100_50 = {setup_adjoint_online, destroy_online, 1, 100 ,50};
 static const testcase_delegate_online_t nfft_adjoint_online_1d_200_50 = {setup_adjoint_online, destroy_online, 1, 200 ,50};
@@ -988,6 +1038,15 @@ void X(check_adjoint_1d_online)(void)
   check_many(SIZE(testcases_adjoint_1d_online), SIZE(initializers_1d), SIZE(trafos_adjoint_1d_online),
     testcases_adjoint_1d_online_, initializers_1d, &check_adjoint, trafos_adjoint_1d_online);
 }
+
+#if defined(GAUSSIAN)
+void X(check_adjoint_1d_online_gaussian_m)(void)
+{
+  printf("check_adjoint_1d_online_gaussian_m:\n");
+  check_many(SIZE(testcases_adjoint_1d_online), SIZE(initializers_gaussian_m), SIZE(trafos_adjoint_gaussian_m),
+    testcases_adjoint_1d_online_, initializers_gaussian_m, &check_adjoint, trafos_adjoint_gaussian_m);
+}
+#endif
 
 /* 2D */
 
@@ -1076,6 +1135,15 @@ void X(check_2d_online)(void)
     testcases_2d_online_, initializers_2d, &check_trafo, trafos_2d_online);
 }
 
+#if defined(GAUSSIAN)
+void X(check_2d_online_gaussian_m)(void)
+{
+  printf("check_2d_online_gaussian_m:\n");
+  check_many(SIZE(testcases_2d_online), SIZE(initializers_gaussian_m), SIZE(trafos_gaussian_m),
+    testcases_2d_online_, initializers_gaussian_m, &check_trafo, trafos_gaussian_m);
+}
+#endif
+
 static const testcase_delegate_online_t nfft_adjoint_online_2d_50_50 = {setup_adjoint_online, destroy_online, 2, 50 ,50};
 static const testcase_delegate_online_t nfft_adjoint_online_2d_100_50 = {setup_adjoint_online, destroy_online, 2, 100 ,50};
 static const testcase_delegate_online_t nfft_adjoint_online_2d_200_50 = {setup_adjoint_online, destroy_online, 2, 200 ,50};
@@ -1103,6 +1171,15 @@ void X(check_adjoint_2d_online)(void)
   check_many(SIZE(testcases_adjoint_2d_online), SIZE(initializers_2d), SIZE(trafos_adjoint_2d_online),
     testcases_adjoint_2d_online_, initializers_2d, &check_adjoint, trafos_adjoint_2d_online);
 }
+
+#if defined(GAUSSIAN)
+void X(check_adjoint_2d_online_gaussian_m)(void)
+{
+  printf("check_adjoint_2d_online_gaussian_m:\n");
+  check_many(SIZE(testcases_adjoint_2d_online), SIZE(initializers_gaussian_m), SIZE(trafos_adjoint_gaussian_m),
+    testcases_adjoint_2d_online_, initializers_gaussian_m, &check_adjoint, trafos_adjoint_gaussian_m);
+}
+#endif
 
 /* 3D */
 
@@ -1182,6 +1259,15 @@ void X(check_3d_online)(void)
     testcases_3d_online_, initializers_3d, &check_trafo, trafos_3d_online);
 }
 
+#if defined(GAUSSIAN)
+void X(check_3d_online_gaussian_m)(void)
+{
+  printf("check_3d_online_gaussian_m:\n");
+  check_many(SIZE(testcases_3d_online), SIZE(initializers_gaussian_m), SIZE(trafos_gaussian_m),
+    testcases_3d_online_, initializers_gaussian_m, &check_trafo, trafos_gaussian_m);
+}
+#endif
+
 static const testcase_delegate_online_t nfft_adjoint_online_3d_50_50 = {setup_adjoint_online, destroy_online, 3, 50 ,50};
 
 static const testcase_delegate_online_t *testcases_adjoint_3d_online[] =
@@ -1199,6 +1285,15 @@ void X(check_adjoint_3d_online)(void)
   check_many(SIZE(testcases_adjoint_3d_online), SIZE(initializers_3d), SIZE(trafos_adjoint_3d_online),
     testcases_adjoint_3d_online_, initializers_3d, &check_adjoint, trafos_adjoint_3d_online);
 }
+
+#if defined(GAUSSIAN)
+void X(check_adjoint_3d_online_gaussian_m)(void)
+{
+  printf("check_adjoint_3d_online_gaussian_m:\n");
+  check_many(SIZE(testcases_adjoint_3d_online), SIZE(initializers_gaussian_m), SIZE(trafos_adjoint_gaussian_m),
+    testcases_adjoint_3d_online_, initializers_gaussian_m, &check_adjoint, trafos_adjoint_gaussian_m);
+}
+#endif
 #endif
 
 /* 4D. */

--- a/tests/nfft.h
+++ b/tests/nfft.h
@@ -43,4 +43,13 @@ void X(check_adjoint_3d_fast_file)(void);
 void X(check_adjoint_3d_online)(void);
 void X(check_adjoint_4d_online)(void);
 
+#if defined(GAUSSIAN)
+void X(check_1d_online_gaussian_m)(void);
+void X(check_2d_online_gaussian_m)(void);
+void X(check_3d_online_gaussian_m)(void);
+void X(check_adjoint_1d_online_gaussian_m)(void);
+void X(check_adjoint_2d_online_gaussian_m)(void);
+void X(check_adjoint_3d_online_gaussian_m)(void);
+#endif
+
 void X(check_acc)(void);

--- a/tests/nfst.c
+++ b/tests/nfst.c
@@ -737,6 +737,47 @@ static init_delegate_t init_advanced_pre_full_psi = {"init_guru (PRE FULL PSI)",
 static init_delegate_t init_advanced_pre_lin_psi = {"init_guru (PRE LIN PSI)", init_advanced_pre_psi_, WINDOW_HELP_ESTIMATE_m, PRE_PHI_HUT | PRE_LIN_PSI | DEFAULT_NFFT_FLAGS, DEFAULT_FFTW_FLAGS};
 #if defined(GAUSSIAN)
 static init_delegate_t init_advanced_pre_fg_psi = {"init_guru (PRE FG PSI)", init_advanced_pre_psi_, WINDOW_HELP_ESTIMATE_m, PRE_PHI_HUT | FG_PSI | PRE_FG_PSI | DEFAULT_NFFT_FLAGS, DEFAULT_FFTW_FLAGS};
+
+/* Gaussian at fixed m below the round-off floor, where the window's
+ * truncation error shows. The default m reaches that floor, so each list
+ * stops one below WINDOW_HELP_ESTIMATE_m (infft.h). The bound is the
+ * theoretical 4 exp(-m pi (1 - 1/(2 sigma - 1))) at sigma 2; err_trafo's
+ * prefactor is fitted to the default m only. */
+static R err_trafo_gaussian_m(X(plan) *p)
+{
+  return FMAX(K(4.0) * EXP(-((R)p->m) * KPI * (K(1.0) - K(1.0) / K(3.0))), err_trafo(p));
+}
+static trafo_delegate_t trafo_gaussian_m = {"trafo", X(trafo), X(check), 0, err_trafo_gaussian_m};
+static trafo_delegate_t adjoint_gaussian_m = {"adjoint", X(adjoint), X(check), 0, err_trafo_gaussian_m};
+static const trafo_delegate_t* trafos_gaussian_m[] = {&trafo_gaussian_m};
+static const trafo_delegate_t* trafos_adjoint_gaussian_m[] = {&adjoint_gaussian_m};
+#define GAUSSIAN_M_DELEGATE(mm) \
+  static init_delegate_t init_gaussian_m##mm = {"init_guru (PRE PSI, m=" #mm ")", init_advanced_pre_psi_, mm, PRE_PHI_HUT | PRE_PSI | DEFAULT_NFFT_FLAGS, DEFAULT_FFTW_FLAGS};
+#if MANT_DIG == 24
+  // IEEE 754 single precision, 32 bits.
+GAUSSIAN_M_DELEGATE(2)
+GAUSSIAN_M_DELEGATE(3)
+GAUSSIAN_M_DELEGATE(4)
+static const init_delegate_t* initializers_gaussian_m[] = {&init_gaussian_m2, &init_gaussian_m3, &init_gaussian_m4};
+#elif MANT_DIG == 64 || MANT_DIG == 113
+  // Intel double extended, 80 bits, and IEEE 754 quadruple precision, 128 bits.
+GAUSSIAN_M_DELEGATE(2)
+GAUSSIAN_M_DELEGATE(4)
+GAUSSIAN_M_DELEGATE(8)
+GAUSSIAN_M_DELEGATE(12)
+GAUSSIAN_M_DELEGATE(16)
+static const init_delegate_t* initializers_gaussian_m[] = {&init_gaussian_m2, &init_gaussian_m4, &init_gaussian_m8, &init_gaussian_m12, &init_gaussian_m16};
+#else
+  // IEEE 754 double precision, 64 bits; assumed for unknown types.
+GAUSSIAN_M_DELEGATE(2)
+GAUSSIAN_M_DELEGATE(4)
+GAUSSIAN_M_DELEGATE(6)
+GAUSSIAN_M_DELEGATE(8)
+GAUSSIAN_M_DELEGATE(10)
+GAUSSIAN_M_DELEGATE(12)
+static const init_delegate_t* initializers_gaussian_m[] = {&init_gaussian_m2, &init_gaussian_m4, &init_gaussian_m6, &init_gaussian_m8, &init_gaussian_m10, &init_gaussian_m12};
+#endif
+#undef GAUSSIAN_M_DELEGATE
 #endif
 
 /* Check routines. */
@@ -918,6 +959,15 @@ void X(check_1d_online)(void)
     testcases_1d_online_, initializers_1d, &check_trafo, trafos_1d_online);
 }
 
+#if defined(GAUSSIAN)
+void X(check_1d_online_gaussian_m)(void)
+{
+  printf("check_1d_online_gaussian_m:\n");
+  check_many(SIZE(testcases_1d_online), SIZE(initializers_gaussian_m), SIZE(trafos_gaussian_m),
+    testcases_1d_online_, initializers_gaussian_m, &check_trafo, trafos_gaussian_m);
+}
+#endif
+
 static const testcase_delegate_online_t nfst_adjoint_online_1d_50_50 = {setup_adjoint_online, destroy_online, 1, 50 ,50};
 static const testcase_delegate_online_t nfst_adjoint_online_1d_100_50 = {setup_adjoint_online, destroy_online, 1, 100 ,50};
 static const testcase_delegate_online_t nfst_adjoint_online_1d_200_50 = {setup_adjoint_online, destroy_online, 1, 200 ,50};
@@ -950,6 +1000,15 @@ void X(check_adjoint_1d_online)(void)
   check_many(SIZE(testcases_adjoint_1d_online), SIZE(initializers_1d), SIZE(trafos_adjoint_1d_online),
     testcases_adjoint_1d_online_, initializers_1d, &check_adjoint, trafos_adjoint_1d_online);
 }
+
+#if defined(GAUSSIAN)
+void X(check_adjoint_1d_online_gaussian_m)(void)
+{
+  printf("check_adjoint_1d_online_gaussian_m:\n");
+  check_many(SIZE(testcases_adjoint_1d_online), SIZE(initializers_gaussian_m), SIZE(trafos_adjoint_gaussian_m),
+    testcases_adjoint_1d_online_, initializers_gaussian_m, &check_adjoint, trafos_adjoint_gaussian_m);
+}
+#endif
 
 /* 2D */
 
@@ -1029,6 +1088,15 @@ void X(check_2d_online)(void)
     testcases_2d_online_, initializers_2d, &check_trafo, trafos_2d_online);
 }
 
+#if defined(GAUSSIAN)
+void X(check_2d_online_gaussian_m)(void)
+{
+  printf("check_2d_online_gaussian_m:\n");
+  check_many(SIZE(testcases_2d_online), SIZE(initializers_gaussian_m), SIZE(trafos_gaussian_m),
+    testcases_2d_online_, initializers_gaussian_m, &check_trafo, trafos_gaussian_m);
+}
+#endif
+
 static const testcase_delegate_online_t nfst_adjoint_online_2d_50_50 = {setup_adjoint_online, destroy_online, 2, 50 ,50};
 static const testcase_delegate_online_t nfst_adjoint_online_2d_100_50 = {setup_adjoint_online, destroy_online, 2, 100 ,50};
 static const testcase_delegate_online_t nfst_adjoint_online_2d_200_50 = {setup_adjoint_online, destroy_online, 2, 200 ,50};
@@ -1055,6 +1123,15 @@ void X(check_adjoint_2d_online)(void)
   check_many(SIZE(testcases_adjoint_2d_online), SIZE(initializers_2d), SIZE(trafos_adjoint_2d_online),
     testcases_adjoint_2d_online_, initializers_2d, &check_adjoint, trafos_adjoint_2d_online);
 }
+
+#if defined(GAUSSIAN)
+void X(check_adjoint_2d_online_gaussian_m)(void)
+{
+  printf("check_adjoint_2d_online_gaussian_m:\n");
+  check_many(SIZE(testcases_adjoint_2d_online), SIZE(initializers_gaussian_m), SIZE(trafos_adjoint_gaussian_m),
+    testcases_adjoint_2d_online_, initializers_gaussian_m, &check_adjoint, trafos_adjoint_gaussian_m);
+}
+#endif
 
 /* 3D */
 
@@ -1125,6 +1202,15 @@ void X(check_3d_online)(void)
     testcases_3d_online_, initializers_3d, &check_trafo, trafos_3d_online);
 }
 
+#if defined(GAUSSIAN)
+void X(check_3d_online_gaussian_m)(void)
+{
+  printf("check_3d_online_gaussian_m:\n");
+  check_many(SIZE(testcases_3d_online), SIZE(initializers_gaussian_m), SIZE(trafos_gaussian_m),
+    testcases_3d_online_, initializers_gaussian_m, &check_trafo, trafos_gaussian_m);
+}
+#endif
+
 static const testcase_delegate_online_t nfst_adjoint_online_3d_50_50 = {setup_adjoint_online, destroy_online, 3, 50 ,50};
 
 static const testcase_delegate_online_t *testcases_adjoint_3d_online[] =
@@ -1141,6 +1227,15 @@ void X(check_adjoint_3d_online)(void)
   check_many(SIZE(testcases_adjoint_3d_online), SIZE(initializers_3d), SIZE(trafos_adjoint_3d_online),
     testcases_adjoint_3d_online_, initializers_3d, &check_adjoint, trafos_adjoint_3d_online);
 }
+
+#if defined(GAUSSIAN)
+void X(check_adjoint_3d_online_gaussian_m)(void)
+{
+  printf("check_adjoint_3d_online_gaussian_m:\n");
+  check_many(SIZE(testcases_adjoint_3d_online), SIZE(initializers_gaussian_m), SIZE(trafos_adjoint_gaussian_m),
+    testcases_adjoint_3d_online_, initializers_gaussian_m, &check_adjoint, trafos_adjoint_gaussian_m);
+}
+#endif
 #endif
 
 /* 4D. */

--- a/tests/nfst.c
+++ b/tests/nfst.c
@@ -66,6 +66,7 @@ typedef struct testcase_delegate_online_s
 } testcase_delegate_online_t;
 
 static void setup_online(const testcase_delegate_t *ego_, int *d, int **N, int *NN, int *M, R **x, R **f_hat, R **f);
+static void setup_adjoint_online(const testcase_delegate_t *ego_, int *d, int **N, int *NN, int *M, R **x, R **f_hat, R **f);
 static void destroy_online(const testcase_delegate_t *ego_, int *N, R *x, R *f_hat, R *f);
 
 /* Initialization delegate. */
@@ -401,7 +402,7 @@ static int check_single(const testcase_delegate_t *testcase,
     ok = IF(err < bound, 1, 0);
     printf(" -> %-4s " __FE__ " (" __FE__ ")\n", IF(ok == 0, "FAIL", "OK"), err, bound);
     accuracy_log_append("nfst",
-      testcase->setup == setup_online ? "online" : "file",
+      testcase->setup == setup_online || testcase->setup == setup_adjoint_online ? "online" : "file",
       d, N, M, init_delegate->name, trafo_delegate->name,
       (long double)err, (long double)bound, ok);
   }

--- a/tests/nfst.h
+++ b/tests/nfst.h
@@ -42,3 +42,12 @@ void X(check_adjoint_3d_direct_file)(void);
 void X(check_adjoint_3d_fast_file)(void);
 void X(check_adjoint_3d_online)(void);
 void X(check_adjoint_4d_online)(void);
+
+#if defined(GAUSSIAN)
+void X(check_1d_online_gaussian_m)(void);
+void X(check_2d_online_gaussian_m)(void);
+void X(check_3d_online_gaussian_m)(void);
+void X(check_adjoint_1d_online_gaussian_m)(void);
+void X(check_adjoint_2d_online_gaussian_m)(void);
+void X(check_adjoint_3d_online_gaussian_m)(void);
+#endif


### PR DESCRIPTION
The tests for the Gaussian window function only use the default value for the truncation parameter `m` which sits near the round-off floor. This hides any improvements we can make in regions where the error is dominated by the approximation scheme itself. This PR adds such tests so they are included in the default accuracy report generated for any future PRs. Note that this is only for the Gaussian window. We could and maybe should add similar tests for other window functions as well.

Also: Re-order the columns in the accuracy report so they show as float, double, and long double.