### PR TITLE
Join the OpenMP worker pool when a Matlab mex file is unloaded.

### DIFF
--- a/matlab/args.c
+++ b/matlab/args.c
@@ -21,6 +21,20 @@
 #include "infft.h"
 #include "imex.h"
 
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+/* Join the OpenMP worker pool before the mex image, and with it libgomp, is
+ * unloaded. Parked workers otherwise run their exit handlers in unmapped
+ * memory. */
+void nfft_mex_pause_threads(void)
+{
+#if defined(_OPENMP) && _OPENMP >= 201811
+  omp_pause_resource_all(omp_pause_hard);
+#endif
+}
+
 int nfft_mex_get_int(const mxArray *p, const char *errmsg)
 {
   DM(if (!mxIsDouble(p) || mxIsComplex(p) || mxGetM(p) != 1 || mxGetN(p) != 1)

--- a/matlab/fastsum/fastsummex.c
+++ b/matlab/fastsum/fastsummex.c
@@ -180,6 +180,7 @@ static void cleanup(void)
       plans_num_allocated = 0;
     }
     gflags |= FASTSUM_MEX_FIRST_CALL;
+    nfft_mex_pause_threads();
   }
 }
 

--- a/matlab/fpt/fptmex.c
+++ b/matlab/fpt/fptmex.c
@@ -107,6 +107,7 @@ static void cleanup(void)
       sets_num_allocated = 0;
     }
     gflags |= FPT_MEX_FIRST_CALL;
+    nfft_mex_pause_threads();
     n_max = -1;
   }
 }

--- a/matlab/imex.h
+++ b/matlab/imex.h
@@ -44,6 +44,7 @@
 extern void *nfft_mex_malloc(size_t n);
 extern void nfft_mex_free(void *p);
 extern void nfft_mex_install_mem_hooks(void);
+extern void nfft_mex_pause_threads(void);
 
 int nfft_mex_get_int(const mxArray *p, const char *errmsg);
 double nfft_mex_get_double(const mxArray *p, const char *errmsg);

--- a/matlab/nfct/nfctmex.c
+++ b/matlab/nfct/nfctmex.c
@@ -111,6 +111,7 @@ static void cleanup(void)
       plans_num_allocated = 0;
     }
     gflags |= NFCT_MEX_FIRST_CALL;
+    nfft_mex_pause_threads();
   }
 }
 

--- a/matlab/nfft/nfftmex.c
+++ b/matlab/nfft/nfftmex.c
@@ -121,6 +121,7 @@ static void cleanup(void)
       plans_num_allocated = 0;
     }
     gflags |= NFFT_MEX_FIRST_CALL;
+    nfft_mex_pause_threads();
   }
 }
 

--- a/matlab/nfsft/nfsftmex.c
+++ b/matlab/nfsft/nfsftmex.c
@@ -127,6 +127,7 @@ static void cleanup(void)
     }
     nfsft_forget();
     gflags |= NFSFT_MEX_FIRST_CALL;
+    nfft_mex_pause_threads();
     gflags &= ~NFSFT_MEX_PRECOMPUTED;
     n_max = -1;
   }

--- a/matlab/nfsoft/nfsoftmex.c
+++ b/matlab/nfsoft/nfsoftmex.c
@@ -94,6 +94,7 @@ static void cleanup(void)
       plans_num_allocated = 0;
     }
     gflags |= NFSOFT_MEX_FIRST_CALL;
+    nfft_mex_pause_threads();
     n_max = -1;
   }
 }

--- a/matlab/nfst/nfstmex.c
+++ b/matlab/nfst/nfstmex.c
@@ -111,6 +111,7 @@ static void cleanup(void)
       plans_num_allocated = 0;
     }
     gflags |= NFST_MEX_FIRST_CALL;
+    nfft_mex_pause_threads();
   }
 }
 

--- a/matlab/nnfft/nnfftmex.c
+++ b/matlab/nnfft/nnfftmex.c
@@ -164,6 +164,7 @@ static void cleanup(void)
       plans_num_allocated = 0;
     }
     gflags |= NNFFT_MEX_FIRST_CALL;
+    nfft_mex_pause_threads();
   }
 }
 


### PR DESCRIPTION
Potential fix for crashes on MATLAB on `maci64` with OpenMP.