### PR TITLE
Fill the fast-Gaussian run with fixed trip counts to avoid breaking auto-vectorization.

### DIFF
--- a/include/infft.h
+++ b/include/infft.h
@@ -392,35 +392,43 @@ typedef ptrdiff_t INT;
     } while (0)
 #endif
 
-/* Gaussian run fill for the FG_PSI paths: dst[0 .. len-1], stepping outward
- * from the peak. seed is the window at the grid point nearest the node, kc
- * that point's index in the run, s is exp(2 d / b) for its offset d, e is
+/* Gaussian run fill for the FG_PSI paths: buf[0 .. 2m+2] holds the window at
+ * the 2m+3 grid points -(m+1) .. m+1 away from the anchor, whose value seed
+ * lands in buf[m+1]. s is exp(2 d / b) for the anchor's offset d, e is
  * exp(-1/b) and q is e * e. Stepping outward keeps each step on a value no
  * larger than the one before, holding the run to about an ulp of its peak;
- * stepping up from the tail instead costs an ulp per grid point. */
-#define FG_RUN(dst,len,seed,s,e,q,kc) \
+ * stepping up from the tail instead costs an ulp per grid point. The trip
+ * counts are fixed, so the fill has no branch that depends on the node: a
+ * caller picks its 2m+2 point run with FG_RUN_START. */
+#define FG_RUN(buf,m,seed,s,e,q) \
   do { \
     const R FG_RUN_v0 = (seed), FG_RUN_s = (s), FG_RUN_e = (e), \
         FG_RUN_q = (q); \
-    const INT FG_RUN_c = (kc), FG_RUN_n = (len); \
+    const INT FG_RUN_h = (m) + 1; \
     R FG_RUN_v = FG_RUN_v0, FG_RUN_r = FG_RUN_s * FG_RUN_e; \
     INT FG_RUN_k; \
-    (dst)[FG_RUN_c] = FG_RUN_v0; \
-    for (FG_RUN_k = FG_RUN_c + 1; FG_RUN_k < FG_RUN_n; FG_RUN_k++) \
+    (buf)[FG_RUN_h] = FG_RUN_v0; \
+    for (FG_RUN_k = 1; FG_RUN_k <= FG_RUN_h; FG_RUN_k++) \
     { \
       FG_RUN_v *= FG_RUN_r; \
-      (dst)[FG_RUN_k] = FG_RUN_v; \
+      (buf)[FG_RUN_h + FG_RUN_k] = FG_RUN_v; \
       FG_RUN_r *= FG_RUN_q; \
     } \
     FG_RUN_v = FG_RUN_v0; \
     FG_RUN_r = FG_RUN_e / FG_RUN_s; \
-    for (FG_RUN_k = FG_RUN_c - 1; FG_RUN_k >= 0; FG_RUN_k--) \
+    for (FG_RUN_k = 1; FG_RUN_k <= FG_RUN_h; FG_RUN_k++) \
     { \
       FG_RUN_v *= FG_RUN_r; \
-      (dst)[FG_RUN_k] = FG_RUN_v; \
+      (buf)[FG_RUN_h - FG_RUN_k] = FG_RUN_v; \
       FG_RUN_r *= FG_RUN_q; \
     } \
   } while (0)
+
+/* Start of the 2m+2 point run inside a FG_RUN buffer. The anchor is the grid
+ * point nearest the node; it sits at run index m when it lies at or below the
+ * node (offset d >= 0) and at m+1 when above (d < 0). Any value with the
+ * sign of d serves, such as the seed nfft_precompute_fg_psi() stores. */
+#define FG_RUN_START(buf,d) ((buf) + ((d) < K(0.0) ? 0 : 1))
 
 /* window.c */
 INT Y(m2K)(const INT m);

--- a/kernel/nfct/nfct.c
+++ b/kernel/nfct/nfct.c
@@ -81,7 +81,10 @@ static inline R X(reduced_omega)(const R k, const R x)
   return K2PI * FFMA(k, x, -n); // Calculate k * x - n with a single rounding, then multiply 2 * pi.
 }
 
-#define MACRO_with_FG_PSI fg_psi[t][lj[t]]
+/* uo() anchors the run at the grid point nearest the node, run index m,
+ * which FG_RUN puts at buffer index m + 1 */
+#define MACRO_with_FG_PSI fg_psi[t][lj[t] + 1]
+#define MACRO_with_LIN_PSI fg_psi[t][lj[t]]
 #define MACRO_with_PRE_PSI ths->psi[(j * ths->d + t) * (2 * ths->m + 2) + lj[t]]
 #define MACRO_without_PRE_PSI PHI((2 * NN(ths->n[t])), ((ths->x[(j) * ths->d + t]) \
   - ((R)(lj[t] + u[t])) / (K(2.0) * ((R)NN(ths->n[t])))), t)
@@ -581,7 +584,7 @@ static inline void B_ ## which_one (X(plan) *ths) \
   R *f, *g; /* local copy */ \
   R *fj; /* local copy */ \
   R y[ths->d]; \
-  R fg_psi[ths->d][2*ths->m+2]; \
+  R fg_psi[ths->d][2*ths->m+3]; \
   R fg_e[ths->d], fg_q[ths->d]; \
   INT l_fg,lj_fg; \
   R ip_w; \
@@ -644,8 +647,8 @@ static inline void B_ ## which_one (X(plan) *ths) \
  \
       for (t = 0; t < ths->d; t++) \
       { \
-        FG_RUN(fg_psi[t], 2 * ths->m + 2, ths->psi[2 * (j * ths->d + t)], \
-            ths->psi[2 * (j * ths->d + t) + 1], fg_e[t], fg_q[t], ths->m); \
+        FG_RUN(fg_psi[t], ths->m, ths->psi[2 * (j * ths->d + t)], \
+            ths->psi[2 * (j * ths->d + t) + 1], fg_e[t], fg_q[t]); \
       } \
  \
       for (l_L= 0; l_L < lprod; l_L++) \
@@ -675,10 +678,10 @@ static inline void B_ ## which_one (X(plan) *ths) \
       for (t = 0; t < ths->d; t++) \
       { \
         const INT fg_c = u[t] + ths->m; \
-        FG_RUN(fg_psi[t], 2 * ths->m + 2, \
+        FG_RUN(fg_psi[t], ths->m, \
             (PHI((2 * NN(ths->n[t])), (ths->x[j*ths->d+t] - ((R)fg_c)/(2 * NN(ths->n[t]))),(t))), \
             EXP(K(2.0) * ((2 * NN(ths->n[t])) * ths->x[j * ths->d + t] - fg_c) / ths->b[t]), \
-            fg_e[t], fg_q[t], ths->m); \
+            fg_e[t], fg_q[t]); \
       } \
   \
       for (l_L = 0; l_L < lprod; l_L++) \
@@ -715,7 +718,7 @@ static inline void B_ ## which_one (X(plan) *ths) \
   \
       for (l_L = 0; l_L < lprod; l_L++) \
       { \
-        MACRO_update_phi_prod_ll_plain(which_one, with_FG_PSI); \
+        MACRO_update_phi_prod_ll_plain(which_one, with_LIN_PSI); \
  \
         MACRO_B_compute_ ## which_one; \
  \

--- a/kernel/nfct/nfct.c
+++ b/kernel/nfct/nfct.c
@@ -82,8 +82,8 @@ static inline R X(reduced_omega)(const R k, const R x)
 }
 
 /* uo() anchors the run at the grid point nearest the node, run index m,
- * which FG_RUN puts at buffer index m + 1 */
-#define MACRO_with_FG_PSI fg_psi[t][lj[t] + 1]
+ * which FG_RUN puts at buffer index m + 2 for a fill based at fg_psi[t] + 1 */
+#define MACRO_with_FG_PSI fg_psi[t][lj[t] + 2]
 #define MACRO_with_LIN_PSI fg_psi[t][lj[t]]
 #define MACRO_with_PRE_PSI ths->psi[(j * ths->d + t) * (2 * ths->m + 2) + lj[t]]
 #define MACRO_without_PRE_PSI PHI((2 * NN(ths->n[t])), ((ths->x[(j) * ths->d + t]) \
@@ -584,7 +584,10 @@ static inline void B_ ## which_one (X(plan) *ths) \
   R *f, *g; /* local copy */ \
   R *fj; /* local copy */ \
   R y[ths->d]; \
-  R fg_psi[ths->d][2*ths->m+3]; \
+  /* 2m+4, not the 2m+3 FG_RUN fills: an even row stride and an even offset \
+   * to the used run keep the read base of the l_L loop aligned as it was \
+   * before the run gained its extra point. */ \
+  R fg_psi[ths->d][2*ths->m+4]; \
   R fg_e[ths->d], fg_q[ths->d]; \
   INT l_fg,lj_fg; \
   R ip_w; \
