### PR TITLE
Fix the macOS OpenMP build and cover it in CI

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -72,6 +72,46 @@ jobs:
             openmp: 0
             build_octave: 0
             build_julia: 1
+          # GCC 16
+          - os: "macos-26"
+            compiler: "gcc-16"
+            window: "kaiserbessel"
+            precision_opt: ""
+            openmp: 0
+            build_octave: 0
+            build_julia: 1
+          # GCC 13, OpenMP
+          - os: "macos-26"
+            compiler: "gcc-13"
+            window: "kaiserbessel"
+            precision_opt: ""
+            openmp: 1
+            build_octave: 0
+            build_julia: 1
+          # GCC 14, OpenMP
+          - os: "macos-26"
+            compiler: "gcc-14"
+            window: "kaiserbessel"
+            precision_opt: ""
+            openmp: 1
+            build_octave: 0
+            build_julia: 1
+          # GCC 15, OpenMP
+          - os: "macos-26"
+            compiler: "gcc-15"
+            window: "kaiserbessel"
+            precision_opt: ""
+            openmp: 1
+            build_octave: 0
+            build_julia: 1
+          # GCC 16, OpenMP
+          - os: "macos-26"
+            compiler: "gcc-16"
+            window: "kaiserbessel"
+            precision_opt: ""
+            openmp: 1
+            build_octave: 0
+            build_julia: 1
     steps:    
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
       with:
@@ -89,6 +129,7 @@ jobs:
           cunit
           octave
           llvm
+          gcc
 
     - name: Set up Julia
       if: matrix.build_julia == '1' && matrix.precision_opt == ''

--- a/Makefile.am
+++ b/Makefile.am
@@ -60,7 +60,7 @@ libnfft3@PREC_SUFFIX@_la_LDFLAGS = -no-undefined -version-info @SHARED_VERSION_I
 
 if ENABLE_OPENMP
 libnfft3@PREC_SUFFIX@_threads_la_SOURCES =
-libnfft3@PREC_SUFFIX@_threads_la_LIBADD = kernel/libkernel_threads.la @fftw3_LIBS@ 
+libnfft3@PREC_SUFFIX@_threads_la_LIBADD = kernel/libkernel_threads.la @fftw3_LIBS@ @fftw3_LIBS_omp@
 libnfft3@PREC_SUFFIX@_threads_la_LDFLAGS = -no-undefined -version-info @SHARED_VERSION_INFO@ $(OPENMP_CFLAGS) @fftw3_LDFLAGS@
 libnfft3@PREC_SUFFIX@_threads_la_CFLAGS = $(OPENMP_CFLAGS)
 

--- a/kernel/nfft/nfft.c
+++ b/kernel/nfft/nfft.c
@@ -2268,6 +2268,9 @@ static void nfft_adjoint_1d_compute_omp_blockwise(const C f, C *g,
 }
 #endif
 
