### PR TITLE
Lock Matlab mex files that use OpenMP so they can never be unloaded.

### DIFF
--- a/matlab/args.c
+++ b/matlab/args.c
@@ -21,6 +21,26 @@
 #include "infft.h"
 #include "imex.h"
 
+/* Lock this mex file in memory for the remaining lifetime of the Matlab
+ * session.
+ *
+ * Background: Some versions of the OpenMP runtime implement per-thread
+ * state via a pthread TSD key whose destructor lives inside the runtime's
+ * own shared library, including the thread that merely calls into
+ * an OpenMP region. This can be the Matlab interpreter thread itself.
+ *
+ * If the shared library is unmapped, e.g. when the MATLAB session's main 
+ * thread exits, it still holds a reference to the state in the now unmapped 
+ * library's region and the pthread tries to invoke the dangling destructor
+ * pointer and crashes. */
+void nfft_mex_lock_openmp_runtime(void)
+{
+#ifdef _OPENMP
+  if (!mexIsLocked())
+    mexLock();
+#endif
+}
+
 int nfft_mex_get_int(const mxArray *p, const char *errmsg)
 {
   DM(if (!mxIsDouble(p) || mxIsComplex(p) || mxGetM(p) != 1 || mxGetN(p) != 1)

--- a/matlab/fastsum/fastsummex.c
+++ b/matlab/fastsum/fastsummex.c
@@ -193,6 +193,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     mexEvalString("fft([1,2,3,4]);");
 
     nfft_mex_install_mem_hooks();
+    nfft_mex_lock_openmp_runtime();
 
     mexAtExit(cleanup);
     gflags &= ~FASTSUM_MEX_FIRST_CALL;

--- a/matlab/fpt/fptmex.c
+++ b/matlab/fpt/fptmex.c
@@ -120,6 +120,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     mexEvalString("fft([1,2,3,4]);");
 
     nfft_mex_install_mem_hooks();
+    nfft_mex_lock_openmp_runtime();
 
     mexAtExit(cleanup);
     gflags &= ~FPT_MEX_FIRST_CALL;

--- a/matlab/imex.h
+++ b/matlab/imex.h
@@ -44,6 +44,7 @@
 extern void *nfft_mex_malloc(size_t n);
 extern void nfft_mex_free(void *p);
 extern void nfft_mex_install_mem_hooks(void);
+extern void nfft_mex_lock_openmp_runtime(void);
 
 int nfft_mex_get_int(const mxArray *p, const char *errmsg);
 double nfft_mex_get_double(const mxArray *p, const char *errmsg);

--- a/matlab/nfct/nfctmex.c
+++ b/matlab/nfct/nfctmex.c
@@ -123,6 +123,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     mexEvalString("fft([1,2,3,4]);");
 
     nfft_mex_install_mem_hooks();
+    nfft_mex_lock_openmp_runtime();
 
     mexAtExit(cleanup);
     gflags &= ~NFCT_MEX_FIRST_CALL;

--- a/matlab/nfft/nfftmex.c
+++ b/matlab/nfft/nfftmex.c
@@ -133,6 +133,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     mexEvalString("fft([1,2,3,4]);");
 
     nfft_mex_install_mem_hooks();
+    nfft_mex_lock_openmp_runtime();
 
     mexAtExit(cleanup);
     gflags &= ~NFFT_MEX_FIRST_CALL;

--- a/matlab/nfsft/nfsftmex.c
+++ b/matlab/nfsft/nfsftmex.c
@@ -142,6 +142,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
     nfft_mex_install_mem_hooks();
     nthreads_global = X(get_num_threads)();
+    nfft_mex_lock_openmp_runtime();
 
     mexAtExit(cleanup);
     gflags &= ~NFSFT_MEX_FIRST_CALL;

--- a/matlab/nfsoft/nfsoftmex.c
+++ b/matlab/nfsoft/nfsoftmex.c
@@ -107,7 +107,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     mexEvalString("fft([1,2,3,4]);");
 
     nfft_mex_install_mem_hooks();
-
+    nfft_mex_lock_openmp_runtime();
 
     mexAtExit(cleanup);
     gflags &= ~NFSOFT_MEX_FIRST_CALL;

--- a/matlab/nfst/nfstmex.c
+++ b/matlab/nfst/nfstmex.c
@@ -123,6 +123,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     mexEvalString("fft([1,2,3,4]);");
 
     nfft_mex_install_mem_hooks();
+    nfft_mex_lock_openmp_runtime();
 
     mexAtExit(cleanup);
     gflags &= ~NFST_MEX_FIRST_CALL;

--- a/matlab/nnfft/nnfftmex.c
+++ b/matlab/nnfft/nnfftmex.c
@@ -176,6 +176,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     mexEvalString("fft([1,2,3,4]);");
 
     nfft_mex_install_mem_hooks();
+    nfft_mex_lock_openmp_runtime();
 
     mexAtExit(cleanup);
     gflags &= ~NNFFT_MEX_FIRST_CALL;


### PR DESCRIPTION
Resolves an issue where the MATLAB session's main thread tries to call a per-thread destructor in an already unmapped OpenMP library.