### PR TITLE
Pin the OpenMP runtime for the life of the MATLAB session.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -521,7 +521,8 @@ fi
 
 AC_CHECK_HEADERS([math.h stdio.h stdlib.h time.h  sys/time.h \
   complex.h string.h float.h limits.h stdarg.h stddef.h sys/types.h stdint.h \
-  inttypes.h stdbool.h malloc.h c_asm.h intrinsics.h mach/mach_time.h])
+  inttypes.h stdbool.h malloc.h c_asm.h intrinsics.h mach/mach_time.h \
+  dlfcn.h])
 
 AC_TYPE_SIZE_T
 AC_CHECK_TYPE([long double],
@@ -559,13 +560,17 @@ saved_LIBS=$LIBS
 AC_CHECK_LIB(m, sin, [])
 LIBS=$saved_LIBS
 
+# dladdr/dlopen: used by the Matlab/Octave mex interface (only, guarded by
+# HAVE_DLFCN_H/HAVE_DLADDR) to keep the OpenMP runtime mapped for the life of
+# the process, see matlab/args.c:nfft_mex_pin_openmp_runtime.
+AC_SEARCH_LIBS([dlopen], [dl])
 AC_CHECK_FUNCS([gethrtime read_real_time time_base_to_time clock_gettime mach_absolute_time])
 
 AC_CHECK_FUNCS([memset posix_memalign memalign])
 AC_CHECK_FUNCS([_mm_malloc _mm_free sysctl])
 AC_CHECK_FUNCS([abort snprintf sqrt])
 AC_CHECK_FUNCS([sleep usleep nanosleep drand48 srand48])
-AC_CHECK_FUNCS([gethostname])
+AC_CHECK_FUNCS([gethostname dladdr])
 
 AC_CHECK_DECLS([memalign, posix_memalign])
 AC_CHECK_DECLS([sleep],[],[],[#include <unistd.h>])

--- a/matlab/args.c
+++ b/matlab/args.c
@@ -21,6 +21,49 @@
 #include "infft.h"
 #include "imex.h"
 
+#ifdef _OPENMP
+#include <omp.h>
+#if defined(_WIN32) || defined(__CYGWIN__)
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#elif defined(HAVE_DLFCN_H) && defined(HAVE_DLADDR)
+#include <dlfcn.h>
+#endif
+#endif
+
+/* Pin whichever OpenMP runtime is actually linked so it is never unmapped 
+ * for the remaining lifetime of the MATLAB session. Discover the runtime 
+ * by resolving the shared object that provides a standard OpenMP API symbol.
+ *
+ * Background: Some versions of the OpenMP runtime implement per-thread
+ * state via a pthread TSD key whose destructor lives inside the runtime's
+ * own shared library, including the thread that merely calls into
+ * an OpenMP region. This can be the Matlab interpreter thread itself.
+ *
+ * If the shared library is unmapped, e.g. when the MATLAB session's main 
+ * thread exits, it still holds a reference to the state in the now unmapped 
+ * library's region and the pthread tries to invoke the dangling destructor
+ * pointer and crashes. */
+void nfft_mex_pin_openmp_runtime(void)
+{
+#ifdef _OPENMP
+#if defined(_WIN32) || defined(__CYGWIN__)
+  HMODULE h = NULL;
+  GetModuleHandleExA(
+      GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_PIN,
+      (LPCSTR) (void *) &omp_get_num_threads, &h);
+#elif defined(HAVE_DLFCN_H) && defined(HAVE_DLADDR)
+  Dl_info info;
+  if (dladdr((void *) &omp_get_num_threads, &info) && info.dli_fname)
+  {
+    void *h = dlopen(info.dli_fname, RTLD_NOW | RTLD_NODELETE);
+    if (h)
+      dlclose(h);
+  }
+#endif
+#endif
+}
+
 int nfft_mex_get_int(const mxArray *p, const char *errmsg)
 {
   DM(if (!mxIsDouble(p) || mxIsComplex(p) || mxGetM(p) != 1 || mxGetN(p) != 1)

--- a/matlab/fastsum/fastsummex.c
+++ b/matlab/fastsum/fastsummex.c
@@ -180,6 +180,7 @@ static void cleanup(void)
       plans_num_allocated = 0;
     }
     gflags |= FASTSUM_MEX_FIRST_CALL;
+    nfft_mex_pin_openmp_runtime();
   }
 }
 

--- a/matlab/fpt/fptmex.c
+++ b/matlab/fpt/fptmex.c
@@ -107,6 +107,7 @@ static void cleanup(void)
       sets_num_allocated = 0;
     }
     gflags |= FPT_MEX_FIRST_CALL;
+    nfft_mex_pin_openmp_runtime();
     n_max = -1;
   }
 }

--- a/matlab/imex.h
+++ b/matlab/imex.h
@@ -44,6 +44,7 @@
 extern void *nfft_mex_malloc(size_t n);
 extern void nfft_mex_free(void *p);
 extern void nfft_mex_install_mem_hooks(void);
+extern void nfft_mex_pin_openmp_runtime(void);
 
 int nfft_mex_get_int(const mxArray *p, const char *errmsg);
 double nfft_mex_get_double(const mxArray *p, const char *errmsg);

--- a/matlab/nfct/nfctmex.c
+++ b/matlab/nfct/nfctmex.c
@@ -111,6 +111,7 @@ static void cleanup(void)
       plans_num_allocated = 0;
     }
     gflags |= NFCT_MEX_FIRST_CALL;
+    nfft_mex_pin_openmp_runtime();
   }
 }
 

--- a/matlab/nfft/nfftmex.c
+++ b/matlab/nfft/nfftmex.c
@@ -121,6 +121,7 @@ static void cleanup(void)
       plans_num_allocated = 0;
     }
     gflags |= NFFT_MEX_FIRST_CALL;
+    nfft_mex_pin_openmp_runtime();
   }
 }
 

--- a/matlab/nfsft/nfsftmex.c
+++ b/matlab/nfsft/nfsftmex.c
@@ -127,6 +127,7 @@ static void cleanup(void)
     }
     nfsft_forget();
     gflags |= NFSFT_MEX_FIRST_CALL;
+    nfft_mex_pin_openmp_runtime();
     gflags &= ~NFSFT_MEX_PRECOMPUTED;
     n_max = -1;
   }

--- a/matlab/nfsoft/nfsoftmex.c
+++ b/matlab/nfsoft/nfsoftmex.c
@@ -94,6 +94,7 @@ static void cleanup(void)
       plans_num_allocated = 0;
     }
     gflags |= NFSOFT_MEX_FIRST_CALL;
+    nfft_mex_pin_openmp_runtime();
     n_max = -1;
   }
 }

--- a/matlab/nfst/nfstmex.c
+++ b/matlab/nfst/nfstmex.c
@@ -111,6 +111,7 @@ static void cleanup(void)
       plans_num_allocated = 0;
     }
     gflags |= NFST_MEX_FIRST_CALL;
+    nfft_mex_pin_openmp_runtime();
   }
 }
 

--- a/matlab/nnfft/nnfftmex.c
+++ b/matlab/nnfft/nnfftmex.c
@@ -164,6 +164,7 @@ static void cleanup(void)
       plans_num_allocated = 0;
     }
     gflags |= NNFFT_MEX_FIRST_CALL;
+    nfft_mex_pin_openmp_runtime();
   }
 }
 


### PR DESCRIPTION
Resolves an issue where the MATLAB session's main thread tries to call a per-thread destructor in an already unmapped OpenMP library.