### PR TITLE
Have infft.h include its own config.h.

### DIFF
--- a/include/infft.h
+++ b/include/infft.h
@@ -22,7 +22,7 @@
 #ifndef __INFFT_H__
 #define __INFFT_H__
 
-#include "config.h"
+#include <config.h>
 
 #include <math.h>
 #include <float.h>


### PR DESCRIPTION
`infft.h` included `config.h` with quotes, which makes the preprocessor search the directory of infft.h itself (`include/`) before falling back to the compiler's `-I` search path. This is a problem for the CMake build: an in-tree Autotools configure writes `include/config.h` right next to `infft.h`. If that file is still present, a subsequent CMake build picks it up first via the quote-include rule instead of using its own generated `config.h`, silently building against the wrong precision/feature macros. Switching to angle-bracket include removes that local-directory shortcut, so the `config.h` that wins is whichever directory is placed first on the include path `-I` list, which the build system controls explicitly.