@@ -647,7 +650,7 @@ static inline void B_ ## which_one (X(plan) *ths) \
  \
       for (t = 0; t < ths->d; t++) \
       { \
-        FG_RUN(fg_psi[t], ths->m, ths->psi[2 * (j * ths->d + t)], \
+        FG_RUN(fg_psi[t] + 1, ths->m, ths->psi[2 * (j * ths->d + t)], \
             ths->psi[2 * (j * ths->d + t) + 1], fg_e[t], fg_q[t]); \
       } \
  \
@@ -678,7 +681,7 @@ static inline void B_ ## which_one (X(plan) *ths) \
       for (t = 0; t < ths->d; t++) \
       { \
         const INT fg_c = u[t] + ths->m; \
-        FG_RUN(fg_psi[t], ths->m, \
+        FG_RUN(fg_psi[t] + 1, ths->m, \
             (PHI((2 * NN(ths->n[t])), (ths->x[j*ths->d+t] - ((R)fg_c)/(2 * NN(ths->n[t]))),(t))), \
             EXP(K(2.0) * ((2 * NN(ths->n[t])) * ths->x[j * ths->d + t] - fg_c) / ths->b[t]), \
             fg_e[t], fg_q[t]); \

--- a/kernel/nfft/nfft.c
+++ b/kernel/nfft/nfft.c
@@ -527,13 +527,6 @@ static inline void uo(const X(plan) *ths, const INT j, INT *up, INT *op,
   (*op) = c + 1 + (ths->m);
 }
 
-/* Index in the run of the grid point nearest the node. uo() starts the run at
- * floor(n x) - m, so this is m or m + 1. */
-static inline INT fg_centre(const R nx, const INT m)
-{
-  return m + (INT)(LRINT(nx) - LRINT(FLOOR(nx)));
-}
-
 static inline void uo2(INT *u, INT *o, const R x, const INT n, const INT m)
 {
   INT c = LRINT(FLOOR(x * (R)(n)));
@@ -853,7 +846,9 @@ static void D_T(X(plan) *ths)
   ths->g[ll_plain[ths->d]] += phi_prod[ths->d] * ths->f[j]; \
 }
 
-#define MACRO_with_FG_PSI fg_psi[t2][lj[t2]]
+#define MACRO_with_FG_PSI fg_p[t2][lj[t2]]
+
+#define MACRO_with_LIN_PSI fg_psi[t2][lj[t2]]
 
 #define MACRO_with_PRE_PSI ths->psi[(j*ths->d+t2) * (2*ths->m+2)+lj[t2]]
 
@@ -897,7 +892,8 @@ INT l_all[ths->d*(2*ths->m+2)]; \
 #define MACRO_COMPUTE_with_PRE_PSI MACRO_with_PRE_PSI
 #define MACRO_COMPUTE_with_PRE_FG_PSI MACRO_with_FG_PSI
 #define MACRO_COMPUTE_with_FG_PSI MACRO_with_FG_PSI
-#define MACRO_COMPUTE_with_PRE_LIN_PSI MACRO_with_FG_PSI
+#define MACRO_COMPUTE_with_PRE_LIN_PSI MACRO_with_LIN_PSI
+#define MACRO_COMPUTE_with_LIN_PSI MACRO_with_LIN_PSI
 #define MACRO_COMPUTE_without_PRE_PSI MACRO_without_PRE_PSI_improved
 #define MACRO_COMPUTE_without_PRE_PSI_improved MACRO_without_PRE_PSI_improved
 
@@ -1000,7 +996,8 @@ static inline void B_serial_ ## which_one (X(plan) *ths) \
   INT ll_plain[ths->d+1]; /* postfix plain index in g */ \
   R phi_prod[ths->d+1]; /* postfix product of PHI */ \
   R y[ths->d]; \
-  R fg_psi[ths->d][2*ths->m+2]; \
+  R fg_psi[ths->d][2*ths->m+3]; \
+  const R *fg_p[ths->d]; \
   R fg_e[ths->d], fg_q[ths->d]; \
   INT l_fg,lj_fg; \
   R ip_w; \
@@ -1064,9 +1061,9 @@ static inline void B_serial_ ## which_one (X(plan) *ths) \
  \
       for (t2 = 0; t2 < ths->d; t2++) \
       { \
-        FG_RUN(fg_psi[t2], 2 * ths->m + 2, ths->psi[2*(j*ths->d+t2)], \
-            ths->psi[2*(j*ths->d+t2)+1], fg_e[t2], fg_q[t2], \
-            fg_centre((R)(ths->n[t2]) * ths->x[j*ths->d+t2], ths->m)); \
+        FG_RUN(fg_psi[t2], ths->m, FABS(ths->psi[2*(j*ths->d+t2)]), \
+            ths->psi[2*(j*ths->d+t2)+1], fg_e[t2], fg_q[t2]); \
+        fg_p[t2] = FG_RUN_START(fg_psi[t2], ths->psi[2*(j*ths->d+t2)]); \
       } \
  \
       MACRO_B_COMPUTE_ONE_NODE(which_one,with_FG_PSI); \
@@ -1092,11 +1089,12 @@ static inline void B_serial_ ## which_one (X(plan) *ths) \
       for (t2 = 0; t2 < ths->d; t2++) \
       { \
         const R fg_nx = (R)(ths->n[t2]) * ths->x[j*ths->d+t2]; \
-        const R fg_d = fg_nx - (R)LRINT(fg_nx); \
-        FG_RUN(fg_psi[t2], 2 * ths->m + 2, \
+        const R fg_d = fg_nx - FLOOR(fg_nx + K(0.5)); \
+        FG_RUN(fg_psi[t2], ths->m, \
             (PHI(ths->n[t2], fg_d / ((R)(ths->n[t2])), t2)), \
             EXP(K(2.0) * fg_d / ths->b[t2]), \
-            fg_e[t2], fg_q[t2], fg_centre(fg_nx, ths->m)); \
+            fg_e[t2], fg_q[t2]); \
+        fg_p[t2] = FG_RUN_START(fg_psi[t2], fg_d); \
       } \
  \
       MACRO_B_COMPUTE_ONE_NODE(which_one,with_FG_PSI); \
@@ -1128,7 +1126,7 @@ static inline void B_serial_ ## which_one (X(plan) *ths) \
         } \
       } \
  \
-      MACRO_B_COMPUTE_ONE_NODE(which_one,with_FG_PSI); \
+      MACRO_B_COMPUTE_ONE_NODE(which_one,with_LIN_PSI); \
     } /* for(j) */ \
     return; \
   } /* if(PRE_LIN_PSI) */ \
@@ -1172,9 +1170,9 @@ MACRO_B(A)
 #define MACRO_B_openmp_A_COMPUTE_BEFORE_LOOP_with_PRE_FG_PSI \
       for (t2 = 0; t2 < ths->d; t2++) \
       { \
-        FG_RUN(fg_psi[t2], 2 * ths->m + 2, ths->psi[2*(j*ths->d+t2)], \
-            ths->psi[2*(j*ths->d+t2)+1], fg_e[t2], fg_q[t2], \
-            fg_centre((R)(ths->n[t2]) * ths->x[j*ths->d+t2], ths->m)); \
+        FG_RUN(fg_psi[t2], ths->m, FABS(ths->psi[2*(j*ths->d+t2)]), \
+            ths->psi[2*(j*ths->d+t2)+1], fg_e[t2], fg_q[t2]); \
+        fg_p[t2] = FG_RUN_START(fg_psi[t2], ths->psi[2*(j*ths->d+t2)]); \
       }
 #define MACRO_B_openmp_A_COMPUTE_UPDATE_with_PRE_FG_PSI \
   MACRO_update_phi_prod_ll_plain(with_FG_PSI);
@@ -1183,11 +1181,12 @@ MACRO_B(A)
       for (t2 = 0; t2 < ths->d; t2++) \
       { \
         const R fg_nx = (R)(ths->n[t2]) * ths->x[j*ths->d+t2]; \
-        const R fg_d = fg_nx - (R)LRINT(fg_nx); \
-        FG_RUN(fg_psi[t2], 2 * ths->m + 2, \
+        const R fg_d = fg_nx - FLOOR(fg_nx + K(0.5)); \
+        FG_RUN(fg_psi[t2], ths->m, \
             (PHI(ths->n[t2], fg_d / ((R)(ths->n[t2])), t2)), \
             EXP(K(2.0) * fg_d / ths->b[t2]), \
-            fg_e[t2], fg_q[t2], fg_centre(fg_nx, ths->m)); \
+            fg_e[t2], fg_q[t2]); \
+        fg_p[t2] = FG_RUN_START(fg_psi[t2], fg_d); \
       }
 #define MACRO_B_openmp_A_COMPUTE_UPDATE_with_FG_PSI \
   MACRO_update_phi_prod_ll_plain(with_FG_PSI);
@@ -1207,7 +1206,7 @@ MACRO_B(A)
         } \
       }
 #define MACRO_B_openmp_A_COMPUTE_UPDATE_with_PRE_LIN_PSI \
-  MACRO_update_phi_prod_ll_plain(with_FG_PSI);
+  MACRO_update_phi_prod_ll_plain(with_LIN_PSI);
 
 #define MACRO_B_openmp_A_COMPUTE_BEFORE_LOOP_without_PRE_PSI \
     for (t2 = 0; t2 < ths->d; t2++) \
@@ -1366,9 +1365,8 @@ static inline void B_openmp_A (X(plan) *ths)
     #pragma omp parallel for default(shared) private(k,t,t2)
     for (k = 0; k < ths->M_total; k++)
     {
-      R fg_psi[ths->d][2*ths->m+2];
-      R tmpEXP1, tmp1;
-      INT l_fg,lj_fg;
+      R fg_psi[ths->d][2*ths->m+3];
+      const R *fg_p[ths->d];
 
       MACRO_B_openmp_A_COMPUTE(with_PRE_FG_PSI);
     } /* for(j) */
@@ -1387,9 +1385,8 @@ static inline void B_openmp_A (X(plan) *ths)
     #pragma omp parallel for default(shared) private(k,t,t2)
     for (k = 0; k < ths->M_total; k++)
     {
-      R fg_psi[ths->d][2*ths->m+2];
-      R tmpEXP1, tmp1;
-      INT l_fg,lj_fg;
+      R fg_psi[ths->d][2*ths->m+3];
+      const R *fg_p[ths->d];
 
       MACRO_B_openmp_A_COMPUTE(with_FG_PSI);
     } /* for(j) */
@@ -1749,30 +1746,29 @@ MACRO_B(T)
   MACRO_update_phi_prod_ll_plain(with_PRE_PSI);
 
 #define MACRO_adjoint_nd_B_OMP_COMPUTE_BEFORE_LOOP_with_PRE_FG_PSI \
-      R fg_psi[ths->d][2*ths->m+2]; \
-      R tmpEXP1, tmp1; \
-      INT l_fg,lj_fg; \
+      R fg_psi[ths->d][2*ths->m+3]; \
+      const R *fg_p[ths->d]; \
       for (t2 = 0; t2 < ths->d; t2++) \
       { \
-        FG_RUN(fg_psi[t2], 2 * ths->m + 2, ths->psi[2*(j*ths->d+t2)], \
-            ths->psi[2*(j*ths->d+t2)+1], fg_e[t2], fg_q[t2], \
-            fg_centre((R)(ths->n[t2]) * ths->x[j*ths->d+t2], ths->m)); \
+        FG_RUN(fg_psi[t2], ths->m, FABS(ths->psi[2*(j*ths->d+t2)]), \
+            ths->psi[2*(j*ths->d+t2)+1], fg_e[t2], fg_q[t2]); \
+        fg_p[t2] = FG_RUN_START(fg_psi[t2], ths->psi[2*(j*ths->d+t2)]); \
       }
 #define MACRO_adjoint_nd_B_OMP_COMPUTE_UPDATE_with_PRE_FG_PSI \
   MACRO_update_phi_prod_ll_plain(with_FG_PSI);
 
 #define MACRO_adjoint_nd_B_OMP_COMPUTE_BEFORE_LOOP_with_FG_PSI \
-      R fg_psi[ths->d][2*ths->m+2]; \
-      R tmpEXP1, tmp1; \
-      INT l_fg,lj_fg; \
+      R fg_psi[ths->d][2*ths->m+3]; \
+      const R *fg_p[ths->d]; \
       for (t2 = 0; t2 < ths->d; t2++) \
       { \
         const R fg_nx = (R)(ths->n[t2]) * ths->x[j*ths->d+t2]; \
-        const R fg_d = fg_nx - (R)LRINT(fg_nx); \
-        FG_RUN(fg_psi[t2], 2 * ths->m + 2, \
+        const R fg_d = fg_nx - FLOOR(fg_nx + K(0.5)); \
+        FG_RUN(fg_psi[t2], ths->m, \
             (PHI(ths->n[t2], fg_d / ((R)(ths->n[t2])), t2)), \
             EXP(K(2.0) * fg_d / ths->b[t2]), \
-            fg_e[t2], fg_q[t2], fg_centre(fg_nx, ths->m)); \
+            fg_e[t2], fg_q[t2]); \
+        fg_p[t2] = FG_RUN_START(fg_psi[t2], fg_d); \
       }
 #define MACRO_adjoint_nd_B_OMP_COMPUTE_UPDATE_with_FG_PSI \
   MACRO_update_phi_prod_ll_plain(with_FG_PSI);
@@ -1798,7 +1794,7 @@ MACRO_B(T)
         } \
       }
 #define MACRO_adjoint_nd_B_OMP_COMPUTE_UPDATE_with_PRE_LIN_PSI \
-  MACRO_update_phi_prod_ll_plain(with_FG_PSI);
+  MACRO_update_phi_prod_ll_plain(with_LIN_PSI);
 
 #define MACRO_adjoint_nd_B_OMP_COMPUTE_BEFORE_LOOP_without_PRE_PSI \
       R psij_const[ths->d * (2*ths->m+2)]; \
@@ -2441,22 +2437,22 @@ static void nfft_trafo_1d_B(X(plan) *ths)
 #endif
     {
     INT k;
-    R *psij_const = (R*)Y(malloc)((size_t)(m2p2) * sizeof(R));
+    R *psij_const = (R*)Y(malloc)((size_t)(2 * m + 3) * sizeof(R));
 #ifdef _OPENMP
     #pragma omp for
 #endif
     for (k = 0; k < M; k++)
     {
       INT j = (ths->flags & NFFT_SORT_NODES) ? ths->index_x[2*k+1] : k;
-      INT l;
+      const R *psij0;
 
       {
-        const R fg_nx = (R)(n) * ths->x[j];
-        FG_RUN(psij_const + 0, 2*m+2, ths->psi[2 * j], ths->psi[2 * j + 1],
-            fg_e[0], fg_q[0], fg_centre(fg_nx, m));
+        FG_RUN(psij_const, m, FABS(ths->psi[2 * j]), ths->psi[2 * j + 1],
+            fg_e[0], fg_q[0]);
+        psij0 = FG_RUN_START(psij_const, ths->psi[2 * j]);
       }
 
-      nfft_trafo_1d_compute(&ths->f[j], g, psij_const, &ths->x[j], n, m);
+      nfft_trafo_1d_compute(&ths->f[j], g, psij0, &ths->x[j], n, m);
     }
     Y(free)(psij_const);
     }
@@ -2477,27 +2473,26 @@ static void nfft_trafo_1d_B(X(plan) *ths)
 #endif
     {
     INT k;
-    R *psij_const = (R*)Y(malloc)((size_t)(m2p2) * sizeof(R));
+    R *psij_const = (R*)Y(malloc)((size_t)(2 * m + 3) * sizeof(R));
 #ifdef _OPENMP
     #pragma omp for
 #endif
     for (k = 0; k < M; k++)
     {
       INT j = (ths->flags & NFFT_SORT_NODES) ? ths->index_x[2*k+1] : k;
-      INT u, o, l;
-
-      uo(ths, (INT)j, &u, &o, (INT)0);
+      const R *psij0;
 
       {
         const R fg_nx = (R)(n) * ths->x[j];
-        const R fg_d = fg_nx - (R)LRINT(fg_nx);
-        FG_RUN(psij_const + 0, 2*m+2,
+        const R fg_d = fg_nx - FLOOR(fg_nx + K(0.5));
+        FG_RUN(psij_const, m,
             (PHI(ths->n[0], fg_d / (R)(n), 0)),
             EXP(K(2.0) * fg_d / ths->b[0]),
-            fg_e[0], fg_q[0], fg_centre(fg_nx, m));
+            fg_e[0], fg_q[0]);
+        psij0 = FG_RUN_START(psij_const, fg_d);
       }
 
-      nfft_trafo_1d_compute(&ths->f[j], g, psij_const, &ths->x[j], n, m);
+      nfft_trafo_1d_compute(&ths->f[j], g, psij0, &ths->x[j], n, m);
     }
     Y(free)(psij_const);
     }
@@ -2582,35 +2577,35 @@ static void nfft_trafo_1d_B(X(plan) *ths)
 
 #define MACRO_adjoint_1d_B_OMP_BLOCKWISE_COMPUTE_PRE_FG_PSI \
 { \
-            R psij_const[2 * m + 2]; \
-            INT l; \
+            R psij_const[2 * m + 3]; \
+            const R *psij0; \
  \
             { \
-              const R fg_nx = (R)(n) * ths->x[j]; \
-              FG_RUN(psij_const + 0, 2*m+2, ths->psi[2 * j], ths->psi[2 * j + 1], \
-                  fg_e[0], fg_q[0], fg_centre(fg_nx, m)); \
+              FG_RUN(psij_const, m, FABS(ths->psi[2 * j]), ths->psi[2 * j + 1], \
+                  fg_e[0], fg_q[0]); \
+              psij0 = FG_RUN_START(psij_const, ths->psi[2 * j]); \
             } \
  \
-            nfft_adjoint_1d_compute_omp_blockwise(ths->f[j], g, psij_const, \
+            nfft_adjoint_1d_compute_omp_blockwise(ths->f[j], g, psij0, \
                 ths->x + j, n, m, my_u0, my_o0); \
 }
 
 #define MACRO_adjoint_1d_B_OMP_BLOCKWISE_COMPUTE_FG_PSI \
 { \
-            R psij_const[2 * m + 2]; \
-            INT u, o, l; \
+            R psij_const[2 * m + 3]; \
+            const R *psij0; \
  \
-            uo(ths, j, &u, &o, (INT)0); \
             { \
               const R fg_nx = (R)(n) * ths->x[j]; \
-              const R fg_d = fg_nx - (R)LRINT(fg_nx); \
-              FG_RUN(psij_const + 0, 2*m+2, \
+              const R fg_d = fg_nx - FLOOR(fg_nx + K(0.5)); \
+              FG_RUN(psij_const, m, \
                   (PHI(ths->n[0], fg_d / (R)(n), 0)), \
                   EXP(K(2.0) * fg_d / ths->b[0]), \
-                  fg_e[0], fg_q[0], fg_centre(fg_nx, m)); \
+                  fg_e[0], fg_q[0]); \
+              psij0 = FG_RUN_START(psij_const, fg_d); \
             } \
  \
-            nfft_adjoint_1d_compute_omp_blockwise(ths->f[j], g, psij_const, \
+            nfft_adjoint_1d_compute_omp_blockwise(ths->f[j], g, psij0, \
                 ths->x + j, n, m, my_u0, my_o0); \
 }
 
@@ -2757,20 +2752,20 @@ static void nfft_adjoint_1d_B(X(plan) *ths)
 #endif
     for (k = 0; k < M; k++)
     {
-      R psij_const[2 * m + 2];
+      R psij_const[2 * m + 3];
+      const R *psij0;
       INT j = (ths->flags & NFFT_SORT_NODES) ? ths->index_x[2*k+1] : k;
-      INT l;
 
       {
-        const R fg_nx = (R)(n) * ths->x[j];
-        FG_RUN(psij_const + 0, 2*m+2, ths->psi[2 * j], ths->psi[2 * j + 1],
-            fg_e[0], fg_q[0], fg_centre(fg_nx, m));
+        FG_RUN(psij_const, m, FABS(ths->psi[2 * j]), ths->psi[2 * j + 1],
+            fg_e[0], fg_q[0]);
+        psij0 = FG_RUN_START(psij_const, ths->psi[2 * j]);
       }
 
 #ifdef _OPENMP
-      nfft_adjoint_1d_compute_omp_atomic(ths->f[j], g, psij_const, ths->x + j, n, m);
+      nfft_adjoint_1d_compute_omp_atomic(ths->f[j], g, psij0, ths->x + j, n, m);
 #else
-      nfft_adjoint_1d_compute_serial(ths->f + j, g, psij_const, ths->x + j, n, m);
+      nfft_adjoint_1d_compute_serial(ths->f + j, g, psij0, ths->x + j, n, m);
 #endif
     }
 
@@ -2794,24 +2789,24 @@ static void nfft_adjoint_1d_B(X(plan) *ths)
 #endif
     for (k = 0; k < M; k++)
     {
-      INT u,o,l;
-      R psij_const[2 * m + 2];
+      R psij_const[2 * m + 3];
+      const R *psij0;
       INT j = (ths->flags & NFFT_SORT_NODES) ? ths->index_x[2*k+1] : k;
 
-      uo(ths, j, &u, &o, (INT)0);
       {
         const R fg_nx = (R)(n) * ths->x[j];
-        const R fg_d = fg_nx - (R)LRINT(fg_nx);
-        FG_RUN(psij_const + 0, 2*m+2,
+        const R fg_d = fg_nx - FLOOR(fg_nx + K(0.5));
+        FG_RUN(psij_const, m,
             (PHI(ths->n[0], fg_d / (R)(n), 0)),
             EXP(K(2.0) * fg_d / ths->b[0]),
-            fg_e[0], fg_q[0], fg_centre(fg_nx, m));
+            fg_e[0], fg_q[0]);
+        psij0 = FG_RUN_START(psij_const, fg_d);
       }
 
 #ifdef _OPENMP
-      nfft_adjoint_1d_compute_omp_atomic(ths->f[j], g, psij_const, ths->x + j, n, m);
+      nfft_adjoint_1d_compute_omp_atomic(ths->f[j], g, psij0, ths->x + j, n, m);
 #else
-      nfft_adjoint_1d_compute_serial(ths->f + j, g, psij_const, ths->x + j, n, m);
+      nfft_adjoint_1d_compute_serial(ths->f + j, g, psij0, ths->x + j, n, m);
 #endif
     }
 
@@ -3369,23 +3364,23 @@ static void nfft_trafo_2d_B(X(plan) *ths)
 #endif
     for (k = 0; k < M; k++)
     {
-      R psij_const[2*(2*m+2)];
+      R psij_const[2*(2*m+3)];
+      const R *psij0, *psij1;
       INT j = (ths->flags & NFFT_SORT_NODES) ? ths->index_x[2*k+1] : k;
-      INT l;
 
       {
-        const R fg_nx = (R)(n0) * ths->x[2*j];
-        FG_RUN(psij_const + 0, 2*m+2, ths->psi[2*j*2], ths->psi[2*j*2+1],
-            fg_e[0], fg_q[0], fg_centre(fg_nx, m));
+        FG_RUN(psij_const, m, FABS(ths->psi[2*j*2]), ths->psi[2*j*2+1],
+            fg_e[0], fg_q[0]);
+        psij0 = FG_RUN_START(psij_const, ths->psi[2*j*2]);
       }
 
       {
-        const R fg_nx = (R)(n1) * ths->x[2*j+1];
-        FG_RUN(psij_const + 2*m+2, 2*m+2, ths->psi[2*(j*2+1)], ths->psi[2*(j*2+1)+1],
-            fg_e[1], fg_q[1], fg_centre(fg_nx, m));
+        FG_RUN(psij_const + 2*m+3, m, FABS(ths->psi[2*(j*2+1)]), ths->psi[2*(j*2+1)+1],
+            fg_e[1], fg_q[1]);
+        psij1 = FG_RUN_START(psij_const + 2*m+3, ths->psi[2*(j*2+1)]);
       }
 
-      nfft_trafo_2d_compute(ths->f+j, g, psij_const, psij_const+2*m+2, ths->x+2*j, ths->x+2*j+1, n0, n1, m);
+      nfft_trafo_2d_compute(ths->f+j, g, psij0, psij1, ths->x+2*j, ths->x+2*j+1, n0, n1, m);
     }
 
     return;
@@ -3405,31 +3400,31 @@ static void nfft_trafo_2d_B(X(plan) *ths)
 #endif
     for (k = 0; k < M; k++)
     {
-      INT u, o, l;
-      R psij_const[2*(2*m+2)];
+      R psij_const[2*(2*m+3)];
+      const R *psij0, *psij1;
       INT j = (ths->flags & NFFT_SORT_NODES) ? ths->index_x[2*k+1] : k;
 
-      uo(ths, j, &u, &o, (INT)0);
       {
         const R fg_nx = (R)(n0) * ths->x[2*j];
-        const R fg_d = fg_nx - (R)LRINT(fg_nx);
-        FG_RUN(psij_const + 0, 2*m+2,
+        const R fg_d = fg_nx - FLOOR(fg_nx + K(0.5));
+        FG_RUN(psij_const, m,
             (PHI(ths->n[0], fg_d / (R)(n0), 0)),
             EXP(K(2.0) * fg_d / ths->b[0]),
-            fg_e[0], fg_q[0], fg_centre(fg_nx, m));
+            fg_e[0], fg_q[0]);
+        psij0 = FG_RUN_START(psij_const, fg_d);
       }
 
-      uo(ths,j,&u,&o, (INT)1);
       {
         const R fg_nx = (R)(n1) * ths->x[2*j+1];
-        const R fg_d = fg_nx - (R)LRINT(fg_nx);
-        FG_RUN(psij_const + 2*m+2, 2*m+2,
+        const R fg_d = fg_nx - FLOOR(fg_nx + K(0.5));
+        FG_RUN(psij_const + 2*m+3, m,
             (PHI(ths->n[1], fg_d / (R)(n1), 1)),
             EXP(K(2.0) * fg_d / ths->b[1]),
-            fg_e[1], fg_q[1], fg_centre(fg_nx, m));
+            fg_e[1], fg_q[1]);
+        psij1 = FG_RUN_START(psij_const + 2*m+3, fg_d);
       }
 
-      nfft_trafo_2d_compute(ths->f+j, g, psij_const, psij_const+2*m+2, ths->x+2*j, ths->x+2*j+1, n0, n1, m);
+      nfft_trafo_2d_compute(ths->f+j, g, psij0, psij1, ths->x+2*j, ths->x+2*j+1, n0, n1, m);
     }
 
     return;
@@ -3501,53 +3496,53 @@ static void nfft_trafo_2d_B(X(plan) *ths)
 
 #define MACRO_adjoint_2d_B_OMP_BLOCKWISE_COMPUTE_PRE_FG_PSI \
 { \
-            R psij_const[2*(2*m+2)]; \
-            INT l; \
+            R psij_const[2*(2*m+3)]; \
+            const R *psij0, *psij1; \
  \
             { \
-              const R fg_nx = (R)(n0) * ths->x[2*j]; \
-              FG_RUN(psij_const + 0, 2*m+2, ths->psi[2*j*2], ths->psi[2*j*2+1], \
-                  fg_e[0], fg_q[0], fg_centre(fg_nx, m)); \
+              FG_RUN(psij_const, m, FABS(ths->psi[2*j*2]), ths->psi[2*j*2+1], \
+                  fg_e[0], fg_q[0]); \
+              psij0 = FG_RUN_START(psij_const, ths->psi[2*j*2]); \
             } \
  \
             { \
-              const R fg_nx = (R)(n1) * ths->x[2*j+1]; \
-              FG_RUN(psij_const + 2*m+2, 2*m+2, ths->psi[2*(j*2+1)], ths->psi[2*(j*2+1)+1], \
-                  fg_e[1], fg_q[1], fg_centre(fg_nx, m)); \
+              FG_RUN(psij_const + 2*m+3, m, FABS(ths->psi[2*(j*2+1)]), ths->psi[2*(j*2+1)+1], \
+                  fg_e[1], fg_q[1]); \
+              psij1 = FG_RUN_START(psij_const + 2*m+3, ths->psi[2*(j*2+1)]); \
             } \
  \
             nfft_adjoint_2d_compute_omp_blockwise(ths->f[j], g, \
-                psij_const, psij_const+2*m+2, ths->x+2*j, ths->x+2*j+1, \
+                psij0, psij1, ths->x+2*j, ths->x+2*j+1, \
                 n0, n1, m, my_u0, my_o0); \
 }
 
 #define MACRO_adjoint_2d_B_OMP_BLOCKWISE_COMPUTE_FG_PSI \
 { \
-            R psij_const[2*(2*m+2)]; \
-            INT u, o, l; \
+            R psij_const[2*(2*m+3)]; \
+            const R *psij0, *psij1; \
  \
-            uo(ths,j,&u,&o,(INT)0); \
             { \
               const R fg_nx = (R)(n0) * ths->x[2*j]; \
-              const R fg_d = fg_nx - (R)LRINT(fg_nx); \
-              FG_RUN(psij_const + 0, 2*m+2, \
+              const R fg_d = fg_nx - FLOOR(fg_nx + K(0.5)); \
+              FG_RUN(psij_const, m, \
                   (PHI(ths->n[0], fg_d / (R)(n0), 0)), \
                   EXP(K(2.0) * fg_d / ths->b[0]), \
-                  fg_e[0], fg_q[0], fg_centre(fg_nx, m)); \
+                  fg_e[0], fg_q[0]); \
+              psij0 = FG_RUN_START(psij_const, fg_d); \
             } \
  \
-            uo(ths,j,&u,&o,(INT)1); \
             { \
               const R fg_nx = (R)(n1) * ths->x[2*j+1]; \
-              const R fg_d = fg_nx - (R)LRINT(fg_nx); \
-              FG_RUN(psij_const + 2*m+2, 2*m+2, \
+              const R fg_d = fg_nx - FLOOR(fg_nx + K(0.5)); \
+              FG_RUN(psij_const + 2*m+3, m, \
                   (PHI(ths->n[1], fg_d / (R)(n1), 1)), \
                   EXP(K(2.0) * fg_d / ths->b[1]), \
-                  fg_e[1], fg_q[1], fg_centre(fg_nx, m)); \
+                  fg_e[1], fg_q[1]); \
+              psij1 = FG_RUN_START(psij_const + 2*m+3, fg_d); \
             } \
  \
             nfft_adjoint_2d_compute_omp_blockwise(ths->f[j], g, \
-                psij_const, psij_const+2*m+2, ths->x+2*j, ths->x+2*j+1, \
+                psij0, psij1, ths->x+2*j, ths->x+2*j+1, \
                 n0, n1, m, my_u0, my_o0); \
 }
 
@@ -3708,26 +3703,26 @@ static void nfft_adjoint_2d_B(X(plan) *ths)
 #endif
     for (k = 0; k < M; k++)
     {
-      R psij_const[2*(2*m+2)];
+      R psij_const[2*(2*m+3)];
+      const R *psij0, *psij1;
       INT j = (ths->flags & NFFT_SORT_NODES) ? ths->index_x[2*k+1] : k;
-      INT l;
 
       {
-        const R fg_nx = (R)(n0) * ths->x[2*j];
-        FG_RUN(psij_const + 0, 2*m+2, ths->psi[2*j*2], ths->psi[2*j*2+1],
-            fg_e[0], fg_q[0], fg_centre(fg_nx, m));
+        FG_RUN(psij_const, m, FABS(ths->psi[2*j*2]), ths->psi[2*j*2+1],
+            fg_e[0], fg_q[0]);
+        psij0 = FG_RUN_START(psij_const, ths->psi[2*j*2]);
       }
 
       {
-        const R fg_nx = (R)(n1) * ths->x[2*j+1];
-        FG_RUN(psij_const + 2*m+2, 2*m+2, ths->psi[2*(j*2+1)], ths->psi[2*(j*2+1)+1],
-            fg_e[1], fg_q[1], fg_centre(fg_nx, m));
+        FG_RUN(psij_const + 2*m+3, m, FABS(ths->psi[2*(j*2+1)]), ths->psi[2*(j*2+1)+1],
+            fg_e[1], fg_q[1]);
+        psij1 = FG_RUN_START(psij_const + 2*m+3, ths->psi[2*(j*2+1)]);
       }
 
 #ifdef _OPENMP
-      nfft_adjoint_2d_compute_omp_atomic(ths->f[j], g, psij_const, psij_const+2*m+2, ths->x+2*j, ths->x+2*j+1, n0, n1, m);
+      nfft_adjoint_2d_compute_omp_atomic(ths->f[j], g, psij0, psij1, ths->x+2*j, ths->x+2*j+1, n0, n1, m);
 #else
-      nfft_adjoint_2d_compute_serial(ths->f+j, g, psij_const, psij_const+2*m+2, ths->x+2*j, ths->x+2*j+1, n0, n1, m);
+      nfft_adjoint_2d_compute_serial(ths->f+j, g, psij0, psij1, ths->x+2*j, ths->x+2*j+1, n0, n1, m);
 #endif
     }
 
@@ -3752,34 +3747,34 @@ static void nfft_adjoint_2d_B(X(plan) *ths)
 #endif
     for (k = 0; k < M; k++)
     {
-      INT u, o, l;
-      R psij_const[2*(2*m+2)];
+      R psij_const[2*(2*m+3)];
+      const R *psij0, *psij1;
       INT j = (ths->flags & NFFT_SORT_NODES) ? ths->index_x[2*k+1] : k;
 
-      uo(ths,j,&u,&o,(INT)0);
       {
         const R fg_nx = (R)(n0) * ths->x[2*j];
-        const R fg_d = fg_nx - (R)LRINT(fg_nx);
-        FG_RUN(psij_const + 0, 2*m+2,
+        const R fg_d = fg_nx - FLOOR(fg_nx + K(0.5));
+        FG_RUN(psij_const, m,
             (PHI(ths->n[0], fg_d / (R)(n0), 0)),
             EXP(K(2.0) * fg_d / ths->b[0]),
-            fg_e[0], fg_q[0], fg_centre(fg_nx, m));
+            fg_e[0], fg_q[0]);
+        psij0 = FG_RUN_START(psij_const, fg_d);
       }
 
-      uo(ths,j,&u,&o,(INT)1);
       {
         const R fg_nx = (R)(n1) * ths->x[2*j+1];
-        const R fg_d = fg_nx - (R)LRINT(fg_nx);
-        FG_RUN(psij_const + 2*m+2, 2*m+2,
+        const R fg_d = fg_nx - FLOOR(fg_nx + K(0.5));
+        FG_RUN(psij_const + 2*m+3, m,
             (PHI(ths->n[1], fg_d / (R)(n1), 1)),
             EXP(K(2.0) * fg_d / ths->b[1]),
-            fg_e[1], fg_q[1], fg_centre(fg_nx, m));
+            fg_e[1], fg_q[1]);
+        psij1 = FG_RUN_START(psij_const + 2*m+3, fg_d);
       }
 
 #ifdef _OPENMP
-      nfft_adjoint_2d_compute_omp_atomic(ths->f[j], g, psij_const, psij_const+2*m+2, ths->x+2*j, ths->x+2*j+1, n0, n1, m);
+      nfft_adjoint_2d_compute_omp_atomic(ths->f[j], g, psij0, psij1, ths->x+2*j, ths->x+2*j+1, n0, n1, m);
 #else
-      nfft_adjoint_2d_compute_serial(ths->f+j, g, psij_const, psij_const+2*m+2, ths->x+2*j, ths->x+2*j+1, n0, n1, m);
+      nfft_adjoint_2d_compute_serial(ths->f+j, g, psij0, psij1, ths->x+2*j, ths->x+2*j+1, n0, n1, m);
 #endif
     }
 
@@ -4782,28 +4777,28 @@ static void nfft_trafo_3d_B(X(plan) *ths)
     for (k = 0; k < M; k++)
     {
       INT j = (ths->flags & NFFT_SORT_NODES) ? ths->index_x[2*k+1] : k;
-      INT l;
-      R psij_const[3*(2*m+2)];
+      R psij_const[3*(2*m+3)];
+      const R *psij0, *psij1, *psij2;
 
       {
-        const R fg_nx = (R)(n0) * ths->x[3*j];
-        FG_RUN(psij_const + 0, 2*m+2, ths->psi[2*j*3], ths->psi[2*j*3+1],
-            fg_e[0], fg_q[0], fg_centre(fg_nx, m));
+        FG_RUN(psij_const, m, FABS(ths->psi[2*j*3]), ths->psi[2*j*3+1],
+            fg_e[0], fg_q[0]);
+        psij0 = FG_RUN_START(psij_const, ths->psi[2*j*3]);
       }
 
       {
-        const R fg_nx = (R)(n1) * ths->x[3*j+1];
-        FG_RUN(psij_const + 2*m+2, 2*m+2, ths->psi[2*(j*3+1)], ths->psi[2*(j*3+1)+1],
-            fg_e[1], fg_q[1], fg_centre(fg_nx, m));
+        FG_RUN(psij_const + 2*m+3, m, FABS(ths->psi[2*(j*3+1)]), ths->psi[2*(j*3+1)+1],
+            fg_e[1], fg_q[1]);
+        psij1 = FG_RUN_START(psij_const + 2*m+3, ths->psi[2*(j*3+1)]);
       }
 
       {
-        const R fg_nx = (R)(n2) * ths->x[3*j+2];
-        FG_RUN(psij_const + 2*(2*m+2), 2*m+2, ths->psi[2*(j*3+2)], ths->psi[2*(j*3+2)+1],
-            fg_e[2], fg_q[2], fg_centre(fg_nx, m));
+        FG_RUN(psij_const + 2*(2*m+3), m, FABS(ths->psi[2*(j*3+2)]), ths->psi[2*(j*3+2)+1],
+            fg_e[2], fg_q[2]);
+        psij2 = FG_RUN_START(psij_const + 2*(2*m+3), ths->psi[2*(j*3+2)]);
       }
 
-      nfft_trafo_3d_compute(ths->f+j, g, psij_const, psij_const+2*m+2, psij_const+(2*m+2)*2, ths->x+3*j, ths->x+3*j+1, ths->x+3*j+2, n0, n1, n2, m);
+      nfft_trafo_3d_compute(ths->f+j, g, psij0, psij1, psij2, ths->x+3*j, ths->x+3*j+1, ths->x+3*j+2, n0, n1, n2, m);
     }
 
     return;
@@ -4825,40 +4820,40 @@ static void nfft_trafo_3d_B(X(plan) *ths)
     for (k = 0; k < M; k++)
     {
       INT j = (ths->flags & NFFT_SORT_NODES) ? ths->index_x[2*k+1] : k;
-      INT u, o, l;
-      R psij_const[3*(2*m+2)];
+      R psij_const[3*(2*m+3)];
+      const R *psij0, *psij1, *psij2;
 
-      uo(ths,j,&u,&o,(INT)0);
       {
         const R fg_nx = (R)(n0) * ths->x[3*j];
-        const R fg_d = fg_nx - (R)LRINT(fg_nx);
-        FG_RUN(psij_const + 0, 2*m+2,
+        const R fg_d = fg_nx - FLOOR(fg_nx + K(0.5));
+        FG_RUN(psij_const, m,
             (PHI(ths->n[0], fg_d / (R)(n0), 0)),
             EXP(K(2.0) * fg_d / ths->b[0]),
-            fg_e[0], fg_q[0], fg_centre(fg_nx, m));
+            fg_e[0], fg_q[0]);
+        psij0 = FG_RUN_START(psij_const, fg_d);
       }
 
-      uo(ths,j,&u,&o,(INT)1);
       {
         const R fg_nx = (R)(n1) * ths->x[3*j+1];
-        const R fg_d = fg_nx - (R)LRINT(fg_nx);
-        FG_RUN(psij_const + 2*m+2, 2*m+2,
+        const R fg_d = fg_nx - FLOOR(fg_nx + K(0.5));
+        FG_RUN(psij_const + 2*m+3, m,
             (PHI(ths->n[1], fg_d / (R)(n1), 1)),
             EXP(K(2.0) * fg_d / ths->b[1]),
-            fg_e[1], fg_q[1], fg_centre(fg_nx, m));
+            fg_e[1], fg_q[1]);
+        psij1 = FG_RUN_START(psij_const + 2*m+3, fg_d);
       }
 
-      uo(ths,j,&u,&o,(INT)2);
       {
         const R fg_nx = (R)(n2) * ths->x[3*j+2];
-        const R fg_d = fg_nx - (R)LRINT(fg_nx);
-        FG_RUN(psij_const + 2*(2*m+2), 2*m+2,
+        const R fg_d = fg_nx - FLOOR(fg_nx + K(0.5));
+        FG_RUN(psij_const + 2*(2*m+3), m,
             (PHI(ths->n[2], fg_d / (R)(n2), 2)),
             EXP(K(2.0) * fg_d / ths->b[2]),
-            fg_e[2], fg_q[2], fg_centre(fg_nx, m));
+            fg_e[2], fg_q[2]);
+        psij2 = FG_RUN_START(psij_const + 2*(2*m+3), fg_d);
       }
 
-      nfft_trafo_3d_compute(ths->f+j, g, psij_const, psij_const+2*m+2, psij_const+(2*m+2)*2, ths->x+3*j, ths->x+3*j+1, ths->x+3*j+2, n0, n1, n2, m);
+      nfft_trafo_3d_compute(ths->f+j, g, psij0, psij1, psij2, ths->x+3*j, ths->x+3*j+1, ths->x+3*j+2, n0, n1, n2, m);
     }
 
     return;
@@ -4946,70 +4941,70 @@ static void nfft_trafo_3d_B(X(plan) *ths)
 
 #define MACRO_adjoint_3d_B_OMP_BLOCKWISE_COMPUTE_PRE_FG_PSI \
 { \
-            INT l; \
-            R psij_const[3*(2*m+2)]; \
+            R psij_const[3*(2*m+3)]; \
+            const R *psij0, *psij1, *psij2; \
  \
             { \
-              const R fg_nx = (R)(n0) * ths->x[3*j]; \
-              FG_RUN(psij_const + 0, 2*m+2, ths->psi[2*j*3], ths->psi[2*j*3+1], \
-                  fg_e[0], fg_q[0], fg_centre(fg_nx, m)); \
+              FG_RUN(psij_const, m, FABS(ths->psi[2*j*3]), ths->psi[2*j*3+1], \
+                  fg_e[0], fg_q[0]); \
+              psij0 = FG_RUN_START(psij_const, ths->psi[2*j*3]); \
             } \
  \
             { \
-              const R fg_nx = (R)(n1) * ths->x[3*j+1]; \
-              FG_RUN(psij_const + 2*m+2, 2*m+2, ths->psi[2*(j*3+1)], ths->psi[2*(j*3+1)+1], \
-                  fg_e[1], fg_q[1], fg_centre(fg_nx, m)); \
+              FG_RUN(psij_const + 2*m+3, m, FABS(ths->psi[2*(j*3+1)]), ths->psi[2*(j*3+1)+1], \
+                  fg_e[1], fg_q[1]); \
+              psij1 = FG_RUN_START(psij_const + 2*m+3, ths->psi[2*(j*3+1)]); \
             } \
  \
             { \
-              const R fg_nx = (R)(n2) * ths->x[3*j+2]; \
-              FG_RUN(psij_const + 2*(2*m+2), 2*m+2, ths->psi[2*(j*3+2)], ths->psi[2*(j*3+2)+1], \
-                  fg_e[2], fg_q[2], fg_centre(fg_nx, m)); \
+              FG_RUN(psij_const + 2*(2*m+3), m, FABS(ths->psi[2*(j*3+2)]), ths->psi[2*(j*3+2)+1], \
+                  fg_e[2], fg_q[2]); \
+              psij2 = FG_RUN_START(psij_const + 2*(2*m+3), ths->psi[2*(j*3+2)]); \
             } \
  \
             nfft_adjoint_3d_compute_omp_blockwise(ths->f[j], g, \
-                psij_const, psij_const+2*m+2, psij_const+(2*m+2)*2, \
+                psij0, psij1, psij2, \
                 ths->x+3*j, ths->x+3*j+1, ths->x+3*j+2, \
                 n0, n1, n2, m, my_u0, my_o0); \
 }
 
 #define MACRO_adjoint_3d_B_OMP_BLOCKWISE_COMPUTE_FG_PSI \
 { \
-            INT u, o, l; \
-            R psij_const[3*(2*m+2)]; \
+            R psij_const[3*(2*m+3)]; \
+            const R *psij0, *psij1, *psij2; \
  \
-            uo(ths,j,&u,&o,(INT)0); \
             { \
               const R fg_nx = (R)(n0) * ths->x[3*j]; \
-              const R fg_d = fg_nx - (R)LRINT(fg_nx); \
-              FG_RUN(psij_const + 0, 2*m+2, \
+              const R fg_d = fg_nx - FLOOR(fg_nx + K(0.5)); \
+              FG_RUN(psij_const, m, \
                   (PHI(ths->n[0], fg_d / (R)(n0), 0)), \
                   EXP(K(2.0) * fg_d / ths->b[0]), \
-                  fg_e[0], fg_q[0], fg_centre(fg_nx, m)); \
+                  fg_e[0], fg_q[0]); \
+              psij0 = FG_RUN_START(psij_const, fg_d); \
             } \
  \
-            uo(ths,j,&u,&o,(INT)1); \
             { \
               const R fg_nx = (R)(n1) * ths->x[3*j+1]; \
-              const R fg_d = fg_nx - (R)LRINT(fg_nx); \
-              FG_RUN(psij_const + 2*m+2, 2*m+2, \
+              const R fg_d = fg_nx - FLOOR(fg_nx + K(0.5)); \
+              FG_RUN(psij_const + 2*m+3, m, \
                   (PHI(ths->n[1], fg_d / (R)(n1), 1)), \
                   EXP(K(2.0) * fg_d / ths->b[1]), \
-                  fg_e[1], fg_q[1], fg_centre(fg_nx, m)); \
+                  fg_e[1], fg_q[1]); \
+              psij1 = FG_RUN_START(psij_const + 2*m+3, fg_d); \
             } \
  \
-            uo(ths,j,&u,&o,(INT)2); \
             { \
               const R fg_nx = (R)(n2) * ths->x[3*j+2]; \
-              const R fg_d = fg_nx - (R)LRINT(fg_nx); \
-              FG_RUN(psij_const + 2*(2*m+2), 2*m+2, \
+              const R fg_d = fg_nx - FLOOR(fg_nx + K(0.5)); \
+              FG_RUN(psij_const + 2*(2*m+3), m, \
                   (PHI(ths->n[2], fg_d / (R)(n2), 2)), \
                   EXP(K(2.0) * fg_d / ths->b[2]), \
-                  fg_e[2], fg_q[2], fg_centre(fg_nx, m)); \
+                  fg_e[2], fg_q[2]); \
+              psij2 = FG_RUN_START(psij_const + 2*(2*m+3), fg_d); \
             } \
  \
             nfft_adjoint_3d_compute_omp_blockwise(ths->f[j], g, \
-                psij_const, psij_const+2*m+2, psij_const+(2*m+2)*2, \
+                psij0, psij1, psij2, \
                 ths->x+3*j, ths->x+3*j+1, ths->x+3*j+2, \
                 n0, n1, n2, m, my_u0, my_o0); \
 }
@@ -5185,32 +5180,32 @@ static void nfft_adjoint_3d_B(X(plan) *ths)
 #endif
     for (k = 0; k < M; k++)
     {
-      R psij_const[3*(2*m+2)];
+      R psij_const[3*(2*m+3)];
+      const R *psij0, *psij1, *psij2;
       INT j = (ths->flags & NFFT_SORT_NODES) ? ths->index_x[2*k+1] : k;
-      INT l;
 
       {
-        const R fg_nx = (R)(n0) * ths->x[3*j];
-        FG_RUN(psij_const + 0, 2*m+2, ths->psi[2*j*3], ths->psi[2*j*3+1],
-            fg_e[0], fg_q[0], fg_centre(fg_nx, m));
+        FG_RUN(psij_const, m, FABS(ths->psi[2*j*3]), ths->psi[2*j*3+1],
+            fg_e[0], fg_q[0]);
+        psij0 = FG_RUN_START(psij_const, ths->psi[2*j*3]);
       }
 
       {
-        const R fg_nx = (R)(n1) * ths->x[3*j+1];
-        FG_RUN(psij_const + 2*m+2, 2*m+2, ths->psi[2*(j*3+1)], ths->psi[2*(j*3+1)+1],
-            fg_e[1], fg_q[1], fg_centre(fg_nx, m));
+        FG_RUN(psij_const + 2*m+3, m, FABS(ths->psi[2*(j*3+1)]), ths->psi[2*(j*3+1)+1],
+            fg_e[1], fg_q[1]);
+        psij1 = FG_RUN_START(psij_const + 2*m+3, ths->psi[2*(j*3+1)]);
       }
 
       {
-        const R fg_nx = (R)(n2) * ths->x[3*j+2];
-        FG_RUN(psij_const + 2*(2*m+2), 2*m+2, ths->psi[2*(j*3+2)], ths->psi[2*(j*3+2)+1],
-            fg_e[2], fg_q[2], fg_centre(fg_nx, m));
+        FG_RUN(psij_const + 2*(2*m+3), m, FABS(ths->psi[2*(j*3+2)]), ths->psi[2*(j*3+2)+1],
+            fg_e[2], fg_q[2]);
+        psij2 = FG_RUN_START(psij_const + 2*(2*m+3), ths->psi[2*(j*3+2)]);
       }
 
 #ifdef _OPENMP
-      nfft_adjoint_3d_compute_omp_atomic(ths->f[j], g, psij_const, psij_const+2*m+2, psij_const+(2*m+2)*2, ths->x+3*j, ths->x+3*j+1, ths->x+3*j+2, n0, n1, n2, m);
+      nfft_adjoint_3d_compute_omp_atomic(ths->f[j], g, psij0, psij1, psij2, ths->x+3*j, ths->x+3*j+1, ths->x+3*j+2, n0, n1, n2, m);
 #else
-      nfft_adjoint_3d_compute_serial(ths->f+j, g, psij_const, psij_const+2*m+2, psij_const+(2*m+2)*2, ths->x+3*j, ths->x+3*j+1, ths->x+3*j+2, n0, n1, n2, m);
+      nfft_adjoint_3d_compute_serial(ths->f+j, g, psij0, psij1, psij2, ths->x+3*j, ths->x+3*j+1, ths->x+3*j+2, n0, n1, n2, m);
 #endif
     }
 
@@ -5236,44 +5231,44 @@ static void nfft_adjoint_3d_B(X(plan) *ths)
 #endif
     for (k = 0; k < M; k++)
     {
-      INT u,o,l;
       INT j = (ths->flags & NFFT_SORT_NODES) ? ths->index_x[2*k+1] : k;
-      R psij_const[3*(2*m+2)];
+      R psij_const[3*(2*m+3)];
+      const R *psij0, *psij1, *psij2;
 
-      uo(ths,j,&u,&o,(INT)0);
       {
         const R fg_nx = (R)(n0) * ths->x[3*j];
-        const R fg_d = fg_nx - (R)LRINT(fg_nx);
-        FG_RUN(psij_const + 0, 2*m+2,
+        const R fg_d = fg_nx - FLOOR(fg_nx + K(0.5));
+        FG_RUN(psij_const, m,
             (PHI(ths->n[0], fg_d / (R)(n0), 0)),
             EXP(K(2.0) * fg_d / ths->b[0]),
-            fg_e[0], fg_q[0], fg_centre(fg_nx, m));
+            fg_e[0], fg_q[0]);
+        psij0 = FG_RUN_START(psij_const, fg_d);
       }
 
-      uo(ths,j,&u,&o,(INT)1);
       {
         const R fg_nx = (R)(n1) * ths->x[3*j+1];
-        const R fg_d = fg_nx - (R)LRINT(fg_nx);
-        FG_RUN(psij_const + 2*m+2, 2*m+2,
+        const R fg_d = fg_nx - FLOOR(fg_nx + K(0.5));
+        FG_RUN(psij_const + 2*m+3, m,
             (PHI(ths->n[1], fg_d / (R)(n1), 1)),
             EXP(K(2.0) * fg_d / ths->b[1]),
-            fg_e[1], fg_q[1], fg_centre(fg_nx, m));
+            fg_e[1], fg_q[1]);
+        psij1 = FG_RUN_START(psij_const + 2*m+3, fg_d);
       }
 
-      uo(ths,j,&u,&o,(INT)2);
       {
         const R fg_nx = (R)(n2) * ths->x[3*j+2];
-        const R fg_d = fg_nx - (R)LRINT(fg_nx);
-        FG_RUN(psij_const + 2*(2*m+2), 2*m+2,
+        const R fg_d = fg_nx - FLOOR(fg_nx + K(0.5));
+        FG_RUN(psij_const + 2*(2*m+3), m,
             (PHI(ths->n[2], fg_d / (R)(n2), 2)),
             EXP(K(2.0) * fg_d / ths->b[2]),
-            fg_e[2], fg_q[2], fg_centre(fg_nx, m));
+            fg_e[2], fg_q[2]);
+        psij2 = FG_RUN_START(psij_const + 2*(2*m+3), fg_d);
       }
 
 #ifdef _OPENMP
-      nfft_adjoint_3d_compute_omp_atomic(ths->f[j], g, psij_const, psij_const+2*m+2, psij_const+(2*m+2)*2, ths->x+3*j, ths->x+3*j+1, ths->x+3*j+2, n0, n1, n2, m);
+      nfft_adjoint_3d_compute_omp_atomic(ths->f[j], g, psij0, psij1, psij2, ths->x+3*j, ths->x+3*j+1, ths->x+3*j+2, n0, n1, n2, m);
 #else
-      nfft_adjoint_3d_compute_serial(ths->f+j, g, psij_const, psij_const+2*m+2, psij_const+(2*m+2)*2, ths->x+3*j, ths->x+3*j+1, ths->x+3*j+2, n0, n1, n2, m);
+      nfft_adjoint_3d_compute_serial(ths->f+j, g, psij0, psij1, psij2, ths->x+3*j, ths->x+3*j+1, ths->x+3*j+2, n0, n1, n2, m);
 #endif
     }
 
@@ -5777,7 +5772,6 @@ void X(precompute_lin_psi)(X(plan) *ths)
 void X(precompute_fg_psi)(X(plan) *ths)
 {
   INT t;                                /**< index over all dimensions       */
-  INT u, o;                             /**< depends on x_j                  */
 
   sort(ths);
 
@@ -5785,21 +5779,20 @@ void X(precompute_fg_psi)(X(plan) *ths)
   {
     INT j;
 #ifdef _OPENMP
-    #pragma omp parallel for default(shared) private(j,u,o)
+    #pragma omp parallel for default(shared) private(j)
 #endif
     for (j = 0; j < ths->M_total; j++)
       {
-  uo(ths,j,&u,&o,t);
+        /* anchored at the grid point nearest the node, offset d from it. The
+         * seed carries the sign of d, which is all FG_RUN_START needs to
+         * place the run; a node on a grid point has d = 0 and a positive
+         * seed. FLOOR rather than LRINT keeps this loop vectorisable. */
+        const R nx = (R)(ths->n[t]) * ths->x[j*ths->d+t];
+        const R d = nx - FLOOR(nx + K(0.5));
+        const R seed = (PHI(ths->n[t], d / (R)(ths->n[t]), t));
 
-        /* anchored at the grid point nearest the node; the run index of that
-         * point follows from x, so only the offset d is stored */
-        {
-          const R nx = (R)(ths->n[t]) * ths->x[j*ths->d+t];
-          const R d = nx - (R)LRINT(nx);
-
-          ths->psi[2*(j*ths->d+t)] = (PHI(ths->n[t], d / (R)(ths->n[t]), t));
-          ths->psi[2*(j*ths->d+t)+1] = EXP(K(2.0) * d / ths->b[t]);
-        }
+        ths->psi[2*(j*ths->d+t)] = (d < K(0.0)) ? -seed : seed;
+        ths->psi[2*(j*ths->d+t)+1] = EXP(K(2.0) * d / ths->b[t]);
       } /* for(j) */
   }
   /* for(t) */

--- a/kernel/nfst/nfst.c
+++ b/kernel/nfst/nfst.c
@@ -82,8 +82,8 @@ static inline R X(reduced_omega)(const R k, const R x)
 }
 
 /* uo() anchors the run at the grid point nearest the node, run index m,
- * which FG_RUN puts at buffer index m + 1 */
-#define MACRO_with_FG_PSI fg_psi[t][lj[t] + 1]
+ * which FG_RUN puts at buffer index m + 2 for a fill based at fg_psi[t] + 1 */
+#define MACRO_with_FG_PSI fg_psi[t][lj[t] + 2]
 #define MACRO_with_LIN_PSI fg_psi[t][lj[t]]
 #define MACRO_with_PRE_PSI ths->psi[(j * ths->d + t) * (2 * ths->m + 2) + lj[t]]
 #define MACRO_without_PRE_PSI PHI((2 * NN(ths->n[t])), ((ths->x[(j) * ths->d + t]) \
@@ -583,7 +583,10 @@ static inline void B_ ## which_one (X(plan) *ths) \
   R *f, *g; /* local copy */ \
   R *fj; /* local copy */ \
   R y[ths->d]; \
-  R fg_psi[ths->d][2*ths->m+3]; \
+  /* 2m+4, not the 2m+3 FG_RUN fills: an even row stride and an even offset \
+   * to the used run keep the read base of the l_L loop aligned as it was \
+   * before the run gained its extra point. */ \
+  R fg_psi[ths->d][2*ths->m+4]; \
   R fg_e[ths->d], fg_q[ths->d]; \
   INT l_fg,lj_fg; \
   R ip_w; \
@@ -646,7 +649,7 @@ static inline void B_ ## which_one (X(plan) *ths) \
  \
       for (t = 0; t < ths->d; t++) \
       { \
-        FG_RUN(fg_psi[t], ths->m, ths->psi[2 * (j * ths->d + t)], \
+        FG_RUN(fg_psi[t] + 1, ths->m, ths->psi[2 * (j * ths->d + t)], \
             ths->psi[2 * (j * ths->d + t) + 1], fg_e[t], fg_q[t]); \
       } \
  \
@@ -677,7 +680,7 @@ static inline void B_ ## which_one (X(plan) *ths) \
       for (t = 0; t < ths->d; t++) \
       { \
         const INT fg_c = u[t] + ths->m; \
-        FG_RUN(fg_psi[t], ths->m, \
+        FG_RUN(fg_psi[t] + 1, ths->m, \
             (PHI((2 * NN(ths->n[t])), (ths->x[j*ths->d+t] - ((R)fg_c)/(2 * NN(ths->n[t]))),(t))), \
             EXP(K(2.0) * ((2 * NN(ths->n[t])) * ths->x[j * ths->d + t] - fg_c) / ths->b[t]), \
             fg_e[t], fg_q[t]); \

--- a/kernel/nfst/nfst.c
+++ b/kernel/nfst/nfst.c
@@ -81,7 +81,10 @@ static inline R X(reduced_omega)(const R k, const R x)
   return K2PI * FFMA(k, x, -n); // Calculate k * x - n with a single rounding, then multiply 2 * pi.
 }
 
-#define MACRO_with_FG_PSI fg_psi[t][lj[t]]
+/* uo() anchors the run at the grid point nearest the node, run index m,
+ * which FG_RUN puts at buffer index m + 1 */
+#define MACRO_with_FG_PSI fg_psi[t][lj[t] + 1]
+#define MACRO_with_LIN_PSI fg_psi[t][lj[t]]
 #define MACRO_with_PRE_PSI ths->psi[(j * ths->d + t) * (2 * ths->m + 2) + lj[t]]
 #define MACRO_without_PRE_PSI PHI((2 * NN(ths->n[t])), ((ths->x[(j) * ths->d + t]) \
   - ((R)(lj[t] + u[t])) / (K(2.0) * ((R)NN(ths->n[t])))), t)
@@ -580,7 +583,7 @@ static inline void B_ ## which_one (X(plan) *ths) \
   R *f, *g; /* local copy */ \
   R *fj; /* local copy */ \
   R y[ths->d]; \
-  R fg_psi[ths->d][2*ths->m+2]; \
+  R fg_psi[ths->d][2*ths->m+3]; \
   R fg_e[ths->d], fg_q[ths->d]; \
   INT l_fg,lj_fg; \
   R ip_w; \
@@ -643,8 +646,8 @@ static inline void B_ ## which_one (X(plan) *ths) \
  \
       for (t = 0; t < ths->d; t++) \
       { \
-        FG_RUN(fg_psi[t], 2 * ths->m + 2, ths->psi[2 * (j * ths->d + t)], \
-            ths->psi[2 * (j * ths->d + t) + 1], fg_e[t], fg_q[t], ths->m); \
+        FG_RUN(fg_psi[t], ths->m, ths->psi[2 * (j * ths->d + t)], \
+            ths->psi[2 * (j * ths->d + t) + 1], fg_e[t], fg_q[t]); \
       } \
  \
       for (l_L= 0; l_L < lprod; l_L++) \
@@ -674,10 +677,10 @@ static inline void B_ ## which_one (X(plan) *ths) \
       for (t = 0; t < ths->d; t++) \
       { \
         const INT fg_c = u[t] + ths->m; \
-        FG_RUN(fg_psi[t], 2 * ths->m + 2, \
+        FG_RUN(fg_psi[t], ths->m, \
             (PHI((2 * NN(ths->n[t])), (ths->x[j*ths->d+t] - ((R)fg_c)/(2 * NN(ths->n[t]))),(t))), \
             EXP(K(2.0) * ((2 * NN(ths->n[t])) * ths->x[j * ths->d + t] - fg_c) / ths->b[t]), \
-            fg_e[t], fg_q[t], ths->m); \
+            fg_e[t], fg_q[t]); \
       } \
   \
       for (l_L = 0; l_L < lprod; l_L++) \
@@ -714,7 +717,7 @@ static inline void B_ ## which_one (X(plan) *ths) \
   \
       for (l_L = 0; l_L < lprod; l_L++) \
       { \
-        MACRO_update_phi_prod_ll_plain(which_one, with_FG_PSI); \
+        MACRO_update_phi_prod_ll_plain(which_one, with_LIN_PSI); \
  \
         MACRO_B_compute_ ## which_one; \
  \


### PR DESCRIPTION
A previous changed incurred a penalty on precomputation when using the Gaussian window. While the change improved accuracy, they made branch prediction more difficult and also prevented auto-vectorization through the use of LRINT. This resulted in slower precomputation. This PR avoids both so the performance should be comparable with the state before the accuracy optimization.