+/* Window buffers come from the heap, once per thread: GCC 13 and newer abort
+ * expanding this function's OpenMP regions on aarch64-apple-darwin when they
+ * hold a run-time sized stack array. */
 static void nfft_trafo_1d_B(X(plan) *ths)
 {
   const INT n = ths->n[0], M = ths->M_total, m = ths->m, m2p2 = 2*m+2;
@@ -2307,18 +2310,22 @@ static void nfft_trafo_1d_B(X(plan) *ths)
 
   if (ths->flags & PRE_FG_PSI)
   {
-    INT k;
     R fg_e[1], fg_q[1];
 
     nfft_init_fg(&fg_e[0], &fg_q[0], ths->b[0]);
 
 #ifdef _OPENMP
-    #pragma omp parallel for default(shared) private(k)
+    #pragma omp parallel default(shared)
+#endif
+    {
+    INT k;
+    R *psij_const = (R*)Y(malloc)((size_t)(m2p2) * sizeof(R));
+#ifdef _OPENMP
+    #pragma omp for
 #endif
     for (k = 0; k < M; k++)
     {
       INT j = (ths->flags & NFFT_SORT_NODES) ? ths->index_x[2*k+1] : k;
-      R psij_const[m2p2];
       INT l;
 
       {
@@ -2329,13 +2336,14 @@ static void nfft_trafo_1d_B(X(plan) *ths)
 
       nfft_trafo_1d_compute(&ths->f[j], g, psij_const, &ths->x[j], n, m);
     }
+    Y(free)(psij_const);
+    }
 
     return;
   } /* if(PRE_FG_PSI) */
 
   if (ths->flags & FG_PSI)
   {
-    INT k;
     R fg_e[1], fg_q[1];
 
     sort(ths);
@@ -2343,13 +2351,18 @@ static void nfft_trafo_1d_B(X(plan) *ths)
     nfft_init_fg(&fg_e[0], &fg_q[0], ths->b[0]);
 
 #ifdef _OPENMP
-    #pragma omp parallel for default(shared) private(k)
+    #pragma omp parallel default(shared)
+#endif
+    {
+    INT k;
+    R *psij_const = (R*)Y(malloc)((size_t)(m2p2) * sizeof(R));
+#ifdef _OPENMP
+    #pragma omp for
 #endif
     for (k = 0; k < M; k++)
     {
       INT j = (ths->flags & NFFT_SORT_NODES) ? ths->index_x[2*k+1] : k;
       INT u, o, l;
-      R psij_const[m2p2];
 
       uo(ths, (INT)j, &u, &o, (INT)0);
 
@@ -2364,25 +2377,31 @@ static void nfft_trafo_1d_B(X(plan) *ths)
 
       nfft_trafo_1d_compute(&ths->f[j], g, psij_const, &ths->x[j], n, m);
     }
+    Y(free)(psij_const);
+    }
     return;
   } /* if(FG_PSI) */
 
   if (ths->flags & PRE_LIN_PSI)
   {
     const INT K = ths->K, ip_s = K / (m + 2);
-    INT k;
 
     sort(ths);
 
 #ifdef _OPENMP
-    #pragma omp parallel for default(shared) private(k)
+    #pragma omp parallel default(shared)
+#endif
+    {
+    INT k;
+    R *psij_const = (R*)Y(malloc)((size_t)(m2p2) * sizeof(R));
+#ifdef _OPENMP
+    #pragma omp for
 #endif
     for (k = 0; k < M; k++)
     {
       INT u, o, l;
       R ip_y, ip_w;
       INT ip_u;
-      R psij_const[m2p2];
       INT j = (ths->flags & NFFT_SORT_NODES) ? ths->index_x[2*k+1] : k;
 
       uo(ths, (INT)j, &u, &o, (INT)0);
@@ -2397,21 +2416,27 @@ static void nfft_trafo_1d_B(X(plan) *ths)
 
       nfft_trafo_1d_compute(&ths->f[j], g, psij_const, &ths->x[j], n, m);
     }
+    Y(free)(psij_const);
+    }
     return;
   } /* if(PRE_LIN_PSI) */
   else
   {
     /* no precomputed psi at all */
-    INT k;
 
     sort(ths);
 
 #ifdef _OPENMP
-    #pragma omp parallel for default(shared) private(k)
+    #pragma omp parallel default(shared)
+#endif
+    {
+    INT k;
+    R *psij_const = (R*)Y(malloc)((size_t)(m2p2) * sizeof(R));
+#ifdef _OPENMP
+    #pragma omp for
 #endif
     for (k = 0; k < M; k++)
     {
-      R psij_const[m2p2];
       INT u, o;
       INT j = (ths->flags & NFFT_SORT_NODES) ? ths->index_x[2*k+1] : k;
 
@@ -2420,6 +2445,8 @@ static void nfft_trafo_1d_B(X(plan) *ths)
       PHI_RUN(psij_const, ths->n[0], ths->x[j], u, 0);
 
       nfft_trafo_1d_compute(&ths->f[j], g, psij_const, &ths->x[j], n, m);
+    }
+    Y(free)(psij_const);
     }
   }
 }


### PR DESCRIPTION
This PR pulls together three changes:

**Link fix.** `libnfft3_threads` linked without the threaded FFTW, so every macOS OpenMP build failed with undefined `_fftw_plan_with_nthreads`. `Makefile.am:63` now carries `@fftw3_LIBS_omp@`, as `release/3.6.0` already does via `6d3d0bb0`.

**Compiler workaround.** `nfft_trafo_1d_B` held run-time sized stack arrays inside OpenMP node loops. GCC 13 to 16 abort on aarch64-apple-darwin:

```
during GIMPLE pass: ompexp
internal compiler error: in make_ssa_name_fn, at tree-ssanames.cc:355
```

The four node loops now take `psij_const` from the heap once per thread. Same change as #270.

**CI.** Enable OpenMP path in the macOS matrix gcc-13 to gcc-